### PR TITLE
URLs should refer to entities, rather than charms

### DIFF
--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -23,29 +23,29 @@ var _ = gc.Suite(&bundleDataSuite{})
 
 const mediawikiBundle = `
 series: precise
-services: 
-    mediawiki: 
+services:
+    mediawiki:
         charm: "cs:precise/mediawiki-10"
         num_units: 1
-        options: 
+        options:
             debug: false
             name: Please set name of wiki
             skin: vector
-        annotations: 
+        annotations:
             "gui-x": 609
             "gui-y": -15
-    mysql: 
+    mysql:
         charm: "cs:precise/mysql-28"
         num_units: 2
         to: [0, mediawiki/0]
-        options: 
+        options:
             "binlog-format": MIXED
             "block-size": 5
             "dataset-size": "80%"
             flavor: distro
             "ha-bindiface": eth0
             "ha-mcastport": 5411
-        annotations: 
+        annotations:
             "gui-x": 610
             "gui-y": 255
         constraints: "mem=8g"
@@ -172,29 +172,29 @@ machines:
          series: 'bad series'
     bogus:
     3:
-services: 
-    mediawiki: 
+services:
+    mediawiki:
         charm: "bogus:precise/mediawiki-10"
         num_units: -4
-        options: 
+        options:
             debug: false
             name: Please set name of wiki
             skin: vector
-        annotations: 
+        annotations:
             "gui-x": 609
             "gui-y": -15
-    mysql: 
+    mysql:
         charm: "cs:precise/mysql-28"
         num_units: 2
         to: [0, mediawiki/0, nowhere/3, 2, "bad placement"]
-        options: 
+        options:
             "binlog-format": MIXED
             "block-size": 5
             "dataset-size": "80%"
             flavor: distro
             "ha-bindiface": eth0
             "ha-mcastport": 5411
-        annotations: 
+        annotations:
             "gui-x": 610
             "gui-y": 255
         constraints: "bad constraints"
@@ -216,7 +216,7 @@ relations:
 		`machine "bogus" is not referred to by a placement directive`,
 		`invalid machine id "bogus" found in machines`,
 		`invalid constraints "bad constraints" in machine "0": bad constraint`,
-		`invalid charm URL in service "mediawiki": charm URL has invalid schema: "bogus:precise/mediawiki-10"`,
+		`invalid charm URL in service "mediawiki": entity URL has invalid schema: "bogus:precise/mediawiki-10"`,
 		`invalid constraints "bad constraints" in service "mysql": bad constraint`,
 		`negative number of units specified on service "mediawiki"`,
 		`too many units specified in unit placement for service "mysql"`,
@@ -424,11 +424,11 @@ var verifyWithCharmsErrorsTests = []struct {
 	about: "all present and correct",
 	data: `
 services:
-    service1: 
+    service1:
         charm: "test"
-    service2: 
+    service2:
         charm: "test"
-    service3: 
+    service3:
         charm: "test"
 relations:
     - ["service1:prova", "service2:reqa"]
