### PR TITLE
Fix GenerateFingerprint() and add ParseFingerprint().

### DIFF
--- a/resource/fingerprint.go
+++ b/resource/fingerprint.go
@@ -18,13 +18,30 @@ type Fingerprint struct {
 	raw []byte
 }
 
-// NewFingerprint returns wraps the provided raw fingerprint.
+// NewFingerprint returns wraps the provided raw fingerprint bytes.
+// This function roundtrips with Fingerprint.Bytes().
 func NewFingerprint(raw []byte) (Fingerprint, error) {
 	fp := Fingerprint{
 		raw: append([]byte{}, raw...),
 	}
 	if err := fp.validate(); err != nil {
 		return Fingerprint{}, errors.Trace(err)
+	}
+	return fp, nil
+}
+
+// ParseFingerprint returns wraps the provided raw fingerprint string.
+// This function roundtrips with Fingerprint.String().
+func ParseFingerprint(raw string) (Fingerprint, error) {
+	var fp Fingerprint
+
+	rawBytes, err := hex.DecodeString(raw)
+	if err != nil {
+		return fp, errors.Trace(err)
+	}
+	fp, err = NewFingerprint(rawBytes)
+	if err != nil {
+		return fp, errors.Trace(err)
 	}
 	return fp, nil
 }

--- a/resource/fingerprint.go
+++ b/resource/fingerprint.go
@@ -6,6 +6,7 @@ package resource
 import (
 	"crypto/sha512"
 	"encoding/hex"
+	"io"
 
 	"github.com/juju/errors"
 )
@@ -29,11 +30,11 @@ func NewFingerprint(raw []byte) (Fingerprint, error) {
 }
 
 // GenerateFingerprint returns the fingerprint for the provided data.
-func GenerateFingerprint(data []byte) (Fingerprint, error) {
+func GenerateFingerprint(data io.Reader) (Fingerprint, error) {
 	var fp Fingerprint
 
 	hash := sha512.New384()
-	if _, err := hash.Write([]byte(data)); err != nil {
+	if _, err := io.Copy(hash, data); err != nil {
 		return fp, errors.Trace(err)
 	}
 	fp.raw = hash.Sum(nil)

--- a/resource/fingerprint_test.go
+++ b/resource/fingerprint_test.go
@@ -57,6 +57,22 @@ func (s *FingerprintSuite) TestNewFingerprintTooBig(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `.*too big.*`)
 }
 
+func (s *FingerprintSuite) TestParseFingerprintOkay(c *gc.C) {
+	_, expected := newFingerprint(c, "spamspamspam")
+
+	fp, err := resource.ParseFingerprint(expected)
+	c.Assert(err, jc.ErrorIsNil)
+	hex := fp.String()
+
+	c.Check(hex, jc.DeepEquals, expected)
+}
+
+func (s *FingerprintSuite) TestParseFingerprintNonHex(c *gc.C) {
+	_, err := resource.ParseFingerprint("XYZ") // not hex
+
+	c.Check(err, gc.ErrorMatches, `.*odd length hex string.*`)
+}
+
 func (s *FingerprintSuite) TestGenerateFingerprint(c *gc.C) {
 	expected, _ := newFingerprint(c, "spamspamspam")
 	data := bytes.NewBufferString("spamspamspam")
@@ -78,11 +94,31 @@ func (s *FingerprintSuite) TestString(c *gc.C) {
 	c.Check(hex, gc.Equals, expected)
 }
 
+func (s *FingerprintSuite) TestRoundtripString(c *gc.C) {
+	_, expected := newFingerprint(c, "spamspamspam")
+
+	fp, err := resource.ParseFingerprint(expected)
+	c.Assert(err, jc.ErrorIsNil)
+	hex := fp.String()
+
+	c.Check(hex, gc.Equals, expected)
+}
+
 func (s *FingerprintSuite) TestBytes(c *gc.C) {
 	expected, _ := newFingerprint(c, "spamspamspam")
 	fp, err := resource.NewFingerprint(expected)
 	c.Assert(err, jc.ErrorIsNil)
 
+	raw := fp.Bytes()
+
+	c.Check(raw, jc.DeepEquals, expected)
+}
+
+func (s *FingerprintSuite) TestRoundtripBytes(c *gc.C) {
+	expected, _ := newFingerprint(c, "spamspamspam")
+
+	fp, err := resource.NewFingerprint(expected)
+	c.Assert(err, jc.ErrorIsNil)
 	raw := fp.Bytes()
 
 	c.Check(raw, jc.DeepEquals, expected)

--- a/resource/fingerprint_test.go
+++ b/resource/fingerprint_test.go
@@ -4,6 +4,7 @@
 package resource_test
 
 import (
+	"bytes"
 	"crypto/sha512"
 	"encoding/hex"
 
@@ -58,8 +59,9 @@ func (s *FingerprintSuite) TestNewFingerprintTooBig(c *gc.C) {
 
 func (s *FingerprintSuite) TestGenerateFingerprint(c *gc.C) {
 	expected, _ := newFingerprint(c, "spamspamspam")
+	data := bytes.NewBufferString("spamspamspam")
 
-	fp, err := resource.GenerateFingerprint([]byte("spamspamspam"))
+	fp, err := resource.GenerateFingerprint(data)
 	c.Assert(err, jc.ErrorIsNil)
 	raw := fp.Bytes()
 

--- a/resource/fingerprint_test.go
+++ b/resource/fingerprint_test.go
@@ -4,9 +4,9 @@
 package resource_test
 
 import (
-	"bytes"
 	"crypto/sha512"
 	"encoding/hex"
+	"strings"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -75,7 +75,7 @@ func (s *FingerprintSuite) TestParseFingerprintNonHex(c *gc.C) {
 
 func (s *FingerprintSuite) TestGenerateFingerprint(c *gc.C) {
 	expected, _ := newFingerprint(c, "spamspamspam")
-	data := bytes.NewBufferString("spamspamspam")
+	data := strings.NewReader("spamspamspam")
 
 	fp, err := resource.GenerateFingerprint(data)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
This patch changes GenerateFingerprint to take a reader rather than bytes.  This aligns better with how it will be used.

ParseFingerprint() is added to provide a roundtrip for Fingerprint.String().  This is useful when Fingerprint.String() is used to serialize.  Then ParseFingerprint() can be used to deserialize.