### PR TITLE
migratebundle: remove getCharm argument from Migrate

### DIFF
--- a/migratebundle/migrate.go
+++ b/migratebundle/migrate.go
@@ -56,7 +56,11 @@ type legacyService struct {
 //
 // - A relation clause with multiple targets is expanded
 // into multiple relation clauses.
-func Migrate(bundlesYAML []byte) (map[string]*charm.BundleData, error) {
+//
+// The getCharm argument is ignored and provided for
+// backward compatibility only. It will be removed in
+// charm.v5.
+func Migrate(bundlesYAML []byte, getCharm func(id *charm.Reference) (*charm.Meta, error)) (map[string]*charm.BundleData, error) {
 	var bundles map[string]*legacyBundle
 	if err := yaml.Unmarshal(bundlesYAML, &bundles); err != nil {
 		return nil, errgo.Notef(err, "cannot parse legacy bundle")

--- a/migratebundle/migrate_test.go
+++ b/migratebundle/migrate_test.go
@@ -373,7 +373,7 @@ var migrateTests = []struct {
 func (*migrateSuite) TestMigrate(c *gc.C) {
 	for i, test := range migrateTests {
 		c.Logf("test %d: %s", i, test.about)
-		result, err := Migrate(unbeautify(test.bundles))
+		result, err := Migrate(unbeautify(test.bundles), nil)
 		if test.expectError != "" {
 			c.Assert(err, gc.ErrorMatches, test.expectError)
 		} else {
@@ -389,7 +389,7 @@ func (*migrateSuite) TestMigrateAll(c *gc.C) {
 	doAllBundles(c, func(c *gc.C, id string, data []byte) {
 		c.Logf("\nmigrate test %s", id)
 		ok := true
-		bundles, err := Migrate(data)
+		bundles, err := Migrate(data, nil)
 		if err != nil {
 			c.Logf("cannot migrate: %v", err)
 			ok = false


### PR DESCRIPTION
I've left the getCharm argument in Migrate to maintain backward compatibility;
to be removed later.
