### PR TITLE
Update to use gopkg.in/yaml.v2

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/juju/errors"
 	gjs "github.com/juju/gojsonschema"
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 )
 
 var prohibitedSchemaKeys = map[string]bool{"$ref": true, "$schema": true}

--- a/actions_test.go
+++ b/actions_test.go
@@ -533,7 +533,7 @@ snapshot:
          default: foo.bz2
 `,
 
-		expectedError: "YAML error: line 6: mapping values are not allowed in this context",
+		expectedError: "yaml: line 6: mapping values are not allowed in this context",
 	}, {
 		description: "Malformed JSON-Schema: $schema element misplaced.",
 		yaml: `
@@ -547,7 +547,7 @@ description: Take a snapshot of the database.
          default: foo.bz2
 `,
 
-		expectedError: "YAML error: line 3: mapping values are not allowed in this context",
+		expectedError: "yaml: line 3: mapping values are not allowed in this context",
 	}, {
 		description: "Malformed Actions: hyphen at beginning of action name.",
 		yaml: `
@@ -641,7 +641,7 @@ snapshot:
       something-else: {}
    other-key: ["some", "values"],
 `,
-		expectedError: "YAML error: line 16: did not find expected key",
+		expectedError: "yaml: line 16: did not find expected key",
 	}}
 
 	for i, test := range badActionsYamlTests {

--- a/bundledata.go
+++ b/bundledata.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 
 	"github.com/juju/names"
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 )
 
 // BundleData holds the contents of the bundle.

--- a/charm_test.go
+++ b/charm_test.go
@@ -15,7 +15,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/fs"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 
 	"gopkg.in/juju/charm.v6-unstable"
 )

--- a/charmarchive_test.go
+++ b/charmarchive_test.go
@@ -17,7 +17,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 
 	"gopkg.in/juju/charm.v6-unstable"
 )

--- a/config.go
+++ b/config.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 
 	"github.com/juju/schema"
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 )
 
 // Settings is a group of charm config option names and values. A Settings

--- a/config_test.go
+++ b/config_test.go
@@ -10,7 +10,7 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 
 	"gopkg.in/juju/charm.v6-unstable"
 )

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -5,9 +5,9 @@ github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-0
 github.com/juju/loggo	git	8477fc936adf0e382d680310047ca27e128a309a	2015-05-27T03:58:39Z
 github.com/juju/names	git	a6a253b0a94cc79e99a68d284b970ffce2a11ecd	2015-07-09T13:59:32Z
 github.com/juju/schema	git	afe1151cb49d1d7ed3c75592dfc6f38703f2e988	2015-08-07T07:58:08Z
-github.com/juju/testing	git	31ee64312c3c64cc94a5b41ea7a200b42e0f9767	2015-09-02T15:44:51Z
-github.com/juju/utils	git	03357ca1fc29e4a2b9189c82906475b6bc34f84a	2015-09-10T07:18:02Z
+github.com/juju/testing	git	5955efc6d5f61e41a13e4409ec6bae7a6975546f	2015-10-10T23:46:57Z
+github.com/juju/utils	git	9e6ce972d269929620d1bbf0d37241e27762071c	2015-10-10T23:41:13Z
 golang.org/x/crypto	git	aedad9a179ec1ea11b7064c57cbc6dc30d7724ec	2015-08-30T18:06:42Z
 gopkg.in/check.v1	git	b3d3430320d4260e5fea99841af984b3badcea63	2015-06-26T10:50:28Z
 gopkg.in/mgo.v2	git	f4923a569136442e900b8cf5c1a706c0a8b0883c	2015-08-21T15:31:23Z
-gopkg.in/yaml.v1	git	9f9df34309c04878acc86042b16630b0f696e1de	2014-09-24T16:16:07Z
+gopkg.in/yaml.v2	git	53feefa2559fb8dfa8d81baad31be332c97d6c77	2015-09-24T14:23:14Z

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -6,7 +6,7 @@ github.com/juju/loggo	git	8477fc936adf0e382d680310047ca27e128a309a	2015-05-27T03
 github.com/juju/names	git	a6a253b0a94cc79e99a68d284b970ffce2a11ecd	2015-07-09T13:59:32Z
 github.com/juju/schema	git	afe1151cb49d1d7ed3c75592dfc6f38703f2e988	2015-08-07T07:58:08Z
 github.com/juju/testing	git	5955efc6d5f61e41a13e4409ec6bae7a6975546f	2015-10-10T23:46:57Z
-github.com/juju/utils	git	9e6ce972d269929620d1bbf0d37241e27762071c	2015-10-10T23:41:13Z
+github.com/juju/utils	git	1fc85d7f4bc5e885cc86f68bb6ac610efee5be38	2015-10-14T03:39:15Z
 golang.org/x/crypto	git	aedad9a179ec1ea11b7064c57cbc6dc30d7724ec	2015-08-30T18:06:42Z
 gopkg.in/check.v1	git	b3d3430320d4260e5fea99841af984b3badcea63	2015-06-26T10:50:28Z
 gopkg.in/mgo.v2	git	f4923a569136442e900b8cf5c1a706c0a8b0883c	2015-08-21T15:31:23Z

--- a/meta.go
+++ b/meta.go
@@ -180,20 +180,20 @@ func (r Relation) IsImplicit() bool {
 // only applies to JSON because Meta has a custom
 // YAML marshaller.
 type Meta struct {
-	Name           string                  `bson:"name" json:"name"`
-	Summary        string                  `bson:"summary" json:"summary"`
-	Description    string                  `bson:"description" json:"description"`
-	Subordinate    bool                    `bson:"subordinate" json:"subordinate"`
-	Provides       map[string]Relation     `bson:"provides,omitempty" json:"provides,omitempty"`
-	Requires       map[string]Relation     `bson:"requires,omitempty" json:"requires,omitempty"`
-	Peers          map[string]Relation     `bson:"peers,omitempty" json:"peers,omitempty"`
-	Format         int                     `bson:"format,omitempty" json:"format,omitempty"`
-	OldRevision    int                     `bson:"oldrevision,omitempty"` // Obsolete
-	Categories     []string                `bson:"categories,omitempty" json:"categories,omitempty"`
-	Tags           []string                `bson:"tags,omitempty" json:"tag,omitempty"`
-	Series         []string                `bson:"series,omitempty" json:"supported-series,omitempty"`
-	Storage        map[string]Storage      `bson:"storage,omitempty" json:"storage,omitempty"`
-	PayloadClasses map[string]PayloadClass `bson:"payloadclasses,omitempty" json:"payloadclasses,omitempty"`
+	Name           string                  `bson:"name" json:"name" yaml:"name"`
+	Summary        string                  `bson:"summary" json:"summary" yaml:"summary"`
+	Description    string                  `bson:"description" json:"description" yaml:"description"`
+	Subordinate    bool                    `bson:"subordinate" json:"subordinate" yaml:"subordinate,omitempty"`
+	Provides       map[string]Relation     `bson:"provides,omitempty" json:"provides,omitempty" yaml:"provides,omitempty"`
+	Requires       map[string]Relation     `bson:"requires,omitempty" json:"requires,omitempty" yaml:"requires,omitempty"`
+	Peers          map[string]Relation     `bson:"peers,omitempty" json:"peers,omitempty" yaml:"peers,omitempty"`
+	Format         int                     `bson:"format,omitempty" json:"format,omitempty" yaml:"-"`
+	OldRevision    int                     `bson:"oldrevision,omitempty" yaml:"-"` // Obsolete
+	Categories     []string                `bson:"categories,omitempty" json:"categories,omitempty" yaml:"categories,omitempty"`
+	Tags           []string                `bson:"tags,omitempty" json:"tag,omitempty" yaml:"tags,omitempty"`
+	Series         []string                `bson:"series,omitempty" json:"supported-series,omitempty" yaml:"series,omitempty"`
+	Storage        map[string]Storage      `bson:"storage,omitempty" json:"storage,omitempty" yaml:"-"`
+	PayloadClasses map[string]PayloadClass `bson:"payloadclasses,omitempty" json:"payloadclasses,omitempty" yaml:"-"`
 }
 
 func generateRelationHooks(relName string, allHooks map[string]bool) {

--- a/meta_test.go
+++ b/meta_test.go
@@ -14,7 +14,7 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 
 	"gopkg.in/juju/charm.v6-unstable"
 )
@@ -587,10 +587,7 @@ peers:
 	gotYAML, err := yaml.Marshal(ch)
 	c.Assert(err, gc.IsNil)
 
-	var x interface{}
-	err = yaml.Unmarshal(gotYAML, &x)
-	c.Assert(err, gc.IsNil)
-	c.Assert(x, jc.DeepEquals, map[interface{}]interface{}{
+	c.Assert(string(gotYAML), jc.YAMLEquals, map[interface{}]interface{}{
 		"name":        "minimal",
 		"description": "d",
 		"summary":     "s",

--- a/metrics.go
+++ b/metrics.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 )
 
 // MetricType is used to identify metric types supported by juju.


### PR DESCRIPTION
The GetYAML interface has been dropped in favour of MarshalYAML
and some error messages have been improved.

It was possible to get rid of the Meta.GetYAML function entirely,
and as a side effect the storage attribute will now be serialised
to yaml rather than accidentally omitted.