### PR TITLE
Added support for extra-bindings within BundleData

### DIFF
--- a/bundledata.go
+++ b/bundledata.go
@@ -467,11 +467,12 @@ func (verifier *bundleDataVerifier) verifyEndpointBindings() {
 			continue
 		}
 		for endpoint, space := range svc.EndpointBindings {
-			_, matchedProvides := charm.Meta().Provides[endpoint]
-			_, matchedRequires := charm.Meta().Requires[endpoint]
-			_, matchedPeers := charm.Meta().Peers[endpoint]
+			_, isInProvides := charm.Meta().Provides[endpoint]
+			_, isInRequires := charm.Meta().Requires[endpoint]
+			_, isInPeers := charm.Meta().Peers[endpoint]
+			_, isInExtraBindings := charm.Meta().ExtraBindings[endpoint]
 
-			if !(matchedProvides || matchedRequires || matchedPeers) {
+			if !(isInProvides || isInRequires || isInPeers || isInExtraBindings) {
 				verifier.addErrorf(
 					"service %q wants to bind endpoint %q to space %q, "+
 						"but the endpoint is not defined by the charm",

--- a/internal/test-charm-repo/bundle/wordpress-with-logging/bundle.yaml
+++ b/internal/test-charm-repo/bundle/wordpress-with-logging/bundle.yaml
@@ -5,6 +5,8 @@ services:
         bindings:
             db: db
             url: public
+            db-client: db
+            admin-api: public
     mysql:
         charm: mysql
         num_units: 1

--- a/internal/test-charm-repo/quantal/wordpress/metadata.yaml
+++ b/internal/test-charm-repo/quantal/wordpress/metadata.yaml
@@ -21,3 +21,7 @@ requires:
     interface: varnish
     limit: 2
     optional: true
+extra-bindings:
+    db-client:
+    admin-api:
+    foo-bar:


### PR DESCRIPTION
Following up on https://github.com/juju/charm/pull/191, this PR allows extra-bindings
to work when deploying bundles containing charm with extra-bindings in their metadata.
