### PR TITLE
metrics: export a function to decide if a metric is builtin. 

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -17,12 +17,17 @@ import (
 type MetricType string
 
 const (
-	builtinMetricsPrefix = "juju"
+	builtinMetricPrefix = "juju"
 
 	// Supported metric types.
 	MetricTypeGauge    MetricType = "gauge"
 	MetricTypeAbsolute MetricType = "absolute"
 )
+
+// IsBuiltinMetric reports whether the given metric key is in the builtin metric namespace
+func IsBuiltinMetric(key string) bool {
+	return strings.HasPrefix(key, builtinMetricPrefix)
+}
 
 // validateValue checks if the supplied metric value fits the requirements
 // of its expected type.
@@ -70,7 +75,7 @@ func ReadMetrics(r io.Reader) (*Metrics, error) {
 		return &metrics, nil
 	}
 	for name, metric := range metrics.Metrics {
-		if strings.HasPrefix(name, builtinMetricsPrefix) {
+		if IsBuiltinMetric(name) {
 			if metric.Type != MetricType("") || metric.Description != "" {
 				return nil, fmt.Errorf("metric %q is using a prefix reserved for built-in metrics: it should not have type or description specification", name)
 			}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -79,6 +79,29 @@ metrics:
 	c.Assert(metrics.Metrics["some-metric"].Type, gc.Equals, charm.MetricTypeAbsolute)
 }
 
+func (s *MetricsSuite) TestIsBuiltinMetric(c *gc.C) {
+	tests := []struct {
+		input     string
+		isbuiltin bool
+	}{{
+		"juju-thing",
+		true,
+	}, {
+		"jujuthing",
+		true,
+	}, {
+		"thing",
+		false,
+	},
+	}
+
+	for i, test := range tests {
+		c.Logf("test %d isBuiltinMetric(%v) = %v", i, test.input, test.isbuiltin)
+		is := charm.IsBuiltinMetric(test.input)
+		c.Assert(is, gc.Equals, test.isbuiltin)
+	}
+}
+
 func (s *MetricsSuite) TestValidYaml(c *gc.C) {
 	metrics, err := charm.ReadMetrics(strings.NewReader(`
 metrics:
@@ -92,7 +115,7 @@ metrics:
 `))
 	c.Assert(err, gc.IsNil)
 	c.Assert(metrics, gc.NotNil)
-	c.Assert(Keys(metrics), gc.DeepEquals, []string{"blips", "blops", "juju-unit"})
+	c.Assert(Keys(metrics), gc.DeepEquals, []string{"blips", "blops", "juju-unit-time"})
 
 	testCases := []struct {
 		about string


### PR DESCRIPTION
Keeps the logic in one place