### PR TITLE
Correct licence headers to LGPLv3

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -1,5 +1,5 @@
 // Copyright 2011-2015 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm
 

--- a/actions_test.go
+++ b/actions_test.go
@@ -1,5 +1,5 @@
 // Copyright 2011-2015 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm
 

--- a/bundle.go
+++ b/bundle.go
@@ -1,5 +1,5 @@
 // Copyright 2014 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm
 

--- a/bundle_test.go
+++ b/bundle_test.go
@@ -1,5 +1,5 @@
 // Copyright 2014 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm_test
 

--- a/bundlearchive.go
+++ b/bundlearchive.go
@@ -1,5 +1,5 @@
 // Copyright 2014 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm
 

--- a/bundlearchive_test.go
+++ b/bundlearchive_test.go
@@ -1,5 +1,5 @@
 // Copyright 2014 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm_test
 

--- a/bundledata.go
+++ b/bundledata.go
@@ -1,5 +1,5 @@
 // Copyright 2014 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm
 

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -1,5 +1,5 @@
 // Copyright 2014 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm_test
 

--- a/bundledir.go
+++ b/bundledir.go
@@ -1,5 +1,5 @@
 // Copyright 2014 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm
 

--- a/bundledir_test.go
+++ b/bundledir_test.go
@@ -1,5 +1,5 @@
 // Copyright 2014 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm_test
 

--- a/charm.go
+++ b/charm.go
@@ -1,5 +1,5 @@
 // Copyright 2011, 2012, 2013 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm
 

--- a/charm_test.go
+++ b/charm_test.go
@@ -1,5 +1,5 @@
 // Copyright 2011, 2012, 2013 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm_test
 

--- a/charmarchive.go
+++ b/charmarchive.go
@@ -1,5 +1,5 @@
 // Copyright 2011, 2012, 2013 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm
 

--- a/charmarchive_test.go
+++ b/charmarchive_test.go
@@ -1,5 +1,5 @@
 // Copyright 2011, 2012, 2013 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm_test
 

--- a/charmdir.go
+++ b/charmdir.go
@@ -1,5 +1,5 @@
 // Copyright 2011, 2012, 2013 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm
 

--- a/charmdir_test.go
+++ b/charmdir_test.go
@@ -1,5 +1,5 @@
 // Copyright 2011, 2012, 2013 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm_test
 

--- a/charmrepo/charmstore.go
+++ b/charmrepo/charmstore.go
@@ -1,5 +1,5 @@
 // Copyright 2015 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charmrepo
 

--- a/charmrepo/charmstore_test.go
+++ b/charmrepo/charmstore_test.go
@@ -1,5 +1,5 @@
 // Copyright 2015 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charmrepo_test
 

--- a/charmrepo/legacy.go
+++ b/charmrepo/legacy.go
@@ -1,5 +1,5 @@
 // Copyright 2012, 2013 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charmrepo
 

--- a/charmrepo/legacy_test.go
+++ b/charmrepo/legacy_test.go
@@ -1,5 +1,5 @@
 // Copyright 2015 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charmrepo_test
 

--- a/charmrepo/local.go
+++ b/charmrepo/local.go
@@ -1,5 +1,5 @@
 // Copyright 2015 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charmrepo
 

--- a/charmrepo/local_test.go
+++ b/charmrepo/local_test.go
@@ -1,5 +1,5 @@
 // Copyright 2015 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charmrepo_test
 

--- a/charmrepo/package_test.go
+++ b/charmrepo/package_test.go
@@ -1,5 +1,5 @@
 // Copyright 2015 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charmrepo_test
 

--- a/charmrepo/params.go
+++ b/charmrepo/params.go
@@ -1,5 +1,5 @@
 // Copyright 2015 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charmrepo
 

--- a/charmrepo/repo.go
+++ b/charmrepo/repo.go
@@ -1,5 +1,5 @@
 // Copyright 2015 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 // Package charmrepo implements access to charm repositories.
 

--- a/charmrepo/repo_test.go
+++ b/charmrepo/repo_test.go
@@ -1,5 +1,5 @@
 // Copyright 2012, 2013 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charmrepo_test
 

--- a/config.go
+++ b/config.go
@@ -1,5 +1,5 @@
 // Copyright 2011, 2012, 2013 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm
 

--- a/config_test.go
+++ b/config_test.go
@@ -1,5 +1,5 @@
 // Copyright 2011, 2012, 2013 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm_test
 

--- a/export_test.go
+++ b/export_test.go
@@ -1,5 +1,5 @@
 // Copyright 2011, 2012, 2013 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm
 

--- a/hooks/hooks.go
+++ b/hooks/hooks.go
@@ -1,5 +1,5 @@
 // Copyright 2013 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 // hooks provides types and constants that define the hooks known to Juju.
 package hooks

--- a/meta.go
+++ b/meta.go
@@ -1,5 +1,5 @@
 // Copyright 2011, 2012, 2013 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm
 

--- a/meta_test.go
+++ b/meta_test.go
@@ -1,5 +1,5 @@
 // Copyright 2011, 2012, 2013 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm_test
 

--- a/metrics.go
+++ b/metrics.go
@@ -1,5 +1,5 @@
 // Copyright 2014 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,5 +1,5 @@
 // Copyright 2014 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm_test
 

--- a/testing/charm.go
+++ b/testing/charm.go
@@ -1,5 +1,5 @@
 // Copyright 2012, 2013 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package testing
 

--- a/testing/mockstore.go
+++ b/testing/mockstore.go
@@ -1,5 +1,5 @@
 // Copyright 2012, 2013 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package testing
 

--- a/testing/suite.go
+++ b/testing/suite.go
@@ -1,5 +1,5 @@
 // Copyright 2015 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package testing
 

--- a/testing/testcharm.go
+++ b/testing/testcharm.go
@@ -1,5 +1,5 @@
 // Copyright 2012, 2013 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package testing
 

--- a/url.go
+++ b/url.go
@@ -1,5 +1,5 @@
 // Copyright 2011, 2012, 2013 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm
 

--- a/url_test.go
+++ b/url_test.go
@@ -1,5 +1,5 @@
 // Copyright 2011, 2012, 2013 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm_test
 


### PR DESCRIPTION
Correct licence headers from AGPL to LGPL as noted by ubuntu release review:

https://bugs.launchpad.net/juju-core/+bug/1442132