@@ -441,10 +441,10 @@ relations:
 }, {
 	about: "undefined relations",
 	data: `
-services: 
-    service1: 
+services:
+    service1:
         charm: "test"
-    service2: 
+    service2:
         charm: "test"
 relations:
     - ["service1:prova", "service2:blah"]
@@ -460,10 +460,10 @@ relations:
 }, {
 	about: "undefined services",
 	data: `
-services: 
-    service1: 
+services:
+    service1:
         charm: "test"
-    service2: 
+    service2:
         charm: "test"
 relations:
     - ["unknown:prova", "service2:blah"]
@@ -479,10 +479,10 @@ relations:
 }, {
 	about: "equal services",
 	data: `
-services: 
-    service1: 
+services:
+    service1:
         charm: "test"
-    service2: 
+    service2:
         charm: "test"
 relations:
     - ["service2:prova", "service2:reqa"]
@@ -496,10 +496,10 @@ relations:
 }, {
 	about: "provider to provider relation",
 	data: `
-services: 
-    service1: 
+services:
+    service1:
         charm: "test"
-    service2: 
+    service2:
         charm: "test"
 relations:
     - ["service1:prova", "service2:prova"]
@@ -513,10 +513,10 @@ relations:
 }, {
 	about: "provider to provider relation",
 	data: `
-services: 
-    service1: 
+services:
+    service1:
         charm: "test"
-    service2: 
+    service2:
         charm: "test"
 relations:
     - ["service1:reqa", "service2:reqa"]
@@ -530,10 +530,10 @@ relations:
 }, {
 	about: "interface mismatch",
 	data: `
-services: 
-    service1: 
+services:
+    service1:
         charm: "test"
-    service2: 
+    service2:
         charm: "test"
 relations:
     - ["service1:reqa", "service2:provb"]
@@ -547,10 +547,10 @@ relations:
 }, {
 	about: "different charms",
 	data: `
-services: 
-    service1: 
+services:
+    service1:
         charm: "test1"
-    service2: 
+    service2:
         charm: "test2"
 relations:
     - ["service1:reqa", "service2:prova"]
@@ -565,10 +565,10 @@ relations:
 }, {
 	about: "ambiguous relation",
 	data: `
-services: 
-    service1: 
+services:
+    service1:
         charm: "test1"
-    service2: 
+    service2:
         charm: "test2"
 relations:
     - [service1, service2]
@@ -583,10 +583,10 @@ relations:
 }, {
 	about: "relation using juju-info",
 	data: `
-services: 
-    service1: 
+services:
+    service1:
         charm: "provider"
-    service2: 
+    service2:
         charm: "requirer"
 relations:
     - [service1, service2]
@@ -598,10 +598,10 @@ relations:
 }, {
 	about: "ambiguous when implicit relations taken into account",
 	data: `
-services: 
-    service1: 
+services:
+    service1:
         charm: "provider"
-    service2: 
+    service2:
         charm: "requirer"
 relations:
     - [service1, service2]
@@ -613,10 +613,10 @@ relations:
 }, {
 	about: "half of relation left open",
 	data: `
-services: 
-    service1: 
+services:
+    service1:
         charm: "provider"
-    service2: 
+    service2:
         charm: "requirer"
 relations:
     - ["service1:prova2", service2]
@@ -628,10 +628,10 @@ relations:
 }, {
 	about: "duplicate relation between open and fully-specified relations",
 	data: `
-services: 
-    service1: 
+services:
+    service1:
         charm: "provider"
-    service2: 
+    service2:
         charm: "requirer"
 relations:
     - ["service1:prova", "service2:reqa"]
@@ -647,13 +647,13 @@ relations:
 }, {
 	about: "configuration options specified",
 	data: `
-services: 
-    service1: 
+services:
+    service1:
         charm: "test"
         options:
             title: "some title"
             skill-level: 245
-    service2: 
+    service2:
         charm: "test"
         options:
             title: "another title"
@@ -664,13 +664,13 @@ services:
 }, {
 	about: "invalid type for option",
 	data: `
-services: 
-    service1: 
+services:
+    service1:
         charm: "test"
         options:
             title: "some title"
             skill-level: "too much"
-    service2: 
+    service2:
         charm: "test"
         options:
             title: "another title"
@@ -684,8 +684,8 @@ services:
 }, {
 	about: "unknown option",
 	data: `
-services: 
-    service1: 
+services:
+    service1:
         charm: "test"
         options:
             title: "some title"
@@ -700,13 +700,13 @@ services:
 }, {
 	about: "multiple config problems",
 	data: `
-services: 
-    service1: 
+services:
+    service1:
         charm: "test"
         options:
             title: "some title"
             unknown-option: 2345
-    service2: 
+    service2:
         charm: "test"
         options:
             title: 123

--- a/url.go
+++ b/url.go
@@ -155,7 +155,7 @@ func parseReference(url string) (*Reference, error) {
 	i := strings.Index(url, ":")
 	if i >= 0 {
 		r.Schema = url[:i]
-		if r.Schema != "cs" && r.Schema != "local" && r.Schema != "bundle" {
+		if r.Schema != "cs" && r.Schema != "local" {
 			return nil, fmt.Errorf("entity URL has invalid schema: %q", url)
 		}
 		i++

--- a/url.go
+++ b/url.go
@@ -44,7 +44,7 @@ type URL struct {
 //     cs:precise/wordpress
 type Reference URL
 
-var ErrUnresolvedUrl error = fmt.Errorf("charm url series is not resolved")
+var ErrUnresolvedUrl error = fmt.Errorf("entity url series is not resolved")
 
 var (
 	validSeries = regexp.MustCompile("^[a-z]+([a-z0-9]+)?$")
@@ -89,7 +89,7 @@ func ParseURL(urlStr string) (*URL, error) {
 		return nil, ErrUnresolvedUrl
 	}
 	if r.Schema == "" {
-		return nil, fmt.Errorf("charm URL has no schema: %q", urlStr)
+		return nil, fmt.Errorf("entity URL has no schema: %q", urlStr)
 	}
 	url, err := r.URL("")
 	if err != nil {
@@ -155,8 +155,8 @@ func parseReference(url string) (*Reference, error) {
 	i := strings.Index(url, ":")
 	if i >= 0 {
 		r.Schema = url[:i]
-		if r.Schema != "cs" && r.Schema != "local" {
-			return nil, fmt.Errorf("charm URL has invalid schema: %q", url)
+		if r.Schema != "cs" && r.Schema != "local" && r.Schema != "bundle" {
+			return nil, fmt.Errorf("entity URL has invalid schema: %q", url)
 		}
 		i++
 	} else {
@@ -164,33 +164,33 @@ func parseReference(url string) (*Reference, error) {
 	}
 	parts := strings.Split(url[i:], "/")
 	if len(parts) < 1 || len(parts) > 3 {
-		return nil, fmt.Errorf("charm URL has invalid form: %q", url)
+		return nil, fmt.Errorf("entity URL has invalid form: %q", url)
 	}
 
 	// ~<username>
 	if strings.HasPrefix(parts[0], "~") {
 		if r.Schema == "local" {
-			return nil, fmt.Errorf("local charm URL with user name: %q", url)
+			return nil, fmt.Errorf("local entity URL with user name: %q", url)
 		}
 		r.User = parts[0][1:]
 		if !names.IsValidUser(r.User) {
-			return nil, fmt.Errorf("charm URL has invalid user name: %q", url)
+			return nil, fmt.Errorf("entity URL has invalid user name: %q", url)
 		}
 		parts = parts[1:]
 	}
 	if len(parts) > 2 {
-		return nil, fmt.Errorf("charm URL has invalid form: %q", url)
+		return nil, fmt.Errorf("entity URL has invalid form: %q", url)
 	}
 	// <series>
 	if len(parts) == 2 {
 		r.Series = parts[0]
 		if !IsValidSeries(r.Series) {
-			return nil, fmt.Errorf("charm URL has invalid series: %q", url)
+			return nil, fmt.Errorf("entity URL has invalid series: %q", url)
 		}
 		parts = parts[1:]
 	}
 	if len(parts) < 1 {
-		return nil, fmt.Errorf("charm URL without charm name: %q", url)
+		return nil, fmt.Errorf("entity URL without entity name: %q", url)
 	}
 
 	// <name>[-<revision>]
@@ -212,7 +212,7 @@ func parseReference(url string) (*Reference, error) {
 		break
 	}
 	if !IsValidName(r.Name) {
-		return nil, fmt.Errorf("charm URL has invalid charm name: %q", url)
+		return nil, fmt.Errorf("entity URL has invalid entity name: %q", url)
 	}
 	return &r, nil
 }
@@ -249,7 +249,7 @@ func InferURL(src, defaultSeries string) (*URL, error) {
 	}
 	url, err := ref.URL(defaultSeries)
 	if err != nil {
-		return nil, fmt.Errorf("cannot infer charm URL for %q: %v", src, err)
+		return nil, fmt.Errorf("cannot infer entity URL for %q: %v", src, err)
 	}
 	return url, nil
 }

--- a/url_test.go
+++ b/url_test.go
@@ -53,49 +53,52 @@ var urlTests = []struct {
 	s:   "local:name",
 	ref: &charm.Reference{"local", "", "name", -1, ""},
 }, {
+	s:   "bundle:name",
+	ref: &charm.Reference{"bundle", "", "name", -1, ""},
+}, {
 	s:   "bs:~user/series/name-1",
-	err: "charm URL has invalid schema: .*",
+	err: "entity URL has invalid schema: .*",
 }, {
 	s:   ":foo",
-	err: "charm URL has invalid schema: .*",
+	err: "entity URL has invalid schema: .*",
 }, {
 	s:   "cs:~1/series/name-1",
-	err: "charm URL has invalid user name: .*",
+	err: "entity URL has invalid user name: .*",
 }, {
 	s:   "cs:~user",
-	err: "charm URL without charm name: .*",
+	err: "entity URL without entity name: .*",
 }, {
 	s:   "cs:~user/1/name-1",
-	err: "charm URL has invalid series: .*",
+	err: "entity URL has invalid series: .*",
 }, {
 	s:   "cs:~user/series/name-1-2",
-	err: "charm URL has invalid charm name: .*",
+	err: "entity URL has invalid entity name: .*",
 }, {
 	s:   "cs:~user/series/name-1-name-2",
-	err: "charm URL has invalid charm name: .*",
+	err: "entity URL has invalid entity name: .*",
 }, {
 	s:   "cs:~user/series/name--name-2",
-	err: "charm URL has invalid charm name: .*",
+	err: "entity URL has invalid entity name: .*",
 }, {
 	s:   "cs:foo-1-2",
-	err: "charm URL has invalid charm name: .*",
+	err: "entity URL has invalid entity name: .*",
 }, {
 	s:   "cs:~user/series/huh/name-1",
-	err: "charm URL has invalid form: .*",
+	err: "entity URL has invalid form: .*",
 }, {
 	s:   "cs:/name",
-	err: "charm URL has invalid series: .*",
+	err: "entity URL has invalid series: .*",
 }, {
 	s:   "local:~user/series/name",
-	err: "local charm URL with user name: .*",
+	err: "local entity URL with user name: .*",
 }, {
 	s:   "local:~user/name",
-	err: "local charm URL with user name: .*",
+	err: "local entity URL with user name: .*",
 }, {
 	s:     "precise/wordpress",
 	exact: "cs:precise/wordpress",
 	ref:   &charm.Reference{"cs", "", "wordpress", -1, "precise"},
-	err:   `charm URL has no schema: "precise/wordpress"`,
+	err:   `entity URL has no schema: "precise/wordpress"`,
 }, {
 	s:     "foo",
 	exact: "cs:foo",
@@ -120,13 +123,13 @@ var urlTests = []struct {
 	s:     "series/foo",
 	exact: "cs:series/foo",
 	ref:   &charm.Reference{"cs", "", "foo", -1, "series"},
-	err:   `charm URL has no schema: "series/foo"`,
+	err:   `entity URL has no schema: "series/foo"`,
 }, {
 	s:   "series/foo/bar",
-	err: `charm URL has invalid form: "series/foo/bar"`,
+	err: `entity URL has invalid form: "series/foo/bar"`,
 }, {
 	s:   "cs:foo/~blah",
-	err: `charm URL has invalid charm name: "cs:foo/~blah"`,
+	err: `entity URL has invalid entity name: "cs:foo/~blah"`,
 }}
 
 func (s *URLSuite) TestParseURL(c *gc.C) {
@@ -168,7 +171,7 @@ func (s *URLSuite) TestParseURL(c *gc.C) {
 		c.Check(url.Reference(), gc.DeepEquals, ref)
 
 		// URL parsing should always be reversible.
-		c.Check(url.String(), gc.Equals, t.s)
+		c.Check(url.String(), gc.Equals, t.s) // XXX
 	}
 }
 
@@ -212,7 +215,7 @@ func (s *URLSuite) TestInferURL(c *gc.C) {
 	}
 	u, err := charm.InferURL("~blah", "defseries")
 	c.Assert(u, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, "charm URL without charm name: .*")
+	c.Assert(err, gc.ErrorMatches, "entity URL without entity name: .*")
 }
 
 var inferNoDefaultSeriesTests = []struct {
@@ -233,7 +236,7 @@ func (s *URLSuite) TestInferURLNoDefaultSeries(c *gc.C) {
 		c.Logf("%d: %s", i, t.vague)
 		inferred, err := charm.InferURL(t.vague, "")
 		if t.exact == "" {
-			c.Assert(err, gc.ErrorMatches, fmt.Sprintf("cannot infer charm URL for %q: charm url series is not resolved", t.vague))
+			c.Assert(err, gc.ErrorMatches, fmt.Sprintf("cannot infer entity URL for %q: entity url series is not resolved", t.vague))
 		} else {
 			parsed, err := charm.ParseURL(t.exact)
 			c.Assert(err, gc.IsNil)
@@ -291,20 +294,20 @@ func (s *URLSuite) TestMustParseReference(c *gc.C) {
 	f := func() {
 		charm.MustParseReference("bad:bad")
 	}
-	c.Assert(f, gc.PanicMatches, `charm URL has invalid schema: "bad:bad"`)
+	c.Assert(f, gc.PanicMatches, `entity URL has invalid schema: "bad:bad"`)
 }
 
 func (s *URLSuite) TestMustParseURL(c *gc.C) {
 	url := charm.MustParseURL("cs:series/name")
 	c.Assert(url, gc.DeepEquals, &charm.URL{"cs", "", "name", -1, "series"})
 	f := func() { charm.MustParseURL("local:@@/name") }
-	c.Assert(f, gc.PanicMatches, "charm URL has invalid series: .*")
+	c.Assert(f, gc.PanicMatches, "entity URL has invalid series: .*")
 	f = func() { charm.MustParseURL("cs:~user") }
-	c.Assert(f, gc.PanicMatches, "charm URL without charm name: .*")
+	c.Assert(f, gc.PanicMatches, "entity URL without entity name: .*")
 	f = func() { charm.MustParseURL("cs:~user") }
-	c.Assert(f, gc.PanicMatches, "charm URL without charm name: .*")
+	c.Assert(f, gc.PanicMatches, "entity URL without entity name: .*")
 	f = func() { charm.MustParseURL("cs:name") }
-	c.Assert(f, gc.PanicMatches, "charm url series is not resolved")
+	c.Assert(f, gc.PanicMatches, "entity url series is not resolved")
 }
 
 func (s *URLSuite) TestWithRevision(c *gc.C) {

--- a/url_test.go
+++ b/url_test.go
@@ -53,9 +53,6 @@ var urlTests = []struct {
 	s:   "local:name",
 	ref: &charm.Reference{"local", "", "name", -1, ""},
 }, {
-	s:   "bundle:name",
-	ref: &charm.Reference{"bundle", "", "name", -1, ""},
-}, {
 	s:   "bs:~user/series/name-1",
 	err: "entity URL has invalid schema: .*",
 }, {


### PR DESCRIPTION
This is the first step in allowing deployment of bundles from juju with the command line.  This refers to charms and bundles as entities.  Future steps will enable different URL styles and future work in other repos will enable dealing with these references.