### PR TITLE
Resolve fully qualified storefront URLs

### DIFF
--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -216,7 +216,7 @@ relations:
 		`machine "bogus" is not referred to by a placement directive`,
 		`invalid machine id "bogus" found in machines`,
 		`invalid constraints "bad constraints" in machine "0": bad constraint`,
-		`invalid charm URL in service "mediawiki": entity URL has invalid schema: "bogus:precise/mediawiki-10"`,
+		`invalid charm URL in service "mediawiki": charm or bundle URL has invalid schema: "bogus:precise/mediawiki-10"`,
 		`invalid constraints "bad constraints" in service "mysql": bad constraint`,
 		`negative number of units specified on service "mediawiki"`,
 		`too many units specified in unit placement for service "mysql"`,

--- a/url.go
+++ b/url.go
@@ -15,10 +15,6 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
-const (
-	charmstoreURL string = "jujucharms.com"
-)
-
 // Location represents a charm location, which must declare a path component
 // and a string representaion.
 type Location interface {
@@ -54,7 +50,6 @@ var ErrUnresolvedUrl error = fmt.Errorf("entity url series is not resolved")
 var (
 	validSeries = regexp.MustCompile("^[a-z]+([a-z0-9]+)?$")
 	validName   = regexp.MustCompile("^[a-z][a-z0-9]*(-[a-z0-9]*[a-z][a-z0-9]*)*$")
-	validStore  = regexp.MustCompile(fmt.Sprintf("^https?://(www\\.)?%s/", charmstoreURL))
 )
 
 // IsValidSeries returns whether series is a valid series in charm URLs.

--- a/url.go
+++ b/url.go
@@ -184,6 +184,9 @@ func parseReference(url string) (*Reference, error) {
 				r.Revision = revision
 			} else {
 				r.Series = parts[0]
+				if !IsValidSeries(r.Series) {
+					return nil, fmt.Errorf("entity URL has invalid series: %q", url)
+				}
 				parts = parts[1:]
 				if len(parts) == 1 {
 					r.Revision, err = strconv.Atoi(parts[0])

--- a/url.go
+++ b/url.go
@@ -164,12 +164,14 @@ func parseReference(url string) (*Reference, error) {
 	if validStore.MatchString(url) {
 		r.Schema = "cs"
 		url = validStore.ReplaceAllString(url, "")
-		parts := strings.Split(url, "/")
-		// Strip any trailing blank parts.
-		if parts[len(parts)-1] == "" {
-			parts = parts[:len(parts)-1]
+		parts := strings.Split(strings.Trim(url, "/"), "/")
+		if len(parts) == 0 {
+			return nil, fmt.Errorf("entity URL malformed, no parts: %q", url)
 		}
 		if parts[0] == "u" {
+			if len(parts) < 3 {
+				return nil, fmt.Errorf("entity URL malformed, expecting user and name: %q", url)
+			}
 			r.User = parts[1]
 			parts = parts[2:]
 		}

--- a/url_test.go
+++ b/url_test.go
@@ -154,7 +154,7 @@ var urlTests = []struct {
 	err: "entity URL has invalid schema: .*",
 }, {
 	s:   ":foo",
-	err: "entity URL has invalid schema: .*",
+	err: "entity URL is not a valid url: .*",
 }, {
 	s:   "cs:~1/series/name-1",
 	err: "entity URL has invalid user name: .*",

--- a/url_test.go
+++ b/url_test.go
@@ -53,6 +53,82 @@ var urlTests = []struct {
 	s:   "local:name",
 	ref: &charm.Reference{"local", "", "name", -1, ""},
 }, {
+	s:     "http://jujucharms.com/u/user/name/series/1",
+	ref:   &charm.Reference{"cs", "user", "name", 1, "series"},
+	exact: "cs:~user/series/name-1",
+}, {
+	s:     "http://www.jujucharms.com/u/user/name/series/1",
+	ref:   &charm.Reference{"cs", "user", "name", 1, "series"},
+	exact: "cs:~user/series/name-1",
+}, {
+	s:     "https://www.jujucharms.com/u/user/name/series/1",
+	ref:   &charm.Reference{"cs", "user", "name", 1, "series"},
+	exact: "cs:~user/series/name-1",
+}, {
+	s:     "https://jujucharms.com/u/user/name/series/1",
+	ref:   &charm.Reference{"cs", "user", "name", 1, "series"},
+	exact: "cs:~user/series/name-1",
+}, {
+	s:     "https://jujucharms.com/u/user/name/series",
+	ref:   &charm.Reference{"cs", "user", "name", -1, "series"},
+	exact: "cs:~user/series/name",
+}, {
+	s:     "https://jujucharms.com/u/user/name/1",
+	ref:   &charm.Reference{"cs", "user", "name", 1, ""},
+	exact: "cs:~user/name-1",
+}, {
+	s:     "https://jujucharms.com/u/user/name",
+	ref:   &charm.Reference{"cs", "user", "name", -1, ""},
+	exact: "cs:~user/name",
+}, {
+	s:     "https://jujucharms.com/name",
+	ref:   &charm.Reference{"cs", "", "name", -1, ""},
+	exact: "cs:name",
+}, {
+	s:     "https://jujucharms.com/name/series",
+	ref:   &charm.Reference{"cs", "", "name", -1, "series"},
+	exact: "cs:series/name",
+}, {
+	s:     "https://jujucharms.com/name/1",
+	ref:   &charm.Reference{"cs", "", "name", 1, ""},
+	exact: "cs:name-1",
+}, {
+	s:     "https://jujucharms.com/name/series/1",
+	ref:   &charm.Reference{"cs", "", "name", 1, "series"},
+	exact: "cs:series/name-1",
+}, {
+	s:     "https://jujucharms.com/u/user/name/series/1/",
+	ref:   &charm.Reference{"cs", "user", "name", 1, "series"},
+	exact: "cs:~user/series/name-1",
+}, {
+	s:     "https://jujucharms.com/u/user/name/series/",
+	ref:   &charm.Reference{"cs", "user", "name", -1, "series"},
+	exact: "cs:~user/series/name",
+}, {
+	s:     "https://jujucharms.com/u/user/name/1/",
+	ref:   &charm.Reference{"cs", "user", "name", 1, ""},
+	exact: "cs:~user/name-1",
+}, {
+	s:     "https://jujucharms.com/u/user/name/",
+	ref:   &charm.Reference{"cs", "user", "name", -1, ""},
+	exact: "cs:~user/name",
+}, {
+	s:     "https://jujucharms.com/name/",
+	ref:   &charm.Reference{"cs", "", "name", -1, ""},
+	exact: "cs:name",
+}, {
+	s:     "https://jujucharms.com/name/series/",
+	ref:   &charm.Reference{"cs", "", "name", -1, "series"},
+	exact: "cs:series/name",
+}, {
+	s:     "https://jujucharms.com/name/1/",
+	ref:   &charm.Reference{"cs", "", "name", 1, ""},
+	exact: "cs:name-1",
+}, {
+	s:     "https://jujucharms.com/name/series/1/",
+	ref:   &charm.Reference{"cs", "", "name", 1, "series"},
+	exact: "cs:series/name-1",
+}, {
 	s:   "bs:~user/series/name-1",
 	err: "entity URL has invalid schema: .*",
 }, {
@@ -167,8 +243,13 @@ func (s *URLSuite) TestParseURL(c *gc.C) {
 		c.Assert(uerr, gc.IsNil)
 		c.Check(url.Reference(), gc.DeepEquals, ref)
 
-		// URL parsing should always be reversible.
-		c.Check(url.String(), gc.Equals, t.s) // XXX
+		// URL strings are generated as expected.  Reversability is preserved
+		// with v1 URLs.
+		if t.exact != "" {
+			c.Check(url.String(), gc.Equals, t.exact)
+		} else {
+			c.Check(url.String(), gc.Equals, t.s)
+		}
 	}
 }
 

--- a/url_test.go
+++ b/url_test.go
@@ -132,6 +132,9 @@ var urlTests = []struct {
 	s:   "https://jujucharms.com/",
 	err: "entity URL has invalid entity name: .*",
 }, {
+	s:   "https://jujucharms.com/bad.wolf",
+	err: "entity URL has invalid entity name: .*",
+}, {
 	s:   "https://jujucharms.com/u/",
 	err: "entity URL malformed, expecting user and name: .*",
 }, {
@@ -140,6 +143,9 @@ var urlTests = []struct {
 }, {
 	s:   "https://jujucharms.com/name/series/badwolf",
 	err: "entity URL has malformed revision: \"badwolf\" .*",
+}, {
+	s:   "https://jujucharms.com/name/bad.wolf/42",
+	err: "entity URL has invalid series: .*",
 }, {
 	s:   "https://jujucharms.com/name/series/42/badwolf",
 	err: "entity URL has invalid form: .*",

--- a/url_test.go
+++ b/url_test.go
@@ -129,6 +129,21 @@ var urlTests = []struct {
 	ref:   &charm.Reference{"cs", "", "name", 1, "series"},
 	exact: "cs:series/name-1",
 }, {
+	s:   "https://jujucharms.com/",
+	err: "entity URL has invalid entity name: .*",
+}, {
+	s:   "https://jujucharms.com/u/",
+	err: "entity URL malformed, expecting user and name: .*",
+}, {
+	s:   "https://jujucharms.com/u/badwolf",
+	err: "entity URL malformed, expecting user and name: .*",
+}, {
+	s:   "https://jujucharms.com/name/series/badwolf",
+	err: "entity URL has malformed revision: \"badwolf\" .*",
+}, {
+	s:   "https://jujucharms.com/name/series/42/badwolf",
+	err: "entity URL has invalid form: .*",
+}, {
 	s:   "bs:~user/series/name-1",
 	err: "entity URL has invalid schema: .*",
 }, {


### PR DESCRIPTION
This allows passing a storefront URL (eg: https://jujucharms.com/u/charmers/mysql/trusty/28 - see url_test.go for permutations) to parseReference.  This is the first step to supporting v2 charm/bundle URLs