### PR TITLE
Charm storage metadata

### DIFF
--- a/hooks/hooks.go
+++ b/hooks/hooks.go
@@ -33,6 +33,12 @@ const (
 	// will be prefixed by the relation name, just like the other Relation* Kind
 	// values.
 	RelationBroken Kind = "relation-broken"
+
+	// These hooks require an associated storage. The hook file names that these
+	// kinds represent will be prefixed by the storage name; for example,
+	// "shared-fs-storage-attached".
+	StorageAttached Kind = "storage-attached"
+	StorageDetached Kind = "storage-detached"
 )
 
 var unitHooks = []Kind{
@@ -66,10 +72,31 @@ func RelationHooks() []Kind {
 	return hooks
 }
 
+var storageHooks = []Kind{
+	StorageAttached,
+	StorageDetached,
+}
+
+// StorageHooks returns all known storage hook kinds.
+func StorageHooks() []Kind {
+	hooks := make([]Kind, len(storageHooks))
+	copy(hooks, storageHooks)
+	return hooks
+}
+
 // IsRelation returns whether the Kind represents a relation hook.
 func (kind Kind) IsRelation() bool {
 	switch kind {
 	case RelationJoined, RelationChanged, RelationDeparted, RelationBroken:
+		return true
+	}
+	return false
+}
+
+// IsStorage returns whether the Kind represents a storage hook.
+func (kind Kind) IsStorage() bool {
+	switch kind {
+	case StorageAttached, StorageDetached:
 		return true
 	}
 	return false

--- a/meta.go
+++ b/meta.go
@@ -52,33 +52,33 @@ type Storage struct {
 	// Name is the name of the storage requirement.
 	//
 	// Name has no default, and must be specified.
-	Name string
+	Name string `bson:"name"`
 
 	// Type is the storage type: filesystem or block-device.
 	//
 	// Type has no default, and must be specified.
-	Type StorageType
+	Type StorageType `bson:"type"`
 
 	// Shared indicates that the storage is shared between all units of
 	// a service deployed from the charm. It is an error to attempt to
 	// assign non-shareable storage to a "shared" storage requirement.
 	//
 	// Shared defaults to false.
-	Shared bool
+	Shared bool `bson:"shared"`
 
 	// ReadOnly indicates that the storage should be made read-only if
 	// possible. If the storage cannot be made read-only, Juju will warn
 	// the user.
 	//
 	// ReadOnly defaults to false.
-	ReadOnly bool
+	ReadOnly bool `bson:"read-only"`
 
 	// Persistent indicates that the storage should be made persistent
 	// if possible. If the storage cannot be made persistent, Juju will
 	// warn the user.
 	//
 	// Persistent defaults to false.
-	Persistent bool
+	Persistent bool `bson:"persistent"`
 
 	// CountMin is the number of storage instances that must be attached
 	// to the charm for it to be useful; the charm will not install until
@@ -86,51 +86,51 @@ type Storage struct {
 	//
 	// CountMin defaults to either 0 or 1, depending on whether the storage
 	// is marked "required".
-	CountMin int
+	CountMin int `bson:"countmin"`
 
 	// CountMax is the largest number of storage instances that can be
 	// attached to the charm. If CountMax is -1, then there is no upper
 	// bound.
 	//
 	// CountMax defaults to -1.
-	CountMax int
+	CountMax int `bson:"countmax"`
 
 	// Location is the mount location for filesystem stores. If count does
 	// not have a maximum of 1, then location acts as the parent directory
 	// for each mounted store.
 	//
 	// Location has no default, and is optional.
-	Location string `bson:",omitempty"`
+	Location string `bson:"location,omitempty"`
 
 	// Filesystem is the list of filesystems that Juju will attempt to
 	// create, in order of most to least preferred.
 	//
 	// Filesystem has no default, and is option.
-	Filesystem []Filesystem `bson:",omitempty"`
+	Filesystem []Filesystem `bson:"filesystem,omitempty"`
 }
 
 type Filesystem struct {
 	// Type is the filesystem type.
-	Type string
+	Type string `bson:"type,omitempty"`
 
 	// MkfsOptions is any options to use when creating the filesystem.
 	// MkfsOptions will be passed directly to "mkfs".
-	MkfsOptions []string `bson:",omitempty"`
+	MkfsOptions []string `bson:"mkfsoptions,omitempty"`
 
 	// MountOptions is any options to use when mounting the filesystem.
 	// MountOptions will be passed directly to "mount".
-	MountOptions []string `bson:",omitempty"`
+	MountOptions []string `bson:"mountoptions,omitempty"`
 }
 
 // Relation represents a single relation defined in the charm
 // metadata.yaml file.
 type Relation struct {
-	Name      string
-	Role      RelationRole
-	Interface string
-	Optional  bool
-	Limit     int
-	Scope     RelationScope
+	Name      string        `bson:"name"`
+	Role      RelationRole  `bson:"role"`
+	Interface string        `bson:"interface"`
+	Optional  bool          `bson:"optional"`
+	Limit     int           `bson:"limit"`
+	Scope     RelationScope `bson:"scope"`
 }
 
 // ImplementedBy returns whether the relation is implemented by the supplied charm.
@@ -177,19 +177,19 @@ func (r Relation) IsImplicit() bool {
 // Meta represents all the known content that may be defined
 // within a charm's metadata.yaml file.
 type Meta struct {
-	Name        string
-	Summary     string
-	Description string
-	Subordinate bool
-	Provides    map[string]Relation `bson:",omitempty"`
-	Requires    map[string]Relation `bson:",omitempty"`
-	Peers       map[string]Relation `bson:",omitempty"`
-	Format      int                 `bson:",omitempty"`
-	OldRevision int                 `bson:",omitempty"` // Obsolete
-	Categories  []string            `bson:",omitempty"`
-	Tags        []string            `bson:",omitempty"`
-	Series      string              `bson:",omitempty"`
-	Storage     map[string]Storage  `bson:",omitempty"`
+	Name        string              `bson:"name"`
+	Summary     string              `bson:"summary"`
+	Description string              `bson:"description"`
+	Subordinate bool                `bson:"subordinate"`
+	Provides    map[string]Relation `bson:"provides,omitempty"`
+	Requires    map[string]Relation `bson:"requires,omitempty"`
+	Peers       map[string]Relation `bson:"peers,omitempty"`
+	Format      int                 `bson:"format,omitempty"`
+	OldRevision int                 `bson:"oldrevision,omitempty"` // Obsolete
+	Categories  []string            `bson:"categories,omitempty"`
+	Tags        []string            `bson:"tags,omitempty"`
+	Series      string              `bson:"series,omitempty"`
+	Storage     map[string]Storage  `bson:"storage,omitempty"`
 }
 
 func generateRelationHooks(relName string, allHooks map[string]bool) {
@@ -554,7 +554,7 @@ func parseStorage(stores interface{}) map[string]Storage {
 			store.CountMax = count[1]
 		} else {
 			store.CountMin = -1
-			store.CountMax = 1
+			store.CountMax = -1
 		}
 		if store.CountMin == -1 {
 			if required {
@@ -655,7 +655,7 @@ func (c storageCountC) Coerce(v interface{}, path []string) (newv interface{}, e
 		return nil, err
 	}
 	if len(match[2]) == 0 {
-		// We've got a count of the form "m-1": m represents the
+		// We've got a count of the form "m-": m represents the
 		// minimum, and there is no upper bound.
 		n = -1
 	} else {

--- a/meta.go
+++ b/meta.go
@@ -109,17 +109,11 @@ type Storage struct {
 	Filesystem []Filesystem `bson:"filesystem,omitempty"`
 }
 
+// Filesystem describes a filesystem preference which Juju may use when
+// formatting a block device.
 type Filesystem struct {
 	// Type is the filesystem type.
 	Type string `bson:"type,omitempty"`
-
-	// MkfsOptions is any options to use when creating the filesystem.
-	// MkfsOptions will be passed directly to "mkfs".
-	MkfsOptions []string `bson:"mkfsoptions,omitempty"`
-
-	// MountOptions is any options to use when mounting the filesystem.
-	// MountOptions will be passed directly to "mount".
-	MountOptions []string `bson:"mountoptions,omitempty"`
 }
 
 // Relation represents a single relation defined in the charm
@@ -584,9 +578,7 @@ func parseFilesystem(filesystems interface{}) []Filesystem {
 			result = append(result, Filesystem{Type: elem})
 		case map[string]interface{}:
 			fs := Filesystem{
-				Type:         elem["type"].(string),
-				MountOptions: parseStringList(elem["options"]),
-				MkfsOptions:  parseStringList(elem["mkfs-options"]),
+				Type: elem["type"].(string),
 			}
 			result = append(result, fs)
 		}
@@ -618,14 +610,9 @@ var storageSchema = schema.FieldMap(
 
 var filesystemSchema = schema.FieldMap(
 	schema.Fields{
-		"type":         schema.String(),
-		"mkfs-options": schema.List(schema.String()),
-		"options":      schema.List(schema.String()),
+		"type": schema.String(),
 	},
-	schema.Defaults{
-		"mkfs-options": schema.Omit,
-		"options":      schema.Omit,
-	},
+	schema.Defaults{},
 )
 
 type storageCountC struct{}

--- a/meta.go
+++ b/meta.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/juju/schema"
@@ -36,6 +38,70 @@ const (
 	RoleRequirer RelationRole = "requirer"
 	RolePeer     RelationRole = "peer"
 )
+
+// StorageType defines a storage type.
+type StorageType string
+
+const (
+	StorageBlock      StorageType = "block"
+	StorageFilesystem StorageType = "filesystem"
+)
+
+// Storage represents a charm's storage requirement.
+type Storage struct {
+	// Name is the name of the storage requirement.
+	Name string
+
+	// Type is the storage type: filesystem or block-device.
+	Type StorageType
+
+	// Shared indicates that the storage is shared between all units of
+	// a service deployed from the charm. It is an error to attempt to
+	// assign non-shareable storage to a "shared" storage requirement.
+	Shared bool
+
+	// ReadOnly indicates that the storage should be made read-only if
+	// possible. If the storage cannot be made read-only, Juju will warn
+	// the user.
+	ReadOnly bool
+
+	// Persistent indicates that the storage should be made persistent
+	// if possible. If the storage cannot be made persistent, Juju will
+	// warn the user.
+	Persistent bool
+
+	// CountMin is the number of storage instances that must be attached
+	// to the charm for it to be useful; the charm will not install until
+	// this number has been satisfied. This must be a non-negative number.
+	CountMin int
+
+	// CountMax is the largest number of storage instances that can be
+	// attached to the charm. If CountMax is -1, then there is no upper
+	// bound.
+	CountMax int
+
+	// Location is the mount location for filesystem stores. If count does
+	// not have a maximum of 1, then location acts as the parent directory
+	// for each mounted store.
+	Location string `bson:",omitempty"`
+
+	// Filesystem is the list of filesystems that Juju will attempt to
+	// create, in order of most to least preferred.
+	Filesystem []Filesystem `bson:",omitempty"`
+}
+
+type Filesystem struct {
+	// Type is the filesystem type.
+	Type string
+
+	// MkfsOptions is any options to use when creating the filesystem.
+	// MkfsOptions will be passed directly to "mkfs".
+	MkfsOptions []string `bson:",omitempty"`
+
+	// MountOptions is any options to use when mounting the filesystem.
+	// MountOptions will be passed directly to "mount".
+	MountOptions []string `bson:",omitempty"`
+}
 
 // Relation represents a single relation defined in the charm
 // metadata.yaml file.
@@ -104,6 +170,7 @@ type Meta struct {
 	Categories  []string            `bson:",omitempty"`
 	Tags        []string            `bson:",omitempty"`
 	Series      string              `bson:",omitempty"`
+	Storage     map[string]Storage  `bson:",omitempty"`
 }
 
 func generateRelationHooks(relName string, allHooks map[string]bool) {
@@ -141,8 +208,8 @@ func parseStringList(list interface{}) []string {
 	}
 	slice := list.([]interface{})
 	result := make([]string, 0, len(slice))
-	for _, cat := range slice {
-		result = append(result, cat.(string))
+	for _, elem := range slice {
+		result = append(result, elem.(string))
 	}
 	return result
 }
@@ -186,6 +253,7 @@ func ReadMeta(r io.Reader) (meta *Meta, err error) {
 	if series, ok := m["series"]; ok && series != nil {
 		meta.Series = series.(string)
 	}
+	meta.Storage = parseStorage(m["storage"])
 	if err := meta.Check(); err != nil {
 		return nil, err
 	}
@@ -322,6 +390,29 @@ func (meta Meta) Check() error {
 		}
 	}
 
+	names = make(map[string]bool)
+	for name, store := range meta.Storage {
+		if store.Location != "" && store.Type != StorageFilesystem {
+			return fmt.Errorf(`charm %q storage %q: location may not be specified for "type: %s"`, meta.Name, name, store.Type)
+		}
+		if store.Filesystem != nil && store.Type != StorageFilesystem {
+			return fmt.Errorf(`charm %q storage %q: filesystem may not be specified for "type: %s"`, meta.Name, name, store.Type)
+		}
+		if store.Type == "" {
+			return fmt.Errorf("charm %q storage %q: type must be specified", meta.Name, name)
+		}
+		if store.CountMin < 0 {
+			return fmt.Errorf("charm %q storage %q: invalid minimum count %d", meta.Name, name, store.CountMin)
+		}
+		if store.CountMax == 0 || store.CountMax < -1 {
+			return fmt.Errorf("charm %q storage %q: invalid maximum count %d", meta.Name, name, store.CountMax)
+		}
+		if names[name] {
+			return fmt.Errorf("charm %q storage %q: duplicated storage name", meta.Name, name)
+		}
+		names[name] = true
+	}
+
 	return nil
 }
 
@@ -424,6 +515,138 @@ var ifaceSchema = schema.FieldMap(
 	},
 )
 
+func parseStorage(stores interface{}) map[string]Storage {
+	if stores == nil {
+		return nil
+	}
+	result := make(map[string]Storage)
+	for name, store := range stores.(map[string]interface{}) {
+		storeMap := store.(map[string]interface{})
+		store := Storage{
+			Name:       name,
+			Type:       StorageType(storeMap["type"].(string)),
+			Shared:     storeMap["shared"].(bool),
+			ReadOnly:   storeMap["read-only"].(bool),
+			Persistent: storeMap["persistent"].(bool),
+		}
+		required := storeMap["required"].(bool)
+		if count, ok := storeMap["count"].([2]int); ok {
+			store.CountMin = count[0]
+			store.CountMax = count[1]
+		} else {
+			store.CountMin = -1
+			store.CountMax = 1
+		}
+		if store.CountMin == -1 {
+			if required {
+				store.CountMin = store.CountMax
+			} else {
+				store.CountMin = 0
+			}
+		}
+		if loc, ok := storeMap["location"].(string); ok {
+			store.Location = loc
+		}
+		store.Filesystem = parseFilesystem(storeMap["filesystem"])
+		result[name] = store
+	}
+	return result
+}
+
+func parseFilesystem(filesystems interface{}) []Filesystem {
+	if filesystems == nil {
+		return nil
+	}
+	slice := filesystems.([]interface{})
+	result := make([]Filesystem, 0, len(slice))
+	for _, elem := range slice {
+		switch elem := elem.(type) {
+		case string:
+			result = append(result, Filesystem{Type: elem})
+		case map[string]interface{}:
+			fs := Filesystem{
+				Type:         elem["type"].(string),
+				MountOptions: parseStringList(elem["options"]),
+				MkfsOptions:  parseStringList(elem["mkfs-options"]),
+			}
+			result = append(result, fs)
+		}
+	}
+	return result
+}
+
+var storageSchema = schema.FieldMap(
+	schema.Fields{
+		"required":   schema.Bool(),
+		"shared":     schema.Bool(),
+		"read-only":  schema.Bool(),
+		"persistent": schema.Bool(),
+		"count":      storageCountC{}, // m, m-n, m-
+		"location":   schema.String(),
+		"type":       schema.OneOf(schema.Const(string(StorageBlock)), schema.Const(string(StorageFilesystem))),
+		"filesystem": schema.List(schema.OneOf(schema.String(), filesystemSchema)),
+	},
+	schema.Defaults{
+		"required":   false,
+		"shared":     false,
+		"read-only":  false,
+		"persistent": false,
+		"count":      schema.Omit,
+		"location":   schema.Omit,
+		"filesystem": schema.Omit,
+	},
+)
+
+var filesystemSchema = schema.FieldMap(
+	schema.Fields{
+		"type":         schema.String(),
+		"mkfs-options": schema.List(schema.String()),
+		"options":      schema.List(schema.String()),
+	},
+	schema.Defaults{
+		"mkfs-options": schema.Omit,
+		"options":      schema.Omit,
+	},
+)
+
+type storageCountC struct{}
+
+var storageCountRE = regexp.MustCompile("^([0-9]+)-([0-9]*)$")
+
+func (c storageCountC) Coerce(v interface{}, path []string) (newv interface{}, err error) {
+	s, err := schema.OneOf(schema.Int(), stringC).Coerce(v, path)
+	if err != nil {
+		return nil, err
+	}
+	if m, ok := s.(int64); ok {
+		// We've got a count of the form "m": m represents the
+		// maximum. The minimum is either 0 or m, depending on the
+		// value of "required". Use -1 as a placeholder.
+		if m <= 0 {
+			return nil, fmt.Errorf("%s: invalid count %v", strings.Join(path[1:], ""), m)
+		}
+		return [2]int{-1, int(m)}, nil
+	}
+	match := storageCountRE.FindStringSubmatch(s.(string))
+	if match == nil {
+		return nil, fmt.Errorf("%s: value %q does not match 'm', 'm-n', or 'm-'", strings.Join(path[1:], ""), s)
+	}
+	var m, n int
+	if m, err = strconv.Atoi(match[1]); err != nil {
+		return nil, err
+	}
+	if len(match[2]) == 0 {
+		// We've got a count of the form "m-1": m represents the
+		// minimum, and there is no upper bound.
+		n = -1
+	} else {
+		if n, err = strconv.Atoi(match[2]); err != nil {
+			return nil, err
+		}
+	}
+	return [2]int{m, n}, nil
+}
+
 var charmSchema = schema.FieldMap(
 	schema.Fields{
 		"name":        schema.String(),
@@ -438,6 +661,7 @@ var charmSchema = schema.FieldMap(
 		"categories":  schema.List(schema.String()),
 		"tags":        schema.List(schema.String()),
 		"series":      schema.String(),
+		"storage":     schema.StringMap(storageSchema),
 	},
 	schema.Defaults{
 		"provides":    schema.Omit,
@@ -449,5 +673,6 @@ var charmSchema = schema.FieldMap(
 		"categories":  schema.Omit,
 		"tags":        schema.Omit,
 		"series":      schema.Omit,
+		"storage":     schema.Omit,
 	},
 )

--- a/meta.go
+++ b/meta.go
@@ -50,43 +50,62 @@ const (
 // Storage represents a charm's storage requirement.
 type Storage struct {
 	// Name is the name of the storage requirement.
+	//
+	// Name has no default, and must be specified.
 	Name string
 
 	// Type is the storage type: filesystem or block-device.
+	//
+	// Type has no default, and must be specified.
 	Type StorageType
 
 	// Shared indicates that the storage is shared between all units of
 	// a service deployed from the charm. It is an error to attempt to
 	// assign non-shareable storage to a "shared" storage requirement.
+	//
+	// Shared defaults to false.
 	Shared bool
 
 	// ReadOnly indicates that the storage should be made read-only if
 	// possible. If the storage cannot be made read-only, Juju will warn
 	// the user.
+	//
+	// ReadOnly defaults to false.
 	ReadOnly bool
 
 	// Persistent indicates that the storage should be made persistent
 	// if possible. If the storage cannot be made persistent, Juju will
 	// warn the user.
+	//
+	// Persistent defaults to false.
 	Persistent bool
 
 	// CountMin is the number of storage instances that must be attached
 	// to the charm for it to be useful; the charm will not install until
 	// this number has been satisfied. This must be a non-negative number.
+	//
+	// CountMin defaults to either 0 or 1, depending on whether the storage
+	// is marked "required".
 	CountMin int
 
 	// CountMax is the largest number of storage instances that can be
 	// attached to the charm. If CountMax is -1, then there is no upper
 	// bound.
+	//
+	// CountMax defaults to -1.
 	CountMax int
 
 	// Location is the mount location for filesystem stores. If count does
 	// not have a maximum of 1, then location acts as the parent directory
 	// for each mounted store.
+	//
+	// Location has no default, and is optional.
 	Location string `bson:",omitempty"`
 
 	// Filesystem is the list of filesystems that Juju will attempt to
 	// create, in order of most to least preferred.
+	//
+	// Filesystem has no default, and is option.
 	Filesystem []Filesystem `bson:",omitempty"`
 }
 

--- a/meta_test.go
+++ b/meta_test.go
@@ -741,8 +741,6 @@ storage:
     store1:
         type: filesystem
         filesystem:
-            - {type: btrfs, options: [discard, autodefrag]}
-            - {type: btrfs, mkfs-options: ["-L", mylabel]}
             - btrfs
 `))
 	c.Assert(err, gc.IsNil)
@@ -759,12 +757,6 @@ storage:
 	store = meta.Storage["store1"]
 	c.Assert(store, gc.NotNil)
 	c.Assert(store.Filesystem, gc.DeepEquals, []charm.Filesystem{{
-		Type:         "btrfs",
-		MountOptions: []string{"discard", "autodefrag"},
-	}, {
-		Type:        "btrfs",
-		MkfsOptions: []string{"-L", "mylabel"},
-	}, {
 		Type: "btrfs",
 	}})
 }

--- a/meta_test.go
+++ b/meta_test.go
@@ -622,12 +622,14 @@ storage:
 		"store0": charm.Storage{
 			Name:     "store0",
 			Type:     charm.StorageBlock,
-			CountMax: 1,
+			CountMin: 0, // not required
+			CountMax: -1,
 		},
 		"store1": charm.Storage{
 			Name:     "store1",
 			Type:     charm.StorageFilesystem,
-			CountMax: 1,
+			CountMin: 0, // not required
+			CountMax: -1,
 		},
 	})
 }


### PR DESCRIPTION
We introduce a new "storage" attribute to charm metadata, which describes required and optional storage for a charm. Each may be raw block devices, or file systems. The charm declares the name, type and some restrictions on the storage, and the administrator specifies how to fulfil that storage when deploying the charm.

The metadata format is based on the storage phase 1 scope document:
https://docs.google.com/a/canonical.com/document/d/1-9ZPfdgpkj2R9mBG_tlSclGGyK3tRpMf2L4C37mzYD8/edit#bookmark=id.6abw2ee0ebgm

which is mostly the same as described in the spec: https://docs.google.com/a/canonical.com/document/d/1OhaLiHMoGNFEmDJTiNGMluIlkFtzcYjezC8Yq4nAX3Q/edit

Note that the spec was never signed off, and the scope document is yet to be reviewed. This metadata format is subject to change, and should not be documented until it is finalised. In the short term, this unblocks further work on storage in Juju (which should be uncontroversial).

There are also two new hook kinds defined for notifying units of storage attachment and detachment.