### PR TITLE
Adjust resources code.

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -268,7 +268,10 @@ func ReadMeta(r io.Reader) (meta *Meta, err error) {
 	}
 
 	m := v.(map[string]interface{})
-	meta = parseMeta(m)
+	meta, err = parseMeta(m)
+	if err != nil {
+		return nil, err
+	}
 
 	if err := meta.Check(); err != nil {
 		return nil, err
@@ -281,7 +284,7 @@ func ReadMeta(r io.Reader) (meta *Meta, err error) {
 	return meta, nil
 }
 
-func parseMeta(m map[string]interface{}) *Meta {
+func parseMeta(m map[string]interface{}) (*Meta, error) {
 	var meta Meta
 
 	meta.Name = m["name"].(string)
@@ -307,7 +310,7 @@ func parseMeta(m map[string]interface{}) *Meta {
 	meta.PayloadClasses = parsePayloadClasses(m["payloads"])
 	meta.Resources = parseMetaResources(m["resources"])
 
-	return &meta
+	return &meta, nil
 }
 
 // GetYAML implements yaml.Getter.GetYAML.

--- a/meta.go
+++ b/meta.go
@@ -308,7 +308,12 @@ func parseMeta(m map[string]interface{}) (*Meta, error) {
 	meta.Series = parseStringList(m["series"])
 	meta.Storage = parseStorage(m["storage"])
 	meta.PayloadClasses = parsePayloadClasses(m["payloads"])
-	meta.Resources = parseMetaResources(m["resources"])
+
+	resources, err := parseMetaResources(m["resources"])
+	if err != nil {
+		return nil, err
+	}
+	meta.Resources = resources
 
 	return &meta, nil
 }

--- a/resource/meta.go
+++ b/resource/meta.go
@@ -35,17 +35,21 @@ type Meta struct {
 }
 
 // ParseMeta parses the provided data into a Meta.
-func ParseMeta(name string, data interface{}) Meta {
+func ParseMeta(name string, data interface{}) (Meta, error) {
 	var meta Meta
 	meta.Name = name
 
 	if data == nil {
-		return meta
+		return meta, nil
 	}
 	rMap := data.(map[string]interface{})
 
 	if val := rMap["type"]; val != nil {
-		meta.Type, _ = ParseType(val.(string))
+		var err error
+		meta.Type, err = ParseType(val.(string))
+		if err != nil {
+			return meta, errors.Trace(err)
+		}
 	}
 
 	if val := rMap["filename"]; val != nil {
@@ -56,7 +60,7 @@ func ParseMeta(name string, data interface{}) Meta {
 		meta.Comment = val.(string)
 	}
 
-	return meta
+	return meta, nil
 }
 
 // Validate checks the resource metadata to ensure the data is valid.

--- a/resource/meta.go
+++ b/resource/meta.go
@@ -69,7 +69,8 @@ func (meta Meta) Validate() error {
 		return errors.NewNotValid(nil, "resource missing name")
 	}
 
-	if meta.Type == TypeUnknown {
+	var typeUnknown Type
+	if meta.Type == typeUnknown {
 		return errors.NewNotValid(nil, "resource missing type")
 	}
 	if err := meta.Type.Validate(); err != nil {

--- a/resource/meta_test.go
+++ b/resource/meta_test.go
@@ -22,7 +22,8 @@ func (s *MetaSuite) TestParseMetaOkay(c *gc.C) {
 		"filename": "filename.tgz",
 		"comment":  "One line that is useful when operators need to push it.",
 	}
-	res := resource.ParseMeta(name, data)
+	res, err := resource.ParseMeta(name, data)
+	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(res, jc.DeepEquals, resource.Meta{
 		Name:    "my-resource",
@@ -39,7 +40,8 @@ func (s *MetaSuite) TestParseMetaMissingName(c *gc.C) {
 		"filename": "filename.tgz",
 		"comment":  "One line that is useful when operators need to push it.",
 	}
-	res := resource.ParseMeta(name, data)
+	res, err := resource.ParseMeta(name, data)
+	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(res, jc.DeepEquals, resource.Meta{
 		Name:    "",
@@ -55,7 +57,8 @@ func (s *MetaSuite) TestParseMetaMissingType(c *gc.C) {
 		"filename": "filename.tgz",
 		"comment":  "One line that is useful when operators need to push it.",
 	}
-	res := resource.ParseMeta(name, data)
+	res, err := resource.ParseMeta(name, data)
+	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(res, jc.DeepEquals, resource.Meta{
 		Name:    "my-resource",
@@ -65,13 +68,40 @@ func (s *MetaSuite) TestParseMetaMissingType(c *gc.C) {
 	})
 }
 
+func (s *MetaSuite) TestParseMetaEmptyType(c *gc.C) {
+	name := "my-resource"
+	data := map[string]interface{}{
+		"type":     "",
+		"filename": "filename.tgz",
+		"comment":  "One line that is useful when operators need to push it.",
+	}
+	_, err := resource.ParseMeta(name, data)
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `unsupported resource type .*`)
+}
+
+func (s *MetaSuite) TestParseMetaUnknownType(c *gc.C) {
+	name := "my-resource"
+	data := map[string]interface{}{
+		"type":     "spam",
+		"filename": "filename.tgz",
+		"comment":  "One line that is useful when operators need to push it.",
+	}
+	_, err := resource.ParseMeta(name, data)
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `unsupported resource type .*`)
+}
+
 func (s *MetaSuite) TestParseMetaMissingPath(c *gc.C) {
 	name := "my-resource"
 	data := map[string]interface{}{
 		"type":    "file",
 		"comment": "One line that is useful when operators need to push it.",
 	}
-	res := resource.ParseMeta(name, data)
+	res, err := resource.ParseMeta(name, data)
+	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(res, jc.DeepEquals, resource.Meta{
 		Name:    "my-resource",
@@ -87,7 +117,8 @@ func (s *MetaSuite) TestParseMetaMissingComment(c *gc.C) {
 		"type":     "file",
 		"filename": "filename.tgz",
 	}
-	res := resource.ParseMeta(name, data)
+	res, err := resource.ParseMeta(name, data)
+	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(res, jc.DeepEquals, resource.Meta{
 		Name:    "my-resource",
@@ -100,7 +131,8 @@ func (s *MetaSuite) TestParseMetaMissingComment(c *gc.C) {
 func (s *MetaSuite) TestParseMetaEmpty(c *gc.C) {
 	name := "my-resource"
 	data := make(map[string]interface{})
-	res := resource.ParseMeta(name, data)
+	res, err := resource.ParseMeta(name, data)
+	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(res, jc.DeepEquals, resource.Meta{
 		Name: "my-resource",
@@ -110,7 +142,8 @@ func (s *MetaSuite) TestParseMetaEmpty(c *gc.C) {
 func (s *MetaSuite) TestParseMetaNil(c *gc.C) {
 	name := "my-resource"
 	var data map[string]interface{}
-	res := resource.ParseMeta(name, data)
+	res, err := resource.ParseMeta(name, data)
+	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(res, jc.DeepEquals, resource.Meta{
 		Name: "my-resource",

--- a/resource/meta_test.go
+++ b/resource/meta_test.go
@@ -62,7 +62,7 @@ func (s *MetaSuite) TestParseMetaMissingType(c *gc.C) {
 
 	c.Check(res, jc.DeepEquals, resource.Meta{
 		Name:    "my-resource",
-		Type:    resource.TypeUnknown,
+		Type:    resource.Type{},
 		Path:    "filename.tgz",
 		Comment: "One line that is useful when operators need to push it.",
 	})
@@ -189,19 +189,6 @@ func (s *MetaSuite) TestValidateMissingType(c *gc.C) {
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
 	c.Check(err, gc.ErrorMatches, `resource missing type`)
-}
-
-func (s *MetaSuite) TestValidateUnknownType(c *gc.C) {
-	res := resource.Meta{
-		Name:    "my-resource",
-		Type:    "repo",
-		Path:    "repo-root",
-		Comment: "One line that is useful when operators need to push it.",
-	}
-	err := res.Validate()
-
-	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `.*unsupported resource type .*`)
 }
 
 func (s *MetaSuite) TestValidateMissingPath(c *gc.C) {

--- a/resource/meta_test.go
+++ b/resource/meta_test.go
@@ -77,7 +77,6 @@ func (s *MetaSuite) TestParseMetaEmptyType(c *gc.C) {
 	}
 	_, err := resource.ParseMeta(name, data)
 
-	c.Check(err, jc.Satisfies, errors.IsNotValid)
 	c.Check(err, gc.ErrorMatches, `unsupported resource type .*`)
 }
 
@@ -90,7 +89,6 @@ func (s *MetaSuite) TestParseMetaUnknownType(c *gc.C) {
 	}
 	_, err := resource.ParseMeta(name, data)
 
-	c.Check(err, jc.Satisfies, errors.IsNotValid)
 	c.Check(err, gc.ErrorMatches, `unsupported resource type .*`)
 }
 

--- a/resource/meta_test.go
+++ b/resource/meta_test.go
@@ -61,8 +61,8 @@ func (s *MetaSuite) TestParseMetaMissingType(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(res, jc.DeepEquals, resource.Meta{
-		Name:    "my-resource",
-		Type:    resource.Type{},
+		Name: "my-resource",
+		// Type is the zero value.
 		Path:    "filename.tgz",
 		Comment: "One line that is useful when operators need to push it.",
 	})

--- a/resource/origin.go
+++ b/resource/origin.go
@@ -1,0 +1,50 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resource
+
+import (
+	"github.com/juju/errors"
+)
+
+// These are the valid resource origins.
+const (
+	originUnknown Origin = iota
+	OriginUpload
+	OriginStore
+)
+
+var origins = map[Origin]string{
+	OriginUpload: "upload",
+	OriginStore:  "store",
+}
+
+// Origin identifies where a charm's resource comes from.
+type Origin int
+
+// ParseOrigin converts the provided string into an Origin.
+// If it is not a known origin then an error is returned.
+func ParseOrigin(value string) (Origin, error) {
+	for o, str := range origins {
+		if value == str {
+			return o, nil
+		}
+	}
+	return originUnknown, errors.Errorf("unknown origin %q", value)
+}
+
+// String returns the printable representation of the origin.
+func (o Origin) String() string {
+	return origins[o]
+}
+
+// Validate ensures that the origin is correct.
+func (o Origin) Validate() error {
+	// Ideally, only the (unavoidable) zero value would be invalid.
+	// However, typedef'ing int means that the use of int literals
+	// could result in invalid Type values other than the zero value.
+	if _, ok := origins[o]; !ok {
+		return errors.NewNotValid(nil, "unknown origin")
+	}
+	return nil
+}

--- a/resource/origin_test.go
+++ b/resource/origin_test.go
@@ -1,0 +1,58 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resource_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"gopkg.in/juju/charm.v6-unstable/resource"
+)
+
+type OriginSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&OriginSuite{})
+
+func (OriginSuite) TestParseOriginKnown(c *gc.C) {
+	recognized := map[string]resource.Origin{
+		"upload": resource.OriginUpload,
+		"store":  resource.OriginStore,
+	}
+	for value, expected := range recognized {
+		origin, err := resource.ParseOrigin(value)
+
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(origin, gc.Equals, expected)
+	}
+}
+
+func (OriginSuite) TestParseOriginUnknown(c *gc.C) {
+	_, err := resource.ParseOrigin("<invalid>")
+
+	c.Check(err, gc.ErrorMatches, `.*unknown origin "<invalid>".*`)
+}
+
+func (OriginSuite) TestValidateKnown(c *gc.C) {
+	recognized := []resource.Origin{
+		resource.OriginUpload,
+		resource.OriginStore,
+	}
+	for _, origin := range recognized {
+		err := origin.Validate()
+
+		c.Check(err, jc.ErrorIsNil)
+	}
+}
+
+func (OriginSuite) TestValidateUnknown(c *gc.C) {
+	var origin resource.Origin
+	err := origin.Validate()
+
+	c.Check(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `.*unknown origin.*`)
+}

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -11,6 +11,9 @@ import (
 type Resource struct {
 	Meta
 
+	// Origin identifies where the resource will come from.
+	Origin Origin
+
 	// Revision is the charm store revision of the resource.
 	Revision int
 
@@ -22,6 +25,10 @@ type Resource struct {
 func (res Resource) Validate() error {
 	if err := res.Meta.Validate(); err != nil {
 		return errors.Annotate(err, "invalid resource (bad metadata)")
+	}
+
+	if err := res.Origin.Validate(); err != nil {
+		return errors.Annotate(err, "invalid resource (bad origin)")
 	}
 
 	if res.Revision < 0 {

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -27,6 +27,7 @@ func (s *ResourceSuite) TestValidateFull(c *gc.C) {
 			Path:    "filename.tgz",
 			Comment: "One line that is useful when operators need to push it.",
 		},
+		Origin:      resource.OriginStore,
 		Revision:    1,
 		Fingerprint: fp,
 	}
@@ -50,6 +51,7 @@ func (s *ResourceSuite) TestValidateBadMetadata(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	res := resource.Resource{
 		Meta:        meta,
+		Origin:      resource.OriginStore,
 		Revision:    1,
 		Fingerprint: fp,
 	}
@@ -57,6 +59,28 @@ func (s *ResourceSuite) TestValidateBadMetadata(c *gc.C) {
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
 	c.Check(err, gc.ErrorMatches, `.*bad metadata.*`)
+}
+
+func (s *ResourceSuite) TestValidateBadOrigin(c *gc.C) {
+	var origin resource.Origin
+	c.Assert(origin.Validate(), gc.NotNil)
+	fp, err := resource.NewFingerprint(fingerprint)
+	c.Assert(err, jc.ErrorIsNil)
+	res := resource.Resource{
+		Meta: resource.Meta{
+			Name:    "my-resource",
+			Type:    resource.TypeFile,
+			Path:    "filename.tgz",
+			Comment: "One line that is useful when operators need to push it.",
+		},
+		Origin:      origin,
+		Revision:    1,
+		Fingerprint: fp,
+	}
+	err = res.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `.*bad origin.*`)
 }
 
 func (s *ResourceSuite) TestValidateBadRevision(c *gc.C) {
@@ -69,6 +93,7 @@ func (s *ResourceSuite) TestValidateBadRevision(c *gc.C) {
 			Path:    "filename.tgz",
 			Comment: "One line that is useful when operators need to push it.",
 		},
+		Origin:      resource.OriginStore,
 		Revision:    -1,
 		Fingerprint: fp,
 	}
@@ -89,6 +114,7 @@ func (s *ResourceSuite) TestValidateBadFingerprint(c *gc.C) {
 			Path:    "filename.tgz",
 			Comment: "One line that is useful when operators need to push it.",
 		},
+		Origin:      resource.OriginStore,
 		Revision:    1,
 		Fingerprint: fp,
 	}

--- a/resource/type.go
+++ b/resource/type.go
@@ -4,15 +4,12 @@
 package resource
 
 import (
-	"fmt"
-
 	"github.com/juju/errors"
 )
 
 // These are the valid resource types (except for unknown).
-const (
-	TypeUnknown Type = ""
-	TypeFile    Type = "file"
+var (
+	TypeFile = Type{"file"}
 )
 
 var types = map[Type]bool{
@@ -20,28 +17,32 @@ var types = map[Type]bool{
 }
 
 // Type enumerates the recognized resource types.
-type Type string
+type Type struct {
+	str string
+}
 
 // ParseType converts a string to a Type. If the given value does not
 // match a recognized type then an error is returned.
 func ParseType(value string) (Type, error) {
-	rt := Type(value)
-	if _, ok := types[rt]; !ok {
-		return TypeUnknown, errors.Errorf("unsupported resource type %q", value)
+	for rt := range types {
+		if value == rt.str {
+			return rt, nil
+		}
 	}
-	return rt, rt.Validate()
+	return Type{}, errors.Errorf("unsupported resource type %q", value)
 }
 
 // String returns the printable representation of the type.
 func (rt Type) String() string {
-	return string(rt)
+	return rt.str
 }
 
 // Validate ensures that the type is valid.
 func (rt Type) Validate() error {
-	if _, ok := types[rt]; !ok {
-		msg := fmt.Sprintf("unsupported resource type %v", rt)
-		return errors.NewNotValid(nil, msg)
+	// Only the zero value is invalid.
+	var zero Type
+	if rt == zero {
+		return errors.NotValidf("zero value")
 	}
 	return nil
 }

--- a/resource/type.go
+++ b/resource/type.go
@@ -26,6 +26,9 @@ type Type string
 // match a recognized type then an error is returned.
 func ParseType(value string) (Type, error) {
 	rt := Type(value)
+	if _, ok := types[rt]; !ok {
+		return rt, errors.Errorf("unsupported resource type %q", value)
+	}
 	return rt, rt.Validate()
 }
 

--- a/resource/type.go
+++ b/resource/type.go
@@ -22,12 +22,11 @@ var types = map[Type]bool{
 // Type enumerates the recognized resource types.
 type Type string
 
-// ParseType converts a string to a Type. If the given
-// value does not match a recognized type then TypeUnknown and
-// false are returned.
-func ParseType(value string) (Type, bool) {
+// ParseType converts a string to a Type. If the given value does not
+// match a recognized type then an error is returned.
+func ParseType(value string) (Type, error) {
 	rt := Type(value)
-	return rt, types[rt]
+	return rt, rt.Validate()
 }
 
 // String returns the printable representation of the type.

--- a/resource/type.go
+++ b/resource/type.go
@@ -38,8 +38,10 @@ func (rt Type) String() string {
 
 // Validate ensures that the type is valid.
 func (rt Type) Validate() error {
-	// Only the zero value is invalid.
-	if rt == typeUnknown {
+	// Ideally, only the (unavoidable) zero value would be invalid.
+	// However, typedef'ing int means that the use of int literals
+	// could result in invalid Type values other than the zero value.
+	if _, ok := types[rt]; !ok {
 		return errors.NewNotValid(nil, "unknown resource type")
 	}
 	return nil

--- a/resource/type.go
+++ b/resource/type.go
@@ -34,9 +34,6 @@ func ParseType(value string) (Type, error) {
 
 // String returns the printable representation of the type.
 func (rt Type) String() string {
-	if rt == "" {
-		return "<unknown>"
-	}
 	return string(rt)
 }
 

--- a/resource/type.go
+++ b/resource/type.go
@@ -8,40 +8,38 @@ import (
 )
 
 // These are the valid resource types (except for unknown).
-var (
-	TypeFile = Type{"file"}
+const (
+	typeUnknown Type = iota
+	TypeFile
 )
 
-var types = map[Type]bool{
-	TypeFile: true,
+var types = map[Type]string{
+	TypeFile: "file",
 }
 
 // Type enumerates the recognized resource types.
-type Type struct {
-	str string
-}
+type Type int
 
 // ParseType converts a string to a Type. If the given value does not
 // match a recognized type then an error is returned.
 func ParseType(value string) (Type, error) {
-	for rt := range types {
-		if value == rt.str {
+	for rt, str := range types {
+		if value == str {
 			return rt, nil
 		}
 	}
-	return Type{}, errors.Errorf("unsupported resource type %q", value)
+	return typeUnknown, errors.Errorf("unsupported resource type %q", value)
 }
 
 // String returns the printable representation of the type.
 func (rt Type) String() string {
-	return rt.str
+	return types[rt]
 }
 
 // Validate ensures that the type is valid.
 func (rt Type) Validate() error {
 	// Only the zero value is invalid.
-	var zero Type
-	if rt == zero {
+	if rt == typeUnknown {
 		return errors.NewNotValid(nil, "unknown resource type")
 	}
 	return nil

--- a/resource/type.go
+++ b/resource/type.go
@@ -27,7 +27,7 @@ type Type string
 func ParseType(value string) (Type, error) {
 	rt := Type(value)
 	if _, ok := types[rt]; !ok {
-		return rt, errors.Errorf("unsupported resource type %q", value)
+		return TypeUnknown, errors.Errorf("unsupported resource type %q", value)
 	}
 	return rt, rt.Validate()
 }

--- a/resource/type.go
+++ b/resource/type.go
@@ -42,7 +42,7 @@ func (rt Type) Validate() error {
 	// Only the zero value is invalid.
 	var zero Type
 	if rt == zero {
-		return errors.NotValidf("zero value")
+		return errors.NewNotValid(nil, "unknown resource type")
 	}
 	return nil
 }

--- a/resource/type_test.go
+++ b/resource/type_test.go
@@ -4,6 +4,7 @@
 package resource_test
 
 import (
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -15,9 +16,9 @@ var _ = gc.Suite(&TypeSuite{})
 type TypeSuite struct{}
 
 func (s *TypeSuite) TestParseTypeOkay(c *gc.C) {
-	rt, ok := resource.ParseType("file")
+	rt, err := resource.ParseType("file")
+	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(ok, jc.IsTrue)
 	c.Check(rt, gc.Equals, resource.TypeFile)
 }
 
@@ -26,24 +27,26 @@ func (s *TypeSuite) TestParseTypeRecognized(c *gc.C) {
 		resource.TypeFile,
 	}
 	for _, expected := range supported {
-		rt, ok := resource.ParseType(expected.String())
+		rt, err := resource.ParseType(expected.String())
+		c.Assert(err, jc.ErrorIsNil)
 
-		c.Check(ok, jc.IsTrue)
 		c.Check(rt, gc.Equals, expected)
 	}
 }
 
 func (s *TypeSuite) TestParseTypeEmpty(c *gc.C) {
-	rt, ok := resource.ParseType("")
+	rt, err := resource.ParseType("")
 
-	c.Check(ok, jc.IsFalse)
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `unsupported resource type .*`)
 	c.Check(rt, gc.Equals, resource.TypeUnknown)
 }
 
 func (s *TypeSuite) TestParseTypeUnsupported(c *gc.C) {
-	rt, ok := resource.ParseType("spam")
+	rt, err := resource.ParseType("spam")
 
-	c.Check(ok, jc.IsFalse)
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `unsupported resource type .*`)
 	c.Check(rt, gc.Equals, resource.Type("spam"))
 }
 

--- a/resource/type_test.go
+++ b/resource/type_test.go
@@ -80,5 +80,5 @@ func (s *TypeSuite) TestTypeValidateUnknown(c *gc.C) {
 	err := resource.Type{}.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `zero value not valid`)
+	c.Check(err, gc.ErrorMatches, `unknown resource type`)
 }

--- a/resource/type_test.go
+++ b/resource/type_test.go
@@ -38,14 +38,14 @@ func (s *TypeSuite) TestParseTypeEmpty(c *gc.C) {
 	rt, err := resource.ParseType("")
 
 	c.Check(err, gc.ErrorMatches, `unsupported resource type ""`)
-	c.Check(rt, gc.Equals, resource.TypeUnknown)
+	c.Check(rt, gc.Equals, resource.Type{})
 }
 
 func (s *TypeSuite) TestParseTypeUnsupported(c *gc.C) {
 	rt, err := resource.ParseType("spam")
 
 	c.Check(err, gc.ErrorMatches, `unsupported resource type "spam"`)
-	c.Check(rt, gc.Equals, resource.TypeUnknown)
+	c.Check(rt, gc.Equals, resource.Type{})
 }
 
 func (s *TypeSuite) TestTypeStringSupported(c *gc.C) {
@@ -60,15 +60,9 @@ func (s *TypeSuite) TestTypeStringSupported(c *gc.C) {
 }
 
 func (s *TypeSuite) TestTypeStringUnknown(c *gc.C) {
-	str := resource.TypeUnknown.String()
+	str := resource.Type{}.String()
 
 	c.Check(str, gc.Equals, "")
-}
-
-func (s *TypeSuite) TestTypeStringUnsupported(c *gc.C) {
-	str := resource.Type("spam").String()
-
-	c.Check(str, gc.Equals, "spam")
 }
 
 func (s *TypeSuite) TestTypeValidateSupported(c *gc.C) {
@@ -83,15 +77,8 @@ func (s *TypeSuite) TestTypeValidateSupported(c *gc.C) {
 }
 
 func (s *TypeSuite) TestTypeValidateUnknown(c *gc.C) {
-	err := resource.TypeUnknown.Validate()
+	err := resource.Type{}.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `unsupported resource type .*`)
-}
-
-func (s *TypeSuite) TestTypeValidateUnsupported(c *gc.C) {
-	err := resource.Type("spam").Validate()
-
-	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `unsupported resource type .*`)
+	c.Check(err, gc.ErrorMatches, `zero value not valid`)
 }

--- a/resource/type_test.go
+++ b/resource/type_test.go
@@ -45,7 +45,7 @@ func (s *TypeSuite) TestParseTypeUnsupported(c *gc.C) {
 	rt, err := resource.ParseType("spam")
 
 	c.Check(err, gc.ErrorMatches, `unsupported resource type "spam"`)
-	c.Check(rt, gc.Equals, resource.Type("spam"))
+	c.Check(rt, gc.Equals, resource.TypeUnknown)
 }
 
 func (s *TypeSuite) TestTypeStringSupported(c *gc.C) {

--- a/resource/type_test.go
+++ b/resource/type_test.go
@@ -38,14 +38,16 @@ func (s *TypeSuite) TestParseTypeEmpty(c *gc.C) {
 	rt, err := resource.ParseType("")
 
 	c.Check(err, gc.ErrorMatches, `unsupported resource type ""`)
-	c.Check(rt, gc.Equals, resource.Type{})
+	var unknown resource.Type
+	c.Check(rt, gc.Equals, unknown)
 }
 
 func (s *TypeSuite) TestParseTypeUnsupported(c *gc.C) {
 	rt, err := resource.ParseType("spam")
 
 	c.Check(err, gc.ErrorMatches, `unsupported resource type "spam"`)
-	c.Check(rt, gc.Equals, resource.Type{})
+	var unknown resource.Type
+	c.Check(rt, gc.Equals, unknown)
 }
 
 func (s *TypeSuite) TestTypeStringSupported(c *gc.C) {
@@ -60,7 +62,8 @@ func (s *TypeSuite) TestTypeStringSupported(c *gc.C) {
 }
 
 func (s *TypeSuite) TestTypeStringUnknown(c *gc.C) {
-	str := resource.Type{}.String()
+	var unknown resource.Type
+	str := unknown.String()
 
 	c.Check(str, gc.Equals, "")
 }
@@ -77,7 +80,8 @@ func (s *TypeSuite) TestTypeValidateSupported(c *gc.C) {
 }
 
 func (s *TypeSuite) TestTypeValidateUnknown(c *gc.C) {
-	err := resource.Type{}.Validate()
+	var unknown resource.Type
+	err := unknown.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
 	c.Check(err, gc.ErrorMatches, `unknown resource type`)

--- a/resource/type_test.go
+++ b/resource/type_test.go
@@ -37,16 +37,14 @@ func (s *TypeSuite) TestParseTypeRecognized(c *gc.C) {
 func (s *TypeSuite) TestParseTypeEmpty(c *gc.C) {
 	rt, err := resource.ParseType("")
 
-	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `unsupported resource type .*`)
+	c.Check(err, gc.ErrorMatches, `unsupported resource type ""`)
 	c.Check(rt, gc.Equals, resource.TypeUnknown)
 }
 
 func (s *TypeSuite) TestParseTypeUnsupported(c *gc.C) {
 	rt, err := resource.ParseType("spam")
 
-	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `unsupported resource type .*`)
+	c.Check(err, gc.ErrorMatches, `unsupported resource type "spam"`)
 	c.Check(rt, gc.Equals, resource.Type("spam"))
 }
 
@@ -87,11 +85,13 @@ func (s *TypeSuite) TestTypeValidateSupported(c *gc.C) {
 func (s *TypeSuite) TestTypeValidateUnknown(c *gc.C) {
 	err := resource.TypeUnknown.Validate()
 
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
 	c.Check(err, gc.ErrorMatches, `unsupported resource type .*`)
 }
 
 func (s *TypeSuite) TestTypeValidateUnsupported(c *gc.C) {
 	err := resource.Type("spam").Validate()
 
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
 	c.Check(err, gc.ErrorMatches, `unsupported resource type .*`)
 }

--- a/resource/type_test.go
+++ b/resource/type_test.go
@@ -62,7 +62,7 @@ func (s *TypeSuite) TestTypeStringSupported(c *gc.C) {
 func (s *TypeSuite) TestTypeStringUnknown(c *gc.C) {
 	str := resource.TypeUnknown.String()
 
-	c.Check(str, gc.Equals, "<unknown>")
+	c.Check(str, gc.Equals, "")
 }
 
 func (s *TypeSuite) TestTypeStringUnsupported(c *gc.C) {

--- a/resources.go
+++ b/resources.go
@@ -30,7 +30,11 @@ func parseMetaResources(data interface{}) (map[string]resource.Meta, error) {
 
 	result := make(map[string]resource.Meta)
 	for name, val := range data.(map[string]interface{}) {
-		result[name] = resource.ParseMeta(name, val)
+		meta, err := resource.ParseMeta(name, val)
+		if err != nil {
+			return nil, err
+		}
+		result[name] = meta
 	}
 
 	return result, nil

--- a/resources.go
+++ b/resources.go
@@ -23,9 +23,9 @@ var resourceSchema = schema.FieldMap(
 	},
 )
 
-func parseMetaResources(data interface{}) map[string]resource.Meta {
+func parseMetaResources(data interface{}) (map[string]resource.Meta, error) {
 	if data == nil {
-		return nil
+		return nil, nil
 	}
 
 	result := make(map[string]resource.Meta)
@@ -33,7 +33,7 @@ func parseMetaResources(data interface{}) map[string]resource.Meta {
 		result[name] = resource.ParseMeta(name, val)
 	}
 
-	return result
+	return result, nil
 }
 
 func validateMetaResources(resources map[string]resource.Meta) error {


### PR DESCRIPTION
This patch makes a few adjustments needed for the resources feature:

* Make resource.Type an int enum.
* Add resource.Origin and Resource.Origin.
* Return an error from resource.ParseType().  Returning a bool (and then ignoring it) wasn't very helpful.

This patch also percolates the parsing error up the stack.  The pattern of ignoring errors during metadata parsing relies on parse results causing appropriate errors during validation.  This approach is fragile and easily resolved by supporting error returns from parsing.