### PR TITLE
Added support for ExtraBindings in Meta

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -4,7 +4,7 @@ github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	201
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
 github.com/juju/loggo	git	8477fc936adf0e382d680310047ca27e128a309a	2015-05-27T03:58:39Z
 github.com/juju/names	git	a6a253b0a94cc79e99a68d284b970ffce2a11ecd	2015-07-09T13:59:32Z
-github.com/juju/schema	git	afe1151cb49d1d7ed3c75592dfc6f38703f2e988	2015-08-07T07:58:08Z
+github.com/juju/schema	git	1e25943f8c6fd6815282d6f1ac87091d21e14e19	2016-03-01T11:16:46Z
 github.com/juju/testing	git	ee18040b46bb1f8c93438383bd51ec77eb8c02ab	2016-01-12T21:04:04Z
 github.com/juju/utils	git	ef8480bcaabae506777530725c81d83a4de2fb06	2016-01-12T23:14:21Z
 golang.org/x/crypto	git	aedad9a179ec1ea11b7064c57cbc6dc30d7724ec	2015-08-30T18:06:42Z

--- a/export_test.go
+++ b/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2011, 2012, 2013 Canonical Ltd.
+// Copyright 2011-2016 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENCE file for details.
 
 package charm
@@ -9,8 +9,10 @@ var (
 	IfaceExpander = ifaceExpander
 	ValidateValue = validateValue
 
-	ParsePayloadClass = parsePayloadClass
-	ResourceSchema    = resourceSchema
+	ParsePayloadClass         = parsePayloadClass
+	ResourceSchema            = resourceSchema
+	ExtraBindingsSchema       = extraBindingsSchema
+	ValidateMetaExtraBindings = validateMetaExtraBindings
 )
 
 func MissingSeriesError() error {

--- a/extra_bindings.go
+++ b/extra_bindings.go
@@ -1,0 +1,117 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package charm
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/juju/schema"
+)
+
+// ExtraBinding represents a bindable endpoint which is not also a relation.
+type ExtraBinding struct {
+	Name string `bson:"name" json:"Name"`
+}
+
+// When specified, the "extra-bindings" section in the metadata.yaml
+// should have the following format:
+//
+// extra-bindings:
+//     "<endpoint-name>":
+//     ...
+// Endpoint names are strings and may match an existing relation name from
+// the Provides, Requires, or Peers metadata sections. The values beside
+// each endpoint name must be left out (i.e. "foo": <anything> is invalid).
+var extraBindingsSchema = schema.Map(nonEmptyStringC{"binding name"}, noValueC{})
+
+// noValueC is a schema.Checker that only succeeds if the input an empty
+// value (nil), but unlike the equivalent schema.Const(nil), noValueC provides a
+// slightly better error message.
+type noValueC struct{}
+
+func (c noValueC) Coerce(v interface{}, path []string) (interface{}, error) {
+	if reflect.DeepEqual(v, nil) {
+		return v, nil
+	}
+	pathPrefix := schemaPathAsPrefix(path)
+	return nil, fmt.Errorf("%sexpected no value, got %T(%#v)", pathPrefix, v, v)
+}
+
+// TODO(dimitern): Move noValueC and nonEmptyStringC into the schema package and
+// remove this helper, copied from schema.pathAsPrefix.
+func schemaPathAsPrefix(path []string) string {
+	if len(path) == 0 {
+		return ""
+	}
+	var s string
+	if path[0] == "." {
+		s = strings.Join(path[1:], "")
+	} else {
+		s = strings.Join(path, "")
+	}
+	if s == "" {
+		return ""
+	}
+	return s + ": "
+}
+
+// nonEmptyStringC is a schema.Checker that only succeeds if the input is a
+// non-empty string. To tweak the error message, valueLable can contain a
+// singular label of the value being checked, or "string" will be used when
+// valueLabel is "".
+type nonEmptyStringC struct {
+	valueLabel string
+}
+
+func (c nonEmptyStringC) Coerce(v interface{}, path []string) (interface{}, error) {
+	stringValue, err := schema.String().Coerce(v, path)
+	if err != nil {
+		return nil, err
+	}
+	if stringValue.(string) == "" {
+		pathPrefix := schemaPathAsPrefix(path)
+		label := c.valueLabel
+		if label == "" {
+			label = "string"
+		}
+		return nil, fmt.Errorf("%sexpected non-empty %s, got \"\"", pathPrefix, label)
+
+	}
+	return stringValue, nil
+}
+
+func parseMetaExtraBindings(data interface{}) (map[string]ExtraBinding, error) {
+	if data == nil {
+		return nil, nil
+	}
+
+	bindingsMap := data.(map[interface{}]interface{})
+	result := make(map[string]ExtraBinding)
+	for name, _ := range bindingsMap {
+		stringName := name.(string)
+		result[stringName] = ExtraBinding{Name: stringName}
+	}
+
+	return result, nil
+}
+
+func validateMetaExtraBindings(extraBindings map[string]ExtraBinding) error {
+	if extraBindings == nil {
+		return nil
+	} else if len(extraBindings) == 0 {
+		return fmt.Errorf("extra bindings cannot be empty when specified")
+	}
+
+	for name, binding := range extraBindings {
+		if binding.Name == "" || name == "" {
+			return fmt.Errorf("missing extra binding name")
+		}
+		if binding.Name != name {
+			return fmt.Errorf("mismatched extra binding name: got %q, expected %q", binding.Name, name)
+		}
+	}
+	return nil
+}

