### PR TITLE
charm: better error checking in ParseURL

### DIFF
--- a/url.go
+++ b/url.go
@@ -170,7 +170,9 @@ func parseReference(url string) (*Reference, error) {
 		}
 		parts = parts[1:]
 	}
-
+	if len(parts) > 2 {
+		return nil, fmt.Errorf("charm URL has invalid form: %q", url)
+	}
 	// <series>
 	if len(parts) == 2 {
 		r.Series = parts[0]

--- a/url_test.go
+++ b/url_test.go
@@ -117,6 +117,12 @@ var urlTests = []struct {
 	exact: "cs:series/foo",
 	ref:   &charm.Reference{"cs", "", "foo", -1, "series"},
 	err:   `charm URL has no schema: "series/foo"`,
+}, {
+	s:   "series/foo/bar",
+	err: `charm URL has invalid form: "series/foo/bar"`,
+}, {
+	s:   "cs:foo/~blah",
+	err: `charm URL has invalid charm name: "cs:foo/~blah"`,
 }}
 
 func (s *URLSuite) TestParseURL(c *gc.C) {


### PR DESCRIPTION
I noticed that some invalid charm URLs were parsing as if they were OK.
