### PR TITLE
Add an error when series cannot be determined

### DIFF
--- a/charm.go
+++ b/charm.go
@@ -41,10 +41,6 @@ func ReadCharm(path string) (charm Charm, err error) {
 	return charm, nil
 }
 
-// MissingSeriesError is used to denote that SeriesForCharm could not determine
-// a series because a legacy charm did not declare any.
-var MissingSeriesError = fmt.Errorf("series not specified and charm does not define any")
-
 // SeriesForCharm takes a requested series and a list of series supported by a
 // charm and returns the series which is relevant.
 // If the requested series is empty, then the first supported series is used,
@@ -53,7 +49,7 @@ func SeriesForCharm(requestedSeries string, supportedSeries []string) (string, e
 	// Old charm with no supported series.
 	if len(supportedSeries) == 0 {
 		if requestedSeries == "" {
-			return "", MissingSeriesError
+			return "", missingSeriesError
 		}
 		return requestedSeries, nil
 	}
@@ -66,8 +62,34 @@ func SeriesForCharm(requestedSeries string, supportedSeries []string) (string, e
 			return requestedSeries, nil
 		}
 	}
-	return "", fmt.Errorf(
+	return "", &unsupportedSeriesError{requestedSeries, supportedSeries}
+}
+
+// missingSeriesError is used to denote that SeriesForCharm could not determine
+// a series because a legacy charm did not declare any.
+var missingSeriesError = fmt.Errorf("series not specified and charm does not define any")
+
+// IsMissingSeriesError returns true if err is an missingSeriesError.
+func IsMissingSeriesError(err error) bool {
+	return err == missingSeriesError
+}
+
+// UnsupportedSeriesError represents an error indicating that the requested series
+// is not supported by the charm.
+type unsupportedSeriesError struct {
+	requestedSeries string
+	supportedSeries []string
+}
+
+func (e *unsupportedSeriesError) Error() string {
+	return fmt.Sprintf(
 		"series %q not supported by charm, supported series are: %s",
-		requestedSeries, strings.Join(supportedSeries, ","),
+		e.requestedSeries, strings.Join(e.supportedSeries, ","),
 	)
+}
+
+// IsUnsupportedSeriesError returns true if err is an UnsupportedSeriesError.
+func IsUnsupportedSeriesError(err error) bool {
+	_, ok := err.(*unsupportedSeriesError)
+	return ok
 }

--- a/charm.go
+++ b/charm.go
@@ -41,6 +41,10 @@ func ReadCharm(path string) (charm Charm, err error) {
 	return charm, nil
 }
 
+// MissingSeriesError is used to denote that SeriesForCharm could not determine
+// a series because a legacy charm did not declare any.
+var MissingSeriesError = fmt.Errorf("series not specified and charm does not define any")
+
 // SeriesForCharm takes a requested series and a list of series supported by a
 // charm and returns the series which is relevant.
 // If the requested series is empty, then the first supported series is used,
@@ -48,6 +52,9 @@ func ReadCharm(path string) (charm Charm, err error) {
 func SeriesForCharm(requestedSeries string, supportedSeries []string) (string, error) {
 	// Old charm with no supported series.
 	if len(supportedSeries) == 0 {
+		if requestedSeries == "" {
+			return "", MissingSeriesError
+		}
 		return requestedSeries, nil
 	}
 	// Use the charm default.

--- a/charm_test.go
+++ b/charm_test.go
@@ -5,6 +5,7 @@ package charm_test
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -61,7 +62,7 @@ func (s *CharmSuite) TestSeriesToUse(c *gc.C) {
 		err             string
 	}{{
 		series: "",
-		err:    charm.MissingSeriesError.Error(),
+		err:    "series not specified and charm does not define any",
 	}, {
 		series:      "trusty",
 		seriesToUse: "trusty",
@@ -87,6 +88,18 @@ func (s *CharmSuite) TestSeriesToUse(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(series, jc.DeepEquals, test.seriesToUse)
 	}
+}
+
+func (s *CharmSuite) IsUnsupportedSeriesError(c *gc.C) {
+	err := charm.UnsupportedSeriesError()
+	c.Assert(charm.IsUnsupportedSeriesError(err), jc.IsTrue)
+	c.Assert(charm.IsUnsupportedSeriesError(fmt.Errorf("foo")), jc.IsFalse)
+}
+
+func (s *CharmSuite) IsMissingSeriesError(c *gc.C) {
+	err := charm.MissingSeriesError()
+	c.Assert(charm.IsMissingSeriesError(err), jc.IsTrue)
+	c.Assert(charm.IsMissingSeriesError(fmt.Errorf("foo")), jc.IsFalse)
 }
 
 func checkDummy(c *gc.C, f charm.Charm, path string) {

--- a/charm_test.go
+++ b/charm_test.go
@@ -60,8 +60,8 @@ func (s *CharmSuite) TestSeriesToUse(c *gc.C) {
 		seriesToUse     string
 		err             string
 	}{{
-		series:      "",
-		seriesToUse: "",
+		series: "",
+		err:    charm.MissingSeriesError.Error(),
 	}, {
 		series:      "trusty",
 		seriesToUse: "trusty",

--- a/export_test.go
+++ b/export_test.go
@@ -6,3 +6,11 @@ package charm
 // Export meaningful bits for tests only.
 
 var IfaceExpander = ifaceExpander
+
+func UnsupportedSeriesError() error {
+	return &unsupportedSeriesError{}
+}
+
+func MissingSeriesError() error {
+	return missingSeriesError
+}


### PR DESCRIPTION
If a legacy charm does not declare any series, then we error when SeriesForCharm is called without a series.