### PR TITLE
Export unsupported series error so it can be used by juju-core

### DIFF
--- a/charm.go
+++ b/charm.go
@@ -88,7 +88,7 @@ func (e *unsupportedSeriesError) Error() string {
 	)
 }
 
-// NewUnsupportedSeriesError returns a error indicating that the requested series
+// NewUnsupportedSeriesError returns an error indicating that the requested series
 // is not supported by a charm.
 func NewUnsupportedSeriesError(requestedSeries string, supportedSeries []string) error {
 	return &unsupportedSeriesError{requestedSeries, supportedSeries}

--- a/charm.go
+++ b/charm.go
@@ -88,6 +88,12 @@ func (e *unsupportedSeriesError) Error() string {
 	)
 }
 
+// NewUnsupportedSeriesError returns a error indicating that the requested series
+// is not supported by a charm.
+func NewUnsupportedSeriesError(requestedSeries string, supportedSeries []string) error {
+	return &unsupportedSeriesError{requestedSeries, supportedSeries}
+}
+
 // IsUnsupportedSeriesError returns true if err is an UnsupportedSeriesError.
 func IsUnsupportedSeriesError(err error) bool {
 	_, ok := err.(*unsupportedSeriesError)

--- a/charm_test.go
+++ b/charm_test.go
@@ -91,7 +91,7 @@ func (s *CharmSuite) TestSeriesToUse(c *gc.C) {
 }
 
 func (s *CharmSuite) IsUnsupportedSeriesError(c *gc.C) {
-	err := charm.UnsupportedSeriesError()
+	err := charm.NewUnsupportedSeriesError("series", []string{"supported"})
 	c.Assert(charm.IsUnsupportedSeriesError(err), jc.IsTrue)
 	c.Assert(charm.IsUnsupportedSeriesError(fmt.Errorf("foo")), jc.IsFalse)
 }

--- a/export_test.go
+++ b/export_test.go
@@ -12,10 +12,6 @@ var (
 	ParsePayloadClass = parsePayloadClass
 )
 
-func UnsupportedSeriesError() error {
-	return &unsupportedSeriesError{}
-}
-
 func MissingSeriesError() error {
 	return missingSeriesError
 }


### PR DESCRIPTION
juju-core needs to create an unsupported series error, so export it.