### PR TITLE
Handle CacheDir and improve error handling.

### DIFF
--- a/charmrepo/export_test.go
+++ b/charmrepo/export_test.go
@@ -1,9 +1,0 @@
-// Copyright 2015 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
-
-package charmrepo
-
-// CharmStoreCacheDir returns the charm cache path of the given charm store.
-func CharmStoreCacheDir(r Interface) string {
-	return r.(*CharmStore).cacheDir
-}

--- a/charmrepo/legacy.go
+++ b/charmrepo/legacy.go
@@ -21,9 +21,6 @@ import (
 	"gopkg.in/juju/charm.v5-unstable"
 )
 
-// CacheDir stores the charm cache directory path.
-var CacheDir string
-
 // LegacyCharmStore is a repository Interface that provides access to the
 // legacy Juju charm store.
 type LegacyCharmStore struct {

--- a/charmrepo/repo.go
+++ b/charmrepo/repo.go
@@ -53,7 +53,7 @@ func Latest(repo Interface, curl *charm.URL) (int, error) {
 func InferRepository(ref *charm.Reference, charmStoreParams NewCharmStoreParams, localRepoPath string) (Interface, error) {
 	switch ref.Schema {
 	case "cs":
-		return NewCharmStore(charmStoreParams)
+		return NewCharmStore(charmStoreParams), nil
 	case "local":
 		return NewLocalRepository(localRepoPath)
 	}

--- a/charmrepo/repo_test.go
+++ b/charmrepo/repo_test.go
@@ -20,21 +20,14 @@ type inferRepoSuite struct{}
 var _ = gc.Suite(&inferRepoSuite{})
 
 var inferRepositoryTests = []struct {
-	url              string
-	charmStoreParams charmrepo.NewCharmStoreParams
-	localRepoPath    string
-	err              string
+	url           string
+	localRepoPath string
+	err           string
 }{{
 	url: "cs:trusty/django",
-	err: "charm cache directory path is empty",
 }, {
 	url: "local:precise/wordpress",
 	err: "path to local repository not specified",
-}, {
-	url: "cs:trusty/wordpress-42",
-	charmStoreParams: charmrepo.NewCharmStoreParams{
-		CacheDir: "/tmp/cache-dir",
-	},
 }, {
 	url:           "local:precise/haproxy-47",
 	localRepoPath: "/tmp/repo-path",
@@ -45,7 +38,7 @@ func (s *inferRepoSuite) TestInferRepository(c *gc.C) {
 		c.Logf("test %d: %s", i, test.url)
 		ref := charm.MustParseReference(test.url)
 		repo, err := charmrepo.InferRepository(
-			ref, test.charmStoreParams, test.localRepoPath)
+			ref, charmrepo.NewCharmStoreParams{}, test.localRepoPath)
 		if test.err != "" {
 			c.Assert(err, gc.ErrorMatches, test.err)
 			c.Assert(repo, gc.IsNil)


### PR DESCRIPTION
This branch moves CacheDir from legacy to the new charm store repo, and removes it from the NewCharmStore parameters. This way we are more compatible with the way juju-core currently interacts with the charm store.

Also improve error handling for when a charm is not found.
