### PR TITLE
Add endpoint binding parsing to charm bundles

### DIFF
--- a/bundledata.go
+++ b/bundledata.go
@@ -474,7 +474,7 @@ func (verifier *bundleDataVerifier) verifyEndpointBindings() {
 			if !(matchedProvides || matchedRequires || matchedPeers) {
 				verifier.addErrorf(
 					"service %s wants to bind to endpoint %s to space %s, "+
-						"which isn't provided or required by charm",
+						"which isn't defined by the charm",
 					name, endpoint, space)
 			}
 		}

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -355,7 +355,7 @@ func (*bundleDataSuite) TestVerifyBundleUsingJujuInfoRelationBindingFail(c *gc.C
 	err := bd.VerifyWithCharms(nil, nil, charms)
 
 	c.Assert(err, gc.ErrorMatches,
-		"service wordpress wants to bind to interface foo, "+
+		"service wordpress wants to bind to endpoint foo to space bar, "+
 			"which isn't provided or required by charm")
 }
 

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -356,7 +356,7 @@ func (*bundleDataSuite) TestVerifyBundleUsingJujuInfoRelationBindingFail(c *gc.C
 
 	c.Assert(err, gc.ErrorMatches,
 		"service wordpress wants to bind to endpoint foo to space bar, "+
-			"which isn't provided or required by charm")
+			"which isn't defined by the charm")
 }
 
 func (*bundleDataSuite) TestRequiredCharms(c *gc.C) {

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -37,6 +37,9 @@ services:
             "gui-y": -15
         storage:
             valid-store: 10G
+        bindings:
+            db: db
+            website: public
     mysql:
         charm: "cs:precise/mysql-28"
         num_units: 2
@@ -52,6 +55,8 @@ services:
             "gui-x": 610
             "gui-y": 255
         constraints: "mem=8g"
+        bindings:
+            db: db
 relations:
     - ["mediawiki:db", "mysql:db"]
     - ["mysql:foo", "mediawiki:bar"]
@@ -95,6 +100,10 @@ var parseTests = []struct {
 				Storage: map[string]string{
 					"valid-store": "10G",
 				},
+				EndpointBindings: map[string]string{
+					"db":      "db",
+					"website": "public",
+				},
 			},
 			"mysql": {
 				Charm:    "cs:precise/mysql-28",
@@ -113,6 +122,9 @@ var parseTests = []struct {
 					"gui-y": "255",
 				},
 				Constraints: "mem=8g",
+				EndpointBindings: map[string]string{
+					"db": "db",
+				},
 			},
 		},
 		Machines: map[string]*charm.MachineSpec{
@@ -328,6 +340,23 @@ func (*bundleDataSuite) TestVerifyBundleUsingJujuInfoRelation(c *gc.C) {
 	}
 	err := bd.VerifyWithCharms(nil, nil, charms)
 	c.Assert(err, gc.IsNil)
+}
+
+func (*bundleDataSuite) TestVerifyBundleUsingJujuInfoRelationBindingFail(c *gc.C) {
+	b := readBundleDir(c, "wordpress-with-logging")
+	bd := b.Data()
+
+	charms := map[string]charm.Charm{
+		"wordpress": readCharmDir(c, "wordpress"),
+		"mysql":     readCharmDir(c, "mysql"),
+		"logging":   readCharmDir(c, "logging"),
+	}
+	bd.Services["wordpress"].EndpointBindings["foo"] = "bar"
+	err := bd.VerifyWithCharms(nil, nil, charms)
+
+	c.Assert(err, gc.ErrorMatches,
+		"service wordpress wants to bind to interface foo, "+
+			"which isn't provided or required by charm")
 }
 
 func (*bundleDataSuite) TestRequiredCharms(c *gc.C) {

--- a/internal/test-charm-repo/bundle/wordpress-with-logging/bundle.yaml
+++ b/internal/test-charm-repo/bundle/wordpress-with-logging/bundle.yaml
@@ -3,13 +3,13 @@ services:
         charm: wordpress
         num_units: 1
         bindings:
-            mysql: db
-            http: public
+            db: db
+            url: public
     mysql:
         charm: mysql
         num_units: 1
         bindings:
-            mysql: db
+            server: db
     logging:
         charm: logging
 relations:

--- a/internal/test-charm-repo/bundle/wordpress-with-logging/bundle.yaml
+++ b/internal/test-charm-repo/bundle/wordpress-with-logging/bundle.yaml
@@ -2,9 +2,14 @@ services:
     wordpress:
         charm: wordpress
         num_units: 1
+        bindings:
+            mysql: db
+            http: public
     mysql:
         charm: mysql
         num_units: 1
+        bindings:
+            mysql: db
     logging:
         charm: logging
 relations:


### PR DESCRIPTION
This change adds the ability to bind an endpoint to a space inside a charm bundle, for example:
```yaml
services:
    wordpress:
        charm: wordpress
        num_units: 1
        bindings:
            db: db
            url: public
```
This will request that wordpress has its database endpoint (db) attached to the db space and the url endpoint attached to the public space.