### PR TITLE
Updated mgo import paths for 1.20 branch

### DIFF
--- a/url.go
+++ b/url.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/juju/names"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // Location represents a charm location, which must declare a path component

--- a/url_test.go
+++ b/url_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/juju/charm"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2/bson"
 	gc "launchpad.net/gocheck"
 )
 


### PR DESCRIPTION
This is required to update the mgo version used for Juju 1.20.
