### PR TITLE
migratebundle: allow tags field in legacy bundle

### DIFF
--- a/migratebundle/migrate.go
+++ b/migratebundle/migrate.go
@@ -16,6 +16,7 @@ type legacyBundle struct {
 	// ["r1", "r2"] or ["r1", ["r2", "r3", ...]]
 	Relations []interface{}          `yaml:",omitempty"` // []string or []interface{}{"", []string{...}}
 	Overrides map[string]interface{} `yaml:",omitempty"`
+	Tags      []string               `yaml:",omitempty"`
 }
 
 // legacyService represents a service from a legacy bundle.
@@ -86,6 +87,7 @@ func migrate(b *legacyBundle) (*charm.BundleData, error) {
 		Services: make(map[string]*charm.ServiceSpec),
 		Series:   b.Series,
 		Machines: make(map[string]*charm.MachineSpec),
+		Tags:     b.Tags,
 	}
 	for name, svc := range b.Services {
 		if svc == nil {

--- a/migratebundle/migrate_test.go
+++ b/migratebundle/migrate_test.go
@@ -85,6 +85,7 @@ var migrateTests = []struct {
 	bundles: `
 		|wordpress-simple:
 		|    series: precise
+		|    tags: ["foo", "bar"]
 		|    services:
 		|        wordpress:
 		|            charm: "cs:precise/wordpress-20"
@@ -115,6 +116,7 @@ var migrateTests = []struct {
 	expect: map[string]*charm.BundleData{
 		"wordpress-simple": {
 			Series: "precise",
+			Tags:   []string{"foo", "bar"},
 			Services: map[string]*charm.ServiceSpec{
 				"wordpress": {
 					Charm:    "cs:precise/wordpress-20",


### PR DESCRIPTION
We need to have some way for people publishing old-style bundles to
add tags.