### PR TITLE
 Actions formatting tightened up

### DIFF
--- a/charm_test.go
+++ b/charm_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	stdtesting "testing"
 
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v1"
 
@@ -88,17 +89,21 @@ func checkDummy(c *gc.C, f charm.Charm, path string) {
 	c.Assert(f.Revision(), gc.Equals, 1)
 	c.Assert(f.Meta().Name, gc.Equals, "dummy")
 	c.Assert(f.Config().Options["title"].Default, gc.Equals, "My Title")
-	c.Assert(f.Actions(), gc.DeepEquals,
+	c.Assert(f.Actions(), jc.DeepEquals,
 		&charm.Actions{
 			map[string]charm.ActionSpec{
 				"snapshot": charm.ActionSpec{
 					Description: "Take a snapshot of the database.",
 					Params: map[string]interface{}{
-						"outfile": map[string]interface{}{
-							"description": "The file to write out to.",
-							"type":        "string",
-							"default":     "foo.bz2",
-						}}}}})
+						"type":        "object",
+						"description": "Take a snapshot of the database.",
+						"title":       "snapshot",
+						"properties": map[string]interface{}{
+							"outfile": map[string]interface{}{
+								"description": "The file to write out to.",
+								"type":        "string",
+								"default":     "foo.bz2",
+							}}}}}})
 	switch f := f.(type) {
 	case *charm.CharmArchive:
 		c.Assert(f.Path, gc.Equals, path)

--- a/internal/test-charm-repo/quantal/dummy/actions.yaml
+++ b/internal/test-charm-repo/quantal/dummy/actions.yaml
@@ -1,8 +1,7 @@
-actions:
-   snapshot:
-      description: Take a snapshot of the database.
-      params:
-         outfile:
-            description: The file to write out to.
-            type: string
-            default: foo.bz2
+snapshot:
+   description: Take a snapshot of the database.
+   params:
+      outfile:
+         description: The file to write out to.
+         type: string
+         default: foo.bz2

--- a/repo_test.go
+++ b/repo_test.go
@@ -91,9 +91,9 @@ func (s *StoreSuite) TestLatest(c *gc.C) {
 	revInfo, err := s.store.Latest(urls...)
 	c.Assert(err, gc.IsNil)
 	c.Assert(revInfo, gc.DeepEquals, []charm.CharmRevision{
-		{23, "c89d9b522cebbd68061048ed2910180e1b63b6afaa373d1fe1c47ff9970be126", nil},
-		{23, "c89d9b522cebbd68061048ed2910180e1b63b6afaa373d1fe1c47ff9970be126", nil},
-		{23, "c89d9b522cebbd68061048ed2910180e1b63b6afaa373d1fe1c47ff9970be126", nil},
+		{23, "843f8bba130a9705249f038202fab24e5151e3a2f7b6626f4508a5725739a5b5", nil},
+		{23, "843f8bba130a9705249f038202fab24e5151e3a2f7b6626f4508a5725739a5b5", nil},
+		{23, "843f8bba130a9705249f038202fab24e5151e3a2f7b6626f4508a5725739a5b5", nil},
 	})
 }
 

--- a/testing/testcharm_test.go
+++ b/testing/testcharm_test.go
@@ -37,14 +37,13 @@ options:
   blog-title: {default: My Title, description: Config description, type: string}
 `,
 		Actions: `
-actions:
-   snapshot:
-      description: Take a snapshot of the database.
-      params:
-         outfile:
-            description: snapshot description
-            type: string
-            default: foo.bz2
+snapshot:
+   description: Take a snapshot of the database.
+   params:
+      outfile:
+         description: outfile description
+         type: string
+         default: foo.bz2
 `,
 		Metrics: `
 metrics:
@@ -82,10 +81,15 @@ metrics:
 			"snapshot": {
 				Description: "Take a snapshot of the database.",
 				Params: map[string]interface{}{
-					"outfile": map[string]interface{}{
-						"description": "snapshot description",
-						"type":        "string",
-						"default":     "foo.bz2",
+					"title":       "snapshot",
+					"description": "Take a snapshot of the database.",
+					"type":        "object",
+					"properties": map[string]interface{}{
+						"outfile": map[string]interface{}{
+							"description": "outfile description",
+							"type":        "string",
+							"default":     "foo.bz2",
+						},
 					},
 				},
 			},


### PR DESCRIPTION
Charm now expects a much simpler format for actions.yaml:

``` text
<action name>:
  [description]: <string>
  [params]:
    <param 1>: <JSON-schema>
    <param 2>: <JSON-schema>
    ...
  [required]: <string list>
  [other keys e.g. "definitions"]: ...
<next action name>: ...
```
