### PR TITLE
Add series to machinespec

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -81,7 +81,8 @@ func (spec *ActionSpec) InsertDefaults(into map[string]interface{}) error {
 	if err != nil {
 		return err
 	}
-	return schema.InsertDefaults(into)
+	_, err = schema.InsertDefaults(into)
+	return err
 }
 
 // ReadActions builds an Actions spec from a charm's actions.yaml.

--- a/bundledata.go
+++ b/bundledata.go
@@ -56,6 +56,7 @@ type BundleData struct {
 type MachineSpec struct {
 	Constraints string            `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
 	Annotations map[string]string `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
+	Series      string            `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
 }
 
 // ServiceSpec represents a single service that will
@@ -276,6 +277,9 @@ func (verifier *bundleDataVerifier) verifyMachines() {
 			if err := verifier.verifyConstraints(m.Constraints); err != nil {
 				verifier.addErrorf("invalid constraints %q in machine %q: %v", m.Constraints, id, err)
 			}
+		}
+		if m.Series != "" && !IsValidSeries(m.Series) {
+			verifier.addErrorf("invalid series %s for machine %q", m.Series, id)
 		}
 	}
 }

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -169,6 +169,7 @@ machines:
          constraints: 'bad constraints'
          annotations:
              foo: bar
+         series: 'bad series'
     bogus:
     3:
 services: 
@@ -228,6 +229,7 @@ relations:
 		`relation ["mysql:db" "mediawiki:db"] is defined more than once`,
 		`invalid placement syntax "bad placement"`,
 		`invalid relation syntax "mediawiki/db"`,
+		`invalid series bad series for machine "0"`,
 	},
 }, {
 	about: "mediawiki should be ok",


### PR DESCRIPTION
This branch adds an optional series attribute to MachineSpec, which allows a user to specify a machine of a particular series for creation.  This also includes a drive-by fix to ActionSpec.InsertDefaults so that return types match.