### PR TITLE
support yaml.v2 marshaling for Meta

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -334,14 +334,14 @@ func parseMeta(m map[string]interface{}) (*Meta, error) {
 	return &meta, nil
 }
 
-// GetYAML implements yaml.Getter.GetYAML.
-func (m Meta) GetYAML() (tag string, value interface{}) {
+// MarshalYAML implements yaml.Marshaler (yaml.v2).
+func (m Meta) MarshalYAML() (interface{}, error) {
 	var minver string
 	if m.MinJujuVersion != version.Zero {
 		minver = m.MinJujuVersion.String()
 	}
 
-	return "", struct {
+	return struct {
 		Name           string                       `yaml:"name"`
 		Summary        string                       `yaml:"summary"`
 		Description    string                       `yaml:"description"`
@@ -369,7 +369,14 @@ func (m Meta) GetYAML() (tag string, value interface{}) {
 		Series:         m.Series,
 		Terms:          m.Terms,
 		MinJujuVersion: minver,
-	}
+	}, nil
+}
+	
+
+// GetYAML implements yaml.Getter.GetYAML (yaml.v1).
+func (m Meta) GetYAML() (tag string, value interface{}) {
+	v, _ := m.MarshalYAML()
+	return "", v
 }
 
 func marshaledRelations(relations map[string]Relation) map[string]marshaledRelation {

--- a/meta_test.go
+++ b/meta_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v1"
+	yamlv2 "gopkg.in/yaml.v2"
 
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charm.v6-unstable/resource"
@@ -706,6 +707,19 @@ func (s *MetaSuite) TestYAMLMarshal(c *gc.C) {
 		ch, err := charm.ReadMeta(strings.NewReader(test.yaml))
 		c.Assert(err, gc.IsNil)
 		gotYAML, err := yaml.Marshal(ch)
+		c.Assert(err, gc.IsNil)
+		gotCh, err := charm.ReadMeta(bytes.NewReader(gotYAML))
+		c.Assert(err, gc.IsNil)
+		c.Assert(gotCh, jc.DeepEquals, ch)
+	}
+}
+
+func (s *MetaSuite) TestYAMLMarshalV2(c *gc.C) {
+	for i, test := range metaYAMLMarshalTests {
+		c.Logf("test %d: %s", i, test.about)
+		ch, err := charm.ReadMeta(strings.NewReader(test.yaml))
+		c.Assert(err, gc.IsNil)
+		gotYAML, err := yamlv2.Marshal(ch)
 		c.Assert(err, gc.IsNil)
 		gotCh, err := charm.ReadMeta(bytes.NewReader(gotYAML))
 		c.Assert(err, gc.IsNil)


### PR DESCRIPTION
The YAML package changed its method names. We can support both versions.