### PR TITLE
charm: implement MustParseReference

### DIFF
--- a/url.go
+++ b/url.go
@@ -117,6 +117,15 @@ func (ref *Reference) URL(defaultSeries string) (*URL, error) {
 	return &url, nil
 }
 
+// MustParseReference works like ParseReference, but panics in case of errors.
+func MustParseReference(url string) *Reference {
+	u, err := ParseReference(url)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
 // ParseReference returns a charm reference inferred from src. The provided
 // src may be a valid URL or it may be an alias in one of the following formats:
 //

--- a/url_test.go
+++ b/url_test.go
@@ -281,6 +281,19 @@ func (s *URLSuite) TestValidCheckers(c *gc.C) {
 	}
 }
 
+func (s *URLSuite) TestMustParseReference(c *gc.C) {
+	ref := charm.MustParseReference("wordpress")
+	c.Assert(ref, gc.DeepEquals, &charm.Reference{
+		Schema:   "cs",
+		Name:     "wordpress",
+		Revision: -1,
+	})
+	f := func() {
+		charm.MustParseReference("bad:bad")
+	}
+	c.Assert(f, gc.PanicMatches, `charm URL has invalid schema: "bad:bad"`)
+}
+
 func (s *URLSuite) TestMustParseURL(c *gc.C) {
 	url := charm.MustParseURL("cs:series/name")
 	c.Assert(url, gc.DeepEquals, &charm.URL{"cs", "", "name", -1, "series"})


### PR DESCRIPTION
We had far too many duplicated implementations of this...
