### PR TITLE
charmrepo: make Resolve actually resolve URLs

### DIFF
--- a/charmrepo/charmstore.go
+++ b/charmrepo/charmstore.go
@@ -192,7 +192,7 @@ func (s *CharmStore) Latest(curls ...*charm.URL) ([]CharmRevision, error) {
 // Resolve implements Interface.Resolve.
 func (s *CharmStore) Resolve(ref *charm.Reference) (*charm.URL, error) {
 	var result struct {
-		IdSeries params.IdSeriesResponse
+		Id params.IdResponse
 	}
 	if _, err := s.client.Meta(ref, &result); err != nil {
 		if errgo.Cause(err) == params.ErrNotFound {
@@ -200,9 +200,11 @@ func (s *CharmStore) Resolve(ref *charm.Reference) (*charm.URL, error) {
 		}
 		return nil, errgo.Notef(err, "cannot resolve charm URL %q", ref)
 	}
-	url := charm.URL(*ref)
-	url.Series = result.IdSeries.Series
-	return &url, nil
+	url, err := result.Id.Id.URL("")
+	if err != nil {
+		return nil, errgo.Notef(err, "cannot make fully resolved entity URL from %s", url)
+	}
+	return url, nil
 }
 
 // URL returns the root endpoint URL of the charm store.

--- a/charmrepo/charmstore_test.go
+++ b/charmrepo/charmstore_test.go
@@ -388,25 +388,25 @@ func (s *charmStoreRepoSuite) TestResolve(c *gc.C) {
 		err string
 	}{{
 		id:  "~who/mysql",
-		url: "cs:~who/trusty/mysql",
+		url: "cs:~who/trusty/mysql-0",
 	}, {
 		id:  "~who/trusty/mysql",
-		url: "cs:~who/trusty/mysql",
+		url: "cs:~who/trusty/mysql-0",
 	}, {
 		id:  "~who/wordpress",
-		url: "cs:~who/precise/wordpress",
+		url: "cs:~who/precise/wordpress-2",
 	}, {
 		id:  "~who/wordpress-2",
 		url: "cs:~who/precise/wordpress-2",
 	}, {
 		id:  "~dalek/riak",
-		url: "cs:~dalek/utopic/riak",
+		url: "cs:~dalek/utopic/riak-42",
 	}, {
 		id:  "~dalek/utopic/riak-42",
 		url: "cs:~dalek/utopic/riak-42",
 	}, {
 		id:  "utopic/mysql",
-		url: "cs:utopic/mysql",
+		url: "cs:utopic/mysql-47",
 	}, {
 		id:  "utopic/mysql-47",
 		url: "cs:utopic/mysql-47",

--- a/charmrepo/repo.go
+++ b/charmrepo/repo.go
@@ -24,7 +24,11 @@ type Interface interface {
 	// regardless of the revision set on each curl.
 	Latest(curls ...*charm.URL) ([]CharmRevision, error)
 
-	// Resolve resolves the series of the given entity reference.
+	// Resolve resolves the series and revision of the given entity
+	// reference. If the series is not specified, it may be resolved
+	// by the charm store or rejected. After the series is resolved,
+	// if the revision is not specified, it will be resolved to the latest
+	// available revision for that series.
 	Resolve(ref *charm.Reference) (*charm.URL, error)
 }
 


### PR DESCRIPTION
This can be used to make the juju deploy logic simpler by resolving
the charm URL in a single place only regardless of where the
repository is located.
