### PR TITLE
charm: allow for juju-info relation

### DIFF
--- a/bundledata.go
+++ b/bundledata.go
@@ -208,7 +208,8 @@ func (bd *BundleData) Verify(
 
 // VerifyWithCharms verifies that the bundle is consistent.
 // The verifyConstraints function is called to verify any constraints
-// that are found.
+// that are found. If verifyConstraints is nil, no checking
+// of constraints will be done.
 //
 // It verifies the following:
 //
@@ -228,6 +229,11 @@ func (bd *BundleData) VerifyWithCharms(
 	verifyConstraints func(c string) error,
 	charms map[string]Charm,
 ) error {
+	if verifyConstraints == nil {
+		verifyConstraints = func(string) error {
+			return nil
+		}
+	}
 	verifier := &bundleDataVerifier{
 		verifyConstraints: verifyConstraints,
 		bd:                bd,
@@ -368,6 +374,13 @@ func (verifier *bundleDataVerifier) verifyRelations() {
 	}
 }
 
+var infoRelation = Relation{
+	Name:      "juju-info",
+	Role:      RoleProvider,
+	Interface: "juju-info",
+	Scope:     ScopeContainer,
+}
+
 // verifyRelation verifies a single relation.
 // It checks that both endpoints of the relation are
 // defined, and that the relationship is correctly
@@ -391,11 +404,21 @@ func (verifier *bundleDataVerifier) verifyRelation(ep0, ep1 endpoint) {
 		return
 	}
 	relProv0, okProv0 := charm0.Meta().Provides[ep0.relation]
+	// The juju-info relation is provided implicitly by every
+	// charm - use it if required.
+	if !okProv0 && ep0.relation == infoRelation.Name {
+		relProv0, okProv0 = infoRelation, true
+	}
 	relReq0, okReq0 := charm0.Meta().Requires[ep0.relation]
 	if !okProv0 && !okReq0 {
 		verifier.addErrorf("charm %q used by service %q does not define relation %q", svc0.Charm, ep0.service, ep0.relation)
 	}
 	relProv1, okProv1 := charm1.Meta().Provides[ep1.relation]
+	// The juju-info relation is provided implicitly by every
+	// charm - use it if required.
+	if !okProv1 && ep1.relation == infoRelation.Name {
+		relProv1, okProv1 = infoRelation, true
+	}
 	relReq1, okReq1 := charm1.Meta().Requires[ep1.relation]
 	if !okProv1 && !okReq1 {
 		verifier.addErrorf("charm %q used by service %q does not define relation %q", svc1.Charm, ep1.service, ep1.relation)

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -12,6 +12,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v4"
+	charmtesting "gopkg.in/juju/charm.v4/testing"
 )
 
 type bundleDataSuite struct {
@@ -277,9 +278,22 @@ func (*bundleDataSuite) TestVerifyCharmURL(c *gc.C) {
 	} {
 		c.Logf("test %d: %s", i, u)
 		bd.Services["mediawiki"].Charm = u
-		err := bd.Verify(func(string) error { return nil })
+		err := bd.Verify(nil)
 		c.Assert(err, gc.IsNil, gc.Commentf("charm url %q", u))
 	}
+}
+
+func (*bundleDataSuite) TestVerifyBundleUsingJujuInfoRelation(c *gc.C) {
+	b := charmtesting.Charms.BundleDir("wordpress-with-logging")
+	bd := b.Data()
+
+	charms := map[string]charm.Charm{
+		"wordpress": charmtesting.Charms.CharmDir("wordpress"),
+		"mysql":     charmtesting.Charms.CharmDir("mysql"),
+		"logging":   charmtesting.Charms.CharmDir("logging"),
+	}
+	err := bd.VerifyWithCharms(nil, charms)
+	c.Assert(err, gc.IsNil)
 }
 
 func (*bundleDataSuite) TestRequiredCharms(c *gc.C) {

--- a/testing/repo/bundle/wordpress-with-logging/README.md
+++ b/testing/repo/bundle/wordpress-with-logging/README.md
@@ -1,0 +1,1 @@
+A dummy bundle

--- a/testing/repo/bundle/wordpress-with-logging/bundle.yaml
+++ b/testing/repo/bundle/wordpress-with-logging/bundle.yaml
@@ -1,0 +1,13 @@
+services:
+    wordpress:
+        charm: wordpress
+        num_units: 1
+    mysql:
+        charm: mysql
+        num_units: 1
+    logging:
+        charm: logging
+relations:
+    - ["wordpress:db", "mysql:server"]
+    - ["wordpress:juju-info", "logging:info"]
+    - ["mysql:juju-info", "logging:info"]


### PR DESCRIPTION
[This is a duplicate of PR #51 but targeted to v4]

We add a bundle that uses it for verification (and because we wanted
another simple bundle anyway).

As a drive-by fix, we change VerifyWithCharms to make it easier
to verify without verifying constraints.
