### PR TITLE
remove "unstable version" notice from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-# WARNING: UNSTABLE DEVELOPMENT VERSION
-
-The latest stable version is gopkg.in/juju/charm.v2.
-
 Juju charms
 ===========
 


### PR DESCRIPTION
The v3 branch is now in use by juju-core. We need to maintain stability.
