### PR TITLE
Fix bundle charm series validation

### DIFF
--- a/bundledata.go
+++ b/bundledata.go
@@ -378,8 +378,8 @@ func (verifier *bundleDataVerifier) verifyServices() {
 		}
 
 		// Check the series.
-		if curl != nil && svc.Series != "" {
-			verifier.addErrorf("service %q declares both a series and a non-local charm", name)
+		if curl != nil && curl.Series != "" && svc.Series != "" && curl.Series != svc.Series {
+			verifier.addErrorf("the charm URL for service %q has a series which does not match, please remove the series from the URL", name)
 		}
 		if svc.Series != "" && !IsValidSeries(svc.Series) {
 			verifier.addErrorf("service %q declares an invalid series %q", name, svc.Series)

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -245,8 +245,11 @@ services:
     wordpress:
           charm: wordpress
     postgres:
-        charm: "cs:postgres"
+        charm: "cs:xenial/postgres"
         series: trusty
+    terracotta:
+        charm: "cs:xenial/terracotta"
+        series: xenial
     ceph:
           charm: ceph
           storage:
@@ -278,7 +281,7 @@ relations:
 		`charm path in service "riak" does not exist: internal/test-charm-repo/bundle/somepath`,
 		`invalid constraints "bad constraints" in service "mysql": bad constraint`,
 		`negative number of units specified on service "mediawiki"`,
-		`service "postgres" declares both a series and a non-local charm`,
+		`the charm URL for service "postgres" has a series which does not match, please remove the series from the URL`,
 		`too many units specified in unit placement for service "mysql"`,
 		`placement "nowhere/3" refers to a service not defined in this bundle`,
 		`placement "mediawiki/0" specifies a unit greater than the -4 unit(s) started by the target service`,


### PR DESCRIPTION
The charm URL in a bundle can include a series so long as it matches any value of the series attribute.