--- a/extra_bindings.go
+++ b/extra_bindings.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/juju/schema"
+	"github.com/juju/utils/set"
 )
 
 // ExtraBinding represents a bindable endpoint which is not also a relation.
@@ -20,8 +21,8 @@ type ExtraBinding struct {
 // extra-bindings:
 //     "<endpoint-name>":
 //     ...
-// Endpoint names are strings and may match an existing relation name from
-// the Provides, Requires, or Peers metadata sections. The values beside
+// Endpoint names are strings and must not match an existing relation names
+// from the Provides, Requires, or Peers metadata sections. The values beside
 // each endpoint name must be left out (i.e. "foo": <anything> is invalid).
 var extraBindingsSchema = schema.Map(schema.NonEmptyString("binding name"), schema.Nil(""))
 
@@ -40,19 +41,28 @@ func parseMetaExtraBindings(data interface{}) (map[string]ExtraBinding, error) {
 	return result, nil
 }
 
-func validateMetaExtraBindings(extraBindings map[string]ExtraBinding) error {
+func validateMetaExtraBindings(meta Meta) error {
+	extraBindings := meta.ExtraBindings
 	if extraBindings == nil {
 		return nil
 	} else if len(extraBindings) == 0 {
 		return fmt.Errorf("extra bindings cannot be empty when specified")
 	}
 
+	usedNames := set.NewStrings()
 	for name, binding := range extraBindings {
 		if binding.Name == "" || name == "" {
 			return fmt.Errorf("missing extra binding name")
 		}
 		if binding.Name != name {
 			return fmt.Errorf("mismatched extra binding name: got %q, expected %q", binding.Name, name)
+		}
+		usedNames.Add(name)
+	}
+
+	for relationName, _ := range meta.CombinedRelations() {
+		if usedNames.Contains(relationName) {
+			return fmt.Errorf("relation %q cannot be used in extra bindings", relationName)
 		}
 	}
 	return nil

--- a/extra_bindings.go
+++ b/extra_bindings.go
@@ -5,8 +5,6 @@ package charm
 
 import (
 	"fmt"
-	"reflect"
-	"strings"
 
 	"github.com/juju/schema"
 )
@@ -25,63 +23,7 @@ type ExtraBinding struct {
 // Endpoint names are strings and may match an existing relation name from
 // the Provides, Requires, or Peers metadata sections. The values beside
 // each endpoint name must be left out (i.e. "foo": <anything> is invalid).
-var extraBindingsSchema = schema.Map(nonEmptyStringC{"binding name"}, noValueC{})
-
-// noValueC is a schema.Checker that only succeeds if the input an empty
-// value (nil), but unlike the equivalent schema.Const(nil), noValueC provides a
-// slightly better error message.
-type noValueC struct{}
-
-func (c noValueC) Coerce(v interface{}, path []string) (interface{}, error) {
-	if reflect.DeepEqual(v, nil) {
-		return v, nil
-	}
-	pathPrefix := schemaPathAsPrefix(path)
-	return nil, fmt.Errorf("%sexpected no value, got %T(%#v)", pathPrefix, v, v)
-}
-
-// TODO(dimitern): Move noValueC and nonEmptyStringC into the schema package and
-// remove this helper, copied from schema.pathAsPrefix.
-func schemaPathAsPrefix(path []string) string {
-	if len(path) == 0 {
-		return ""
-	}
-	var s string
-	if path[0] == "." {
-		s = strings.Join(path[1:], "")
-	} else {
-		s = strings.Join(path, "")
-	}
-	if s == "" {
-		return ""
-	}
-	return s + ": "
-}
-
-// nonEmptyStringC is a schema.Checker that only succeeds if the input is a
-// non-empty string. To tweak the error message, valueLable can contain a
-// singular label of the value being checked, or "string" will be used when
-// valueLabel is "".
-type nonEmptyStringC struct {
-	valueLabel string
-}
-
-func (c nonEmptyStringC) Coerce(v interface{}, path []string) (interface{}, error) {
-	stringValue, err := schema.String().Coerce(v, path)
-	if err != nil {
-		return nil, err
-	}
-	if stringValue.(string) == "" {
-		pathPrefix := schemaPathAsPrefix(path)
-		label := c.valueLabel
-		if label == "" {
-			label = "string"
-		}
-		return nil, fmt.Errorf("%sexpected non-empty %s, got \"\"", pathPrefix, label)
-
-	}
-	return stringValue, nil
-}
+var extraBindingsSchema = schema.Map(schema.NonEmptyString("binding name"), schema.Nil(""))
 
 func parseMetaExtraBindings(data interface{}) (map[string]ExtraBinding, error) {
 	if data == nil {

--- a/extra_bindings_test.go
+++ b/extra_bindings_test.go
@@ -4,8 +4,6 @@
 package charm_test
 
 import (
-	"fmt"
-
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -38,22 +36,6 @@ func (s *extraBindingsSuite) TestSchemaOkay(c *gc.C) {
 	})
 }
 
-func (s *extraBindingsSuite) TestSchemaValuesMustBeEmpty(c *gc.C) {
-	badValues := []interface{}{
-		42, true, 3.14, "bad", []string{"a"}, map[string]string{"x": "y"},
-	}
-	for _, testValue := range badValues {
-		raw := map[interface{}]interface{}{
-			"some-endpoint": testValue,
-		}
-		v, err := charm.ExtraBindingsSchema.Coerce(raw, nil)
-		expectedError := fmt.Sprintf("some-endpoint: expected empty value, got %T(%#v)", testValue, testValue)
-		c.Check(err, gc.NotNil)
-		c.Check(err.Error(), gc.Equals, expectedError)
-		c.Check(v, gc.IsNil)
-	}
-}
-
 func (s *extraBindingsSuite) TestValidateWithEmptyNonNilMap(c *gc.C) {
 	s.riakMeta.ExtraBindings = map[string]charm.ExtraBinding{}
 	err := charm.ValidateMetaExtraBindings(s.riakMeta)
@@ -65,7 +47,7 @@ func (s *extraBindingsSuite) TestValidateWithEmptyName(c *gc.C) {
 		"": charm.ExtraBinding{Name: ""},
 	}
 	err := charm.ValidateMetaExtraBindings(s.riakMeta)
-	c.Assert(err, gc.ErrorMatches, "missing extra binding name")
+	c.Assert(err, gc.ErrorMatches, "missing binding name")
 }
 
 func (s *extraBindingsSuite) TestValidateWithMismatchedName(c *gc.C) {
@@ -79,7 +61,9 @@ func (s *extraBindingsSuite) TestValidateWithMismatchedName(c *gc.C) {
 func (s *extraBindingsSuite) TestValidateWithRelationNamesMatchingExtraBindings(c *gc.C) {
 	s.riakMeta.ExtraBindings = map[string]charm.ExtraBinding{
 		"admin": charm.ExtraBinding{Name: "admin"},
+		"ring":  charm.ExtraBinding{Name: "ring"},
+		"foo":   charm.ExtraBinding{Name: "foo"},
 	}
 	err := charm.ValidateMetaExtraBindings(s.riakMeta)
-	c.Assert(err, gc.ErrorMatches, `relation "admin" cannot be used in extra bindings`)
+	c.Assert(err, gc.ErrorMatches, `relation names \(admin, ring\) cannot be used in extra bindings`)
 }

--- a/extra_bindings_test.go
+++ b/extra_bindings_test.go
@@ -1,0 +1,68 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package charm_test
+
+import (
+	"fmt"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"gopkg.in/juju/charm.v6-unstable"
+)
+
+var _ = gc.Suite(&extraBindingsSuite{})
+
+type extraBindingsSuite struct{}
+
+func (s *extraBindingsSuite) TestSchemaOkay(c *gc.C) {
+	raw := map[interface{}]interface{}{
+		"foo": nil,
+		"bar": nil,
+	}
+	v, err := charm.ExtraBindingsSchema.Coerce(raw, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(v, jc.DeepEquals, map[interface{}]interface{}{
+		"foo": nil,
+		"bar": nil,
+	})
+}
+
+func (s *extraBindingsSuite) TestSchemaValuesMustBeEmpty(c *gc.C) {
+	badValues := []interface{}{
+		42, true, 3.14, "bad", []string{"a"}, map[string]string{"x": "y"},
+	}
+	for _, testValue := range badValues {
+		raw := map[interface{}]interface{}{
+			"some-endpoint": testValue,
+		}
+		v, err := charm.ExtraBindingsSchema.Coerce(raw, nil)
+		expectedError := fmt.Sprintf("some-endpoint: expected no value, got %T(%#v)", testValue, testValue)
+		c.Check(err, gc.NotNil)
+		c.Check(err.Error(), gc.Equals, expectedError)
+		c.Check(v, gc.IsNil)
+	}
+}
+
+func (s *extraBindingsSuite) TestValidateWithEmptyNonNilMap(c *gc.C) {
+	err := charm.ValidateMetaExtraBindings(map[string]charm.ExtraBinding{})
+	c.Assert(err, gc.ErrorMatches, "extra bindings cannot be empty when specified")
+}
+
+func (s *extraBindingsSuite) TestValidateWithEmptyName(c *gc.C) {
+	invalidBindings := map[string]charm.ExtraBinding{
+		"": charm.ExtraBinding{Name: ""},
+	}
+	err := charm.ValidateMetaExtraBindings(invalidBindings)
+	c.Assert(err, gc.ErrorMatches, "missing extra binding name")
+}
+
+func (s *extraBindingsSuite) TestValidateWithMismatchedName(c *gc.C) {
+	invalidBindings := map[string]charm.ExtraBinding{
+		"bar": charm.ExtraBinding{Name: "foo"},
+	}
+	err := charm.ValidateMetaExtraBindings(invalidBindings)
+	c.Assert(err, gc.ErrorMatches, `mismatched extra binding name: got "foo", expected "bar"`)
+}

--- a/extra_bindings_test.go
+++ b/extra_bindings_test.go
@@ -39,7 +39,7 @@ func (s *extraBindingsSuite) TestSchemaValuesMustBeEmpty(c *gc.C) {
 			"some-endpoint": testValue,
 		}
 		v, err := charm.ExtraBindingsSchema.Coerce(raw, nil)
-		expectedError := fmt.Sprintf("some-endpoint: expected no value, got %T(%#v)", testValue, testValue)
+		expectedError := fmt.Sprintf("some-endpoint: expected empty value, got %T(%#v)", testValue, testValue)
 		c.Check(err, gc.NotNil)
 		c.Check(err.Error(), gc.Equals, expectedError)
 		c.Check(v, gc.IsNil)

--- a/meta.go
+++ b/meta.go
@@ -196,7 +196,7 @@ type Meta struct {
 	Storage        map[string]Storage       `bson:"storage,omitempty" json:"Storage,omitempty"`
 	PayloadClasses map[string]PayloadClass  `bson:"payloadclasses,omitempty" json:"PayloadClasses,omitempty"`
 	Resources      map[string]resource.Meta `bson:"resources,omitempty" json:"Resources,omitempty"`
-	Terms          []string                 `bson:"terms,omitempty" json:"Terms,omitempty`
+	Terms          []string                 `bson:"terms,omitempty" json:"Terms,omitempty"`
 }
 
 func generateRelationHooks(relName string, allHooks map[string]bool) {

--- a/meta.go
+++ b/meta.go
@@ -543,6 +543,22 @@ func parseRelations(relations interface{}, role RelationRole) map[string]Relatio
 	return result
 }
 
+// CombinedRelations returns all defined relations, regardless of their type in
+// a single map.
+func (m Meta) CombinedRelations() map[string]Relation {
+	combined := make(map[string]Relation)
+	for name, relation := range m.Provides {
+		combined[name] = relation
+	}
+	for name, relation := range m.Requires {
+		combined[name] = relation
+	}
+	for name, relation := range m.Peers {
+		combined[name] = relation
+	}
+	return combined
+}
+
 // Schema coercer that expands the interface shorthand notation.
 // A consistent format is easier to work with than considering the
 // potential difference everywhere.

--- a/meta.go
+++ b/meta.go
@@ -443,7 +443,7 @@ func (meta Meta) Check() error {
 		return err
 	}
 
-	if err := validateMetaExtraBindings(meta.ExtraBindings); err != nil {
+	if err := validateMetaExtraBindings(meta); err != nil {
 		return fmt.Errorf("charm %q has invalid extra bindings: %v", meta.Name, err)
 	}
 

--- a/meta.go
+++ b/meta.go
@@ -287,6 +287,7 @@ func ReadMeta(r io.Reader) (meta *Meta, err error) {
 
 func parseMeta(m map[string]interface{}) (*Meta, error) {
 	var meta Meta
+	var err error
 
 	meta.Name = m["name"].(string)
 	// Schema decodes as int64, but the int range should be good
@@ -296,11 +297,10 @@ func parseMeta(m map[string]interface{}) (*Meta, error) {
 	meta.Provides = parseRelations(m["provides"], RoleProvider)
 	meta.Requires = parseRelations(m["requires"], RoleRequirer)
 	meta.Peers = parseRelations(m["peers"], RolePeer)
-	extraBindings, err := parseMetaExtraBindings(m["extra-bindings"])
+	meta.ExtraBindings, err = parseMetaExtraBindings(m["extra-bindings"])
 	if err != nil {
 		return nil, err
 	}
-	meta.ExtraBindings = extraBindings
 	meta.Format = int(m["format"].(int64))
 	meta.Categories = parseStringList(m["categories"])
 	meta.Tags = parseStringList(m["tags"])

--- a/meta.go
+++ b/meta.go
@@ -188,6 +188,7 @@ type Meta struct {
 	Provides       map[string]Relation      `bson:"provides,omitempty" json:"Provides,omitempty"`
 	Requires       map[string]Relation      `bson:"requires,omitempty" json:"Requires,omitempty"`
 	Peers          map[string]Relation      `bson:"peers,omitempty" json:"Peers,omitempty"`
+	ExtraBindings  map[string]ExtraBinding  `bson:"extra-bindings,omitempty" json:"ExtraBindings,omitempty"`
 	Format         int                      `bson:"format,omitempty" json:"Format,omitempty"`
 	OldRevision    int                      `bson:"oldrevision,omitempty" json:"OldRevision"` // Obsolete
 	Categories     []string                 `bson:"categories,omitempty" json:"Categories,omitempty"`
@@ -295,6 +296,11 @@ func parseMeta(m map[string]interface{}) (*Meta, error) {
 	meta.Provides = parseRelations(m["provides"], RoleProvider)
 	meta.Requires = parseRelations(m["requires"], RoleRequirer)
 	meta.Peers = parseRelations(m["peers"], RolePeer)
+	extraBindings, err := parseMetaExtraBindings(m["extra-bindings"])
+	if err != nil {
+		return nil, err
+	}
+	meta.ExtraBindings = extraBindings
 	meta.Format = int(m["format"].(int64))
 	meta.Categories = parseStringList(m["categories"])
 	meta.Tags = parseStringList(m["tags"])
@@ -320,38 +326,41 @@ func parseMeta(m map[string]interface{}) (*Meta, error) {
 
 // GetYAML implements yaml.Getter.GetYAML.
 func (m Meta) GetYAML() (tag string, value interface{}) {
-	marshaledRelations := func(rs map[string]Relation) map[string]marshaledRelation {
-		mrs := make(map[string]marshaledRelation)
-		for name, r := range rs {
-			mrs[name] = marshaledRelation(r)
-		}
-		return mrs
-	}
 	return "", struct {
-		Name        string                       `yaml:"name"`
-		Summary     string                       `yaml:"summary"`
-		Description string                       `yaml:"description"`
-		Provides    map[string]marshaledRelation `yaml:"provides,omitempty"`
-		Requires    map[string]marshaledRelation `yaml:"requires,omitempty"`
-		Peers       map[string]marshaledRelation `yaml:"peers,omitempty"`
-		Categories  []string                     `yaml:"categories,omitempty"`
-		Tags        []string                     `yaml:"tags,omitempty"`
-		Subordinate bool                         `yaml:"subordinate,omitempty"`
-		Series      []string                     `yaml:"series,omitempty"`
-		Terms       []string                     `yaml:"terms,omitempty"`
+		Name          string                       `yaml:"name"`
+		Summary       string                       `yaml:"summary"`
+		Description   string                       `yaml:"description"`
+		Provides      map[string]marshaledRelation `yaml:"provides,omitempty"`
+		Requires      map[string]marshaledRelation `yaml:"requires,omitempty"`
+		Peers         map[string]marshaledRelation `yaml:"peers,omitempty"`
+		ExtraBindings map[string]interface{}       `yaml:"extra-bindings,omitempty"`
+		Categories    []string                     `yaml:"categories,omitempty"`
+		Tags          []string                     `yaml:"tags,omitempty"`
+		Subordinate   bool                         `yaml:"subordinate,omitempty"`
+		Series        []string                     `yaml:"series,omitempty"`
+		Terms         []string                     `yaml:"terms,omitempty"`
 	}{
-		Name:        m.Name,
-		Summary:     m.Summary,
-		Description: m.Description,
-		Provides:    marshaledRelations(m.Provides),
-		Requires:    marshaledRelations(m.Requires),
-		Peers:       marshaledRelations(m.Peers),
-		Categories:  m.Categories,
-		Tags:        m.Tags,
-		Subordinate: m.Subordinate,
-		Series:      m.Series,
-		Terms:       m.Terms,
+		Name:          m.Name,
+		Summary:       m.Summary,
+		Description:   m.Description,
+		Provides:      marshaledRelations(m.Provides),
+		Requires:      marshaledRelations(m.Requires),
+		Peers:         marshaledRelations(m.Peers),
+		ExtraBindings: marshaledExtraBindings(m.ExtraBindings),
+		Categories:    m.Categories,
+		Tags:          m.Tags,
+		Subordinate:   m.Subordinate,
+		Series:        m.Series,
+		Terms:         m.Terms,
 	}
+}
+
+func marshaledRelations(relations map[string]Relation) map[string]marshaledRelation {
+	marshaled := make(map[string]marshaledRelation)
+	for name, relation := range relations {
+		marshaled[name] = marshaledRelation(relation)
+	}
+	return marshaled
 }
 
 type marshaledRelation Relation
@@ -383,6 +392,14 @@ func (r marshaledRelation) GetYAML() (tag string, value interface{}) {
 		mr.Scope = r.Scope
 	}
 	return "", mr
+}
+
+func marshaledExtraBindings(bindings map[string]ExtraBinding) map[string]interface{} {
+	marshaled := make(map[string]interface{})
+	for _, binding := range bindings {
+		marshaled[binding.Name] = nil
+	}
+	return marshaled
 }
 
 // Check checks that the metadata is well-formed.
@@ -424,6 +441,10 @@ func (meta Meta) Check() error {
 	}
 	if err := checkRelations(meta.Peers, RolePeer); err != nil {
 		return err
+	}
+
+	if err := validateMetaExtraBindings(meta.ExtraBindings); err != nil {
+		return fmt.Errorf("charm %q has invalid extra bindings: %v", meta.Name, err)
 	}
 
 	// Subordinate charms must have at least one relation that
@@ -713,36 +734,38 @@ func (c propertiesC) Coerce(v interface{}, path []string) (newv interface{}, err
 
 var charmSchema = schema.FieldMap(
 	schema.Fields{
-		"name":        schema.String(),
-		"summary":     schema.String(),
-		"description": schema.String(),
-		"peers":       schema.StringMap(ifaceExpander(int64(1))),
-		"provides":    schema.StringMap(ifaceExpander(nil)),
-		"requires":    schema.StringMap(ifaceExpander(int64(1))),
-		"revision":    schema.Int(), // Obsolete
-		"format":      schema.Int(),
-		"subordinate": schema.Bool(),
-		"categories":  schema.List(schema.String()),
-		"tags":        schema.List(schema.String()),
-		"series":      schema.List(schema.String()),
-		"storage":     schema.StringMap(storageSchema),
-		"payloads":    schema.StringMap(payloadClassSchema),
-		"resources":   schema.StringMap(resourceSchema),
-		"terms":       schema.List(schema.String()),
+		"name":           schema.String(),
+		"summary":        schema.String(),
+		"description":    schema.String(),
+		"peers":          schema.StringMap(ifaceExpander(int64(1))),
+		"provides":       schema.StringMap(ifaceExpander(nil)),
+		"requires":       schema.StringMap(ifaceExpander(int64(1))),
+		"extra-bindings": extraBindingsSchema,
+		"revision":       schema.Int(), // Obsolete
+		"format":         schema.Int(),
+		"subordinate":    schema.Bool(),
+		"categories":     schema.List(schema.String()),
+		"tags":           schema.List(schema.String()),
+		"series":         schema.List(schema.String()),
+		"storage":        schema.StringMap(storageSchema),
+		"payloads":       schema.StringMap(payloadClassSchema),
+		"resources":      schema.StringMap(resourceSchema),
+		"terms":          schema.List(schema.String()),
 	},
 	schema.Defaults{
-		"provides":    schema.Omit,
-		"requires":    schema.Omit,
-		"peers":       schema.Omit,
-		"revision":    schema.Omit,
-		"format":      1,
-		"subordinate": schema.Omit,
-		"categories":  schema.Omit,
-		"tags":        schema.Omit,
-		"series":      schema.Omit,
-		"storage":     schema.Omit,
-		"payloads":    schema.Omit,
-		"resources":   schema.Omit,
-		"terms":       schema.Omit,
+		"provides":       schema.Omit,
+		"requires":       schema.Omit,
+		"peers":          schema.Omit,
+		"extra-bindings": schema.Omit,
+		"revision":       schema.Omit,
+		"format":         1,
+		"subordinate":    schema.Omit,
+		"categories":     schema.Omit,
+		"tags":           schema.Omit,
+		"series":         schema.Omit,
+		"storage":        schema.Omit,
+		"payloads":       schema.Omit,
+		"resources":      schema.Omit,
+		"terms":          schema.Omit,
 	},
 )

--- a/meta_test.go
+++ b/meta_test.go
@@ -411,7 +411,7 @@ func (s *MetaSuite) TestCheckEmptyNameKeyOrEmptyExtraBindingName(c *gc.C) {
 		ExtraBindings: map[string]charm.ExtraBinding{"": {Name: "bar"}},
 	}
 	err := meta.Check()
-	expectedError := `charm "foo" has invalid extra bindings: missing extra binding name`
+	expectedError := `charm "foo" has invalid extra bindings: missing binding name`
 	c.Assert(err, gc.ErrorMatches, expectedError)
 
 	meta.ExtraBindings = map[string]charm.ExtraBinding{"bar": {Name: ""}}

--- a/meta_test.go
+++ b/meta_test.go
@@ -663,9 +663,8 @@ peers:
         interface: peery
         optional: true
 extra-bindings:
-    provideSimple:
+    extraBar:
     extraFoo1:
-    peerSimple:
 categories: [c1, c1]
 tags: [t1, t2]
 series:

--- a/meta_test.go
+++ b/meta_test.go
@@ -220,6 +220,35 @@ func (s *MetaSuite) TestParseMetaRelations(c *gc.C) {
 	c.Assert(meta.Peers, gc.IsNil)
 }
 
+func (s *MetaSuite) TestCombinedRelations(c *gc.C) {
+	meta, err := charm.ReadMeta(repoMeta(c, "riak"))
+	c.Assert(err, gc.IsNil)
+	combinedRelations := meta.CombinedRelations()
+	expectedLength := len(meta.Provides) + len(meta.Requires) + len(meta.Peers)
+	c.Assert(combinedRelations, gc.HasLen, expectedLength)
+	c.Assert(combinedRelations, jc.DeepEquals, map[string]charm.Relation{
+		"endpoint": {
+			Name:      "endpoint",
+			Role:      charm.RoleProvider,
+			Interface: "http",
+			Scope:     charm.ScopeGlobal,
+		},
+		"admin": {
+			Name:      "admin",
+			Role:      charm.RoleProvider,
+			Interface: "http",
+			Scope:     charm.ScopeGlobal,
+		},
+		"ring": {
+			Name:      "ring",
+			Role:      charm.RolePeer,
+			Interface: "riak",
+			Limit:     1,
+			Scope:     charm.ScopeGlobal,
+		},
+	})
+}
+
 var relationsConstraintsTests = []struct {
 	rels string
 	err  string

--- a/meta_test.go
+++ b/meta_test.go
@@ -908,7 +908,7 @@ description: c
 extra-bindings:
     foo: 42
 `))
-	c.Assert(err, gc.ErrorMatches, `metadata: extra-bindings.foo: expected no value, got int\(42\)`)
+	c.Assert(err, gc.ErrorMatches, `metadata: extra-bindings.foo: expected empty value, got int\(42\)`)
 	c.Assert(meta, gc.IsNil)
 }
 
@@ -920,7 +920,7 @@ description: c
 extra-bindings:
     "":
 `))
-	c.Assert(err, gc.ErrorMatches, `metadata: extra-bindings: expected non-empty binding name, got ""`)
+	c.Assert(err, gc.ErrorMatches, `metadata: extra-bindings: expected non-empty binding name, got string\(""\)`)
 	c.Assert(meta, gc.IsNil)
 }
 


### PR DESCRIPTION
Added an optional `extra-bindings` metadata section, with the following format:
```yaml
...
extra-bindings:
   name1:
   other-name2:
   ...
```
None of the names in the extra-bindings map can match existing provided/required/peer relation
names, as relations are already bindable. Extra bindings provide a way to declare named endpoints,
which the charm needs (bound) addresses for, but which are not relations otherwise.

Extra bindings will be accepted in $ juju deploy --bind ... when declared, in a follow-up.

Also added a Meta.CombinedRelations() helper, fixing http://pad.lv/1520623 bug as a result.