### PR TITLE
Updated licence to match LICENSE file

### DIFF
--- a/workload.go
+++ b/workload.go
@@ -1,5 +1,5 @@
 // Copyright 2015 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm
 


### PR DESCRIPTION
Juju 1.25-beta1 cannot go into Ubuntu without reconciling this licensing contradiction. This is a simple case of a typo by an engineer. The file is LGPLv3 with a linking exemption. We only need to show this fix is merged. Ubuntu will accept a package if its copyright file points to upstream commit that fixes the issue.