### PR TITLE
all: use gopkg.in/errgo.v1

### DIFF
--- a/bundle_test.go
+++ b/bundle_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
 	"gopkg.in/juju/charm.v4"
 	charmtesting "gopkg.in/juju/charm.v4/testing"
 )

--- a/bundlearchive_test.go
+++ b/bundlearchive_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	gc "gopkg.in/check.v1"
+
 	"gopkg.in/juju/charm.v4"
 	charmtesting "gopkg.in/juju/charm.v4/testing"
 )

--- a/bundledir_test.go
+++ b/bundledir_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
+
 	"gopkg.in/juju/charm.v4"
 	charmtesting "gopkg.in/juju/charm.v4/testing"
 )

--- a/charmdir_test.go
+++ b/charmdir_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
+
 	"gopkg.in/juju/charm.v4"
 	charmtesting "gopkg.in/juju/charm.v4/testing"
 )

--- a/config_test.go
+++ b/config_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	gc "gopkg.in/check.v1"
+
 	"gopkg.in/juju/charm.v4"
 )
 

--- a/meta.go
+++ b/meta.go
@@ -11,8 +11,9 @@ import (
 	"strings"
 
 	"github.com/juju/schema"
-	"gopkg.in/juju/charm.v4/hooks"
 	goyaml "gopkg.in/yaml.v1"
+
+	"gopkg.in/juju/charm.v4/hooks"
 )
 
 // RelationScope describes the scope of a relation.

--- a/meta_test.go
+++ b/meta_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	gc "gopkg.in/check.v1"
+
 	"gopkg.in/juju/charm.v4"
 	charmtesting "gopkg.in/juju/charm.v4/testing"
 )

--- a/migratebundle/migrate.go
+++ b/migratebundle/migrate.go
@@ -1,7 +1,7 @@
 package migratebundle
 
 import (
-	"github.com/juju/errgo"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/yaml.v1"
 
 	"gopkg.in/juju/charm.v4"

--- a/migratebundle/migrate_test.go
+++ b/migratebundle/migrate_test.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/juju/errgo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/yaml.v1"
 
 	"gopkg.in/juju/charm.v4"

--- a/migratebundle/package_test.go
+++ b/migratebundle/package_test.go
@@ -1,8 +1,9 @@
 package migratebundle
 
 import (
-	gc "gopkg.in/check.v1"
 	"testing"
+
+	gc "gopkg.in/check.v1"
 )
 
 func TestPackage(t *testing.T) {

--- a/repo_test.go
+++ b/repo_test.go
@@ -11,6 +11,7 @@ import (
 
 	gitjujutesting "github.com/juju/testing"
 	gc "gopkg.in/check.v1"
+
 	"gopkg.in/juju/charm.v4"
 	charmtesting "gopkg.in/juju/charm.v4/testing"
 )

--- a/testing/charm.go
+++ b/testing/charm.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/juju/utils/fs"
+
 	"gopkg.in/juju/charm.v4"
 )
 

--- a/testing/mockstore.go
+++ b/testing/mockstore.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
+
 	"gopkg.in/juju/charm.v4"
 )
 

--- a/url_test.go
+++ b/url_test.go
@@ -9,8 +9,9 @@ import (
 	"strings"
 
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/charm.v4"
 	"gopkg.in/mgo.v2/bson"
+
+	"gopkg.in/juju/charm.v4"
 )
 
 type URLSuite struct{}


### PR DESCRIPTION
This is the new canonical location for the errgo package.
Also group imports correctly.
