### PR TITLE
Only copy maps in Workload if they aren't nil.

### DIFF
--- a/workload.go
+++ b/workload.go
@@ -39,8 +39,9 @@ func ParseWorkload(name string, data map[interface{}]interface{}) (*Workload, er
 	return ParseWorkloadWithRefs(name, data, nil, nil)
 }
 
-// ParseWorkload parses the provided data and converts it to a Workload.
-// The data will most likely have been de-serialized, perhaps from YAML.
+// ParseWorkloadWithRefs parses the provided data and converts it to a
+// Workload. The data will most likely have been de-serialized, perhaps
+// from YAML.
 func ParseWorkloadWithRefs(name string, data map[interface{}]interface{}, provides map[string]Relation, storage map[string]Storage) (*Workload, error) {
 	raw, err := workloadSchema.Coerce(data, []string{name})
 	if err != nil {

--- a/workload.go
+++ b/workload.go
@@ -56,17 +56,21 @@ func ParseWorkloadWithRefs(name string, data map[interface{}]interface{}, provid
 
 // Copy create a deep copy of the Workload.
 func (copied Workload) Copy() Workload {
-	typeOptions := make(map[string]string)
-	for k, v := range copied.TypeOptions {
-		typeOptions[k] = v
+	if copied.TypeOptions != nil {
+		typeOptions := make(map[string]string)
+		for k, v := range copied.TypeOptions {
+			typeOptions[k] = v
+		}
+		copied.TypeOptions = typeOptions
 	}
-	copied.TypeOptions = typeOptions
 
-	envVars := make(map[string]string)
-	for k, v := range copied.EnvVars {
-		envVars[k] = v
+	if copied.EnvVars != nil {
+		envVars := make(map[string]string)
+		for k, v := range copied.EnvVars {
+			envVars[k] = v
+		}
+		copied.EnvVars = envVars
 	}
-	copied.EnvVars = envVars
 
 	var ports []WorkloadPort
 	for _, port := range copied.Ports {

--- a/workload.go
+++ b/workload.go
@@ -54,7 +54,7 @@ func ParseWorkloadWithRefs(name string, data map[interface{}]interface{}, provid
 	return &workload, nil
 }
 
-// Copy create a deep copy of the Workload.
+// Copy creates a deep copy of the Workload.
 func (copied Workload) Copy() Workload {
 	if copied.TypeOptions != nil {
 		typeOptions := make(map[string]string)

--- a/workload_test.go
+++ b/workload_test.go
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/juju/charm.v5"
 )
 
-func (s *MetaSuite) TestWorkloadParse(c *gc.C) {
+func (s *MetaSuite) TestWorkloadParseOkay(c *gc.C) {
 	raw := make(map[interface{}]interface{})
 	err := yaml.Unmarshal([]byte(`
 description: a workload
@@ -33,7 +33,7 @@ env:
 	workload, err := charm.ParseWorkload("workload0", raw)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(workload, gc.DeepEquals, &charm.Workload{
+	c.Check(workload, jc.DeepEquals, &charm.Workload{
 		Name:        "workload0",
 		Description: "a workload",
 		Type:        "docker",
@@ -65,6 +65,32 @@ env:
 	})
 }
 
+func (s *MetaSuite) TestWorkloadParseMinimal(c *gc.C) {
+	raw := make(map[interface{}]interface{})
+	err := yaml.Unmarshal([]byte(`
+type: docker
+`), raw)
+	c.Assert(err, jc.ErrorIsNil)
+	workload, err := charm.ParseWorkload("workload0", raw)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(workload, jc.DeepEquals, &charm.Workload{
+		Name:        "workload0",
+		Description: "",
+		Type:        "docker",
+		TypeOptions: nil,
+		Command:     "",
+		Image:       "",
+		Ports:       nil,
+		Volumes:     nil,
+		EnvVars:     nil,
+	})
+	c.Check(workload, jc.DeepEquals, &charm.Workload{
+		Name: "workload0",
+		Type: "docker",
+	})
+}
+
 func (s *MetaSuite) TestWorkloadCopyVolume(c *gc.C) {
 	vol := charm.WorkloadVolume{
 		ExternalMount: "a",
@@ -77,7 +103,7 @@ func (s *MetaSuite) TestWorkloadCopyVolume(c *gc.C) {
 	c.Check(copied, jc.DeepEquals, vol)
 }
 
-func (s *MetaSuite) TestWorkloadCopyWorkload(c *gc.C) {
+func (s *MetaSuite) TestWorkloadCopyWorkloadOkay(c *gc.C) {
 	workload := charm.Workload{
 		Name:        "workload0",
 		Description: "a workload",
@@ -107,6 +133,16 @@ func (s *MetaSuite) TestWorkloadCopyWorkload(c *gc.C) {
 			"ENV_VAR":   "config:config-var",
 			"OTHER_VAR": "some value",
 		},
+	}
+	copied := workload.Copy()
+
+	c.Check(copied, jc.DeepEquals, workload)
+}
+
+func (s *MetaSuite) TestWorkloadCopyWorkloadMinimal(c *gc.C) {
+	workload := charm.Workload{
+		Name: "workload0",
+		Type: "docker",
 	}
 	copied := workload.Copy()
 
@@ -273,6 +309,31 @@ func (s *MetaSuite) TestWorkloadApplyEmpty(c *gc.C) {
 			"ENV_VAR":   "config:config-var",
 			"OTHER_VAR": "some value",
 		},
+	})
+}
+
+func (s *MetaSuite) TestWorkloadApplyMinimal(c *gc.C) {
+	workload := &charm.Workload{
+		Name:  "workload0",
+		Type:  "docker",
+		Image: "nginx/nginx",
+	}
+	overrides := []charm.WorkloadFieldValue{{
+		Field: "image",
+		Value: "nginx/nginx-2",
+	}}
+	additions := []charm.WorkloadFieldValue{{
+		Field: "description",
+		Value: "my workload",
+	}}
+	applied, err := workload.Apply(overrides, additions)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(applied, jc.DeepEquals, &charm.Workload{
+		Name:        "workload0",
+		Description: "my workload",
+		Type:        "docker",
+		Image:       "nginx/nginx-2",
 	})
 }
 


### PR DESCRIPTION
Currently Workload.Copy() turns nil maps into empty-but-allocated maps.  This patch fixes that.