### PR TITLE
Add ActionSpec.InsertDefaults method to charm package

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -73,6 +73,17 @@ func (spec *ActionSpec) ValidateParams(params map[string]interface{}) error {
 	return errors.Errorf("validation failed: %s", strings.Join(errorStrings, "; "))
 }
 
+// InsertDefaults inserts default values in a map[string]interface{} using
+// github.com/juju/gojsonschema.
+func (spec *ActionSpec) InsertDefaults(into map[string]interface{}) error {
+	specLoader := gjs.NewGoLoader(spec.Params)
+	schema, err := gjs.NewSchema(specLoader)
+	if err != nil {
+		return err
+	}
+	return schema.InsertDefaults(into)
+}
+
 // ReadActions builds an Actions spec from a charm's actions.yaml.
 func ReadActionsYaml(r io.Reader) (*Actions, error) {
 	data, err := ioutil.ReadAll(r)

--- a/actions_test.go
+++ b/actions_test.go
@@ -762,7 +762,13 @@ act:
 act:
   params:
     val:
-      type: string
+      type: object
+      properties: 
+        var:
+          type: object
+          properties:
+            x:
+              type: string
 `[1:]}
 
 	for i, t := range []struct {
@@ -779,6 +785,11 @@ act:
 		schema:         schemas["simple"],
 		withParams:     map[string]interface{}{},
 		expectedResult: map[string]interface{}{"val": "somestr"},
+	}, {
+		should:         "do nothing for no default value",
+		schema:         schemas["none"],
+		withParams:     map[string]interface{}{},
+		expectedResult: map[string]interface{}{},
 	}, {
 		should:     "insert a default value within a nested map",
 		schema:     schemas["complicated"],


### PR DESCRIPTION
This method takes a map[string]interface{} and inserts default values
into it based on the defaults specified in the given Action schema.