### PR TITLE
Fixed outdated import

### DIFF
--- a/actions_test.go
+++ b/actions_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 )
 
 type ActionsSuite struct{}

--- a/bundle_test.go
+++ b/bundle_test.go
@@ -8,7 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"gopkg.in/juju/charm.v3"
 	charmtesting "gopkg.in/juju/charm.v3/testing"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 )
 
 var _ = gc.Suite(&BundleSuite{})

--- a/bundlearchive_test.go
+++ b/bundlearchive_test.go
@@ -11,7 +11,7 @@ import (
 
 	"gopkg.in/juju/charm.v3"
 	charmtesting "gopkg.in/juju/charm.v3/testing"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 )
 
 var _ = gc.Suite(&BundleArchiveSuite{})

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"gopkg.in/juju/charm.v3"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 )
 
 type bundleDataSuite struct {

--- a/bundledir_test.go
+++ b/bundledir_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/testing"
 	"gopkg.in/juju/charm.v3"
 	charmtesting "gopkg.in/juju/charm.v3/testing"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 )
 
 type BundleDirSuite struct {

--- a/charm_test.go
+++ b/charm_test.go
@@ -12,7 +12,7 @@ import (
 
 	"gopkg.in/juju/charm.v3"
 	charmtesting "gopkg.in/juju/charm.v3/testing"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 	goyaml "gopkg.in/yaml.v1"
 )
 

--- a/charmarchive_test.go
+++ b/charmarchive_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v3"
 	charmtesting "gopkg.in/juju/charm.v3/testing"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 	goyaml "gopkg.in/yaml.v1"
 )
 

--- a/charmdir_test.go
+++ b/charmdir_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/juju/testing"
 	"gopkg.in/juju/charm.v3"
 	charmtesting "gopkg.in/juju/charm.v3/testing"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 )
 
 type CharmDirSuite struct {

--- a/config_test.go
+++ b/config_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	"gopkg.in/juju/charm.v3"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 )
 
 type ConfigSuite struct {

--- a/meta_test.go
+++ b/meta_test.go
@@ -14,7 +14,7 @@ import (
 
 	"gopkg.in/juju/charm.v3"
 	charmtesting "gopkg.in/juju/charm.v3/testing"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 )
 
 func repoMeta(name string) io.Reader {

--- a/repo_test.go
+++ b/repo_test.go
@@ -12,7 +12,7 @@ import (
 	gitjujutesting "github.com/juju/testing"
 	"gopkg.in/juju/charm.v3"
 	charmtesting "gopkg.in/juju/charm.v3/testing"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 )
 
 type StoreSuite struct {

--- a/testing/mockstore.go
+++ b/testing/mockstore.go
@@ -16,7 +16,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
 	"gopkg.in/juju/charm.v3"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 )
 
 var logger = loggo.GetLogger("juju.charm.testing.mockstore")

--- a/url_test.go
+++ b/url_test.go
@@ -10,7 +10,7 @@ import (
 
 	"gopkg.in/juju/charm.v3"
 	"gopkg.in/mgo.v2/bson"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 )
 
 type URLSuite struct{}


### PR DESCRIPTION
This PR changes the import of gocheck from launchpad to github.