### PR TITLE
Fix mock store test mode handling.

### DIFF
--- a/testing/charm.go
+++ b/testing/charm.go
@@ -195,11 +195,13 @@ func (s *MockCharmStore) AuthAttrs() string {
 	return s.authAttrs
 }
 
-// SetTestMode enables or disables test mode.
-func (s *MockCharmStore) SetTestMode(testMode bool) {
+// WithTestMode returns a repository Interface where testMode is set to value
+// passed to this method.
+func (s *MockCharmStore) WithTestMode(testMode bool) charmrepo.Interface {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.testMode = testMode
+	return s
 }
 
 // TestMode returns the test mode setting of this charm store.


### PR DESCRIPTION
The mock store defines SetTestMode while the real legacy charm store uses WithTestMode.
This historically meant false positives on juju-core tests, with test mode not really working.