### PR TITLE
disallow config.yaml with no options entry

### DIFF
--- a/config.go
+++ b/config.go
@@ -98,6 +98,20 @@ func ReadConfig(r io.Reader) (*Config, error) {
 	if config == nil {
 		return nil, fmt.Errorf("invalid config: empty configuration")
 	}
+	if config.Options == nil {
+		// We are allowed an empty configuration if the options
+		// field is explicitly specified, but there is no easy way
+		// to tell if it was specified or not without unmarshaling
+		// into interface{} and explicitly checking the field.
+		var configInterface interface{}
+		if err := yaml.Unmarshal(data, &configInterface); err != nil {
+			return nil, err
+		}
+		m, _ := configInterface.(map[interface{}]interface{})
+		if _, ok := m["options"]; !ok {
+			return nil, fmt.Errorf("invalid config: empty configuration")
+		}
+	}
 	for name, option := range config.Options {
 		switch option.Type {
 		case "string", "int", "float", "boolean":

--- a/config_test.go
+++ b/config_test.go
@@ -397,6 +397,20 @@ func (s *ConfigSuite) TestConfigError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `invalid config: option "t" has unknown type "foo"`)
 }
 
+func (s *ConfigSuite) TestConfigWithNoOptions(c *gc.C) {
+	_, err := charm.ReadConfig(strings.NewReader("other:\n"))
+	c.Assert(err, gc.ErrorMatches, "invalid config: empty configuration")
+
+	_, err = charm.ReadConfig(strings.NewReader("\n"))
+	c.Assert(err, gc.ErrorMatches, "invalid config: empty configuration")
+
+	_, err = charm.ReadConfig(strings.NewReader("null\n"))
+	c.Assert(err, gc.ErrorMatches, "invalid config: empty configuration")
+
+	_, err = charm.ReadConfig(strings.NewReader("options:\n"))
+	c.Assert(err, gc.IsNil)
+}
+
 func (s *ConfigSuite) TestDefaultType(c *gc.C) {
 	assertDefault := func(type_ string, value string, expected interface{}) {
 		config := fmt.Sprintf(`options: {t: {type: %s, default: %s}}`, type_, value)


### PR DESCRIPTION
Having reviewed all published charms from the charm store,
the only ones that will fail this check are genuinely wrong.
