### PR TITLE
charm: make num_units optional

### DIFF
--- a/bundle_test.go
+++ b/bundle_test.go
@@ -51,11 +51,10 @@ func checkWordpressBundle(c *gc.C, b charm.Bundle, path string) {
 	c.Assert(bd.Services, jc.DeepEquals, map[string]*charm.ServiceSpec{
 		"wordpress": {
 			Charm:    "wordpress",
-			NumUnits: 1,
 		},
 		"mysql": {
 			Charm:    "mysql",
-			NumUnits: 1,
+			NumUnits: newInt(1),
 		},
 	})
 	c.Assert(bd.Relations, jc.DeepEquals, [][]string{
@@ -68,6 +67,10 @@ func checkWordpressBundle(c *gc.C, b charm.Bundle, path string) {
 	case *charm.BundleDir:
 		c.Assert(b.Path, gc.Equals, path)
 	}
+}
+
+func newInt(i int) *int {
+	return &i
 }
 
 func verifyOk(string) error {

--- a/internal/test-charm-repo/bundle/wordpress-simple/bundle.yaml
+++ b/internal/test-charm-repo/bundle/wordpress-simple/bundle.yaml
@@ -1,7 +1,6 @@
 services:
     wordpress:
         charm: wordpress
-        num_units: 1
     mysql:
         charm: mysql
         num_units: 1


### PR DESCRIPTION
This fixes the bug that with subordinate charms, it was not
possible to leave the num_units field unspecified.
