### PR TITLE
Allow negative resource revisions.

### DIFF
--- a/resource/resource.go
+++ b/resource/resource.go
@@ -48,7 +48,13 @@ func (res Resource) Validate() error {
 }
 
 func (res Resource) validateRevision() error {
-	if res.Revision < 0 {
+	if res.Origin == OriginUpload {
+		// We do not care about the revision, so we don't check it.
+		// TODO(ericsnow) Ensure Revision is 0 for OriginUpload?
+		return nil
+	}
+
+	if res.Revision < 0 && res.isFileAvailable() {
 		return errors.NewNotValid(nil, fmt.Sprintf("must be non-negative, got %d", res.Revision))
 	}
 
@@ -71,4 +77,16 @@ func (res Resource) validateFileInfo() error {
 	}
 
 	return nil
+}
+
+// isFileAvailable determines whether or not the resource info indicates
+// that the resource file is available.
+func (res Resource) isFileAvailable() bool {
+	if !res.Fingerprint.IsZero() {
+		return true
+	}
+	if res.Size > 0 {
+		return true
+	}
+	return false
 }

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -84,6 +84,42 @@ func (s *ResourceSuite) TestValidateBadOrigin(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `bad origin: .*`)
 }
 
+func (s *ResourceSuite) TestValidateUploadNegativeRevision(c *gc.C) {
+	fp, err := resource.NewFingerprint(fingerprint)
+	c.Assert(err, jc.ErrorIsNil)
+	res := resource.Resource{
+		Meta: resource.Meta{
+			Name:        "my-resource",
+			Type:        resource.TypeFile,
+			Path:        "filename.tgz",
+			Description: "One line that is useful when operators need to push it.",
+		},
+		Origin:      resource.OriginUpload,
+		Revision:    -1,
+		Fingerprint: fp,
+		Size:        10,
+	}
+	err = res.Validate()
+
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *ResourceSuite) TestValidateStoreNegativeRevisionNoFile(c *gc.C) {
+	res := resource.Resource{
+		Meta: resource.Meta{
+			Name:        "my-resource",
+			Type:        resource.TypeFile,
+			Path:        "filename.tgz",
+			Description: "One line that is useful when operators need to push it.",
+		},
+		Origin:   resource.OriginStore,
+		Revision: -1,
+	}
+	err := res.Validate()
+
+	c.Check(err, jc.ErrorIsNil)
+}
+
 func (s *ResourceSuite) TestValidateBadRevision(c *gc.C) {
 	fp, err := resource.NewFingerprint(fingerprint)
 	c.Assert(err, jc.ErrorIsNil)

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -59,7 +59,7 @@ func (s *ResourceSuite) TestValidateBadMetadata(c *gc.C) {
 	err = res.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `.*bad metadata.*`)
+	c.Check(err, gc.ErrorMatches, `bad metadata: .*`)
 }
 
 func (s *ResourceSuite) TestValidateBadOrigin(c *gc.C) {
@@ -81,7 +81,7 @@ func (s *ResourceSuite) TestValidateBadOrigin(c *gc.C) {
 	err = res.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `.*bad origin.*`)
+	c.Check(err, gc.ErrorMatches, `bad origin: .*`)
 }
 
 func (s *ResourceSuite) TestValidateBadRevision(c *gc.C) {
@@ -101,7 +101,7 @@ func (s *ResourceSuite) TestValidateBadRevision(c *gc.C) {
 	err = res.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `.*revision must be non-negative.*`)
+	c.Check(err, gc.ErrorMatches, `bad revision: must be non-negative, got -1`)
 }
 
 func (s *ResourceSuite) TestValidateZeroValueFingerprint(c *gc.C) {
@@ -143,7 +143,7 @@ func (s *ResourceSuite) TestValidateMissingFingerprint(c *gc.C) {
 	err := res.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `.*missing fingerprint.*`)
+	c.Check(err, gc.ErrorMatches, `bad file info: missing fingerprint`)
 }
 
 func (s *ResourceSuite) TestValidateBadSize(c *gc.C) {
@@ -164,5 +164,5 @@ func (s *ResourceSuite) TestValidateBadSize(c *gc.C) {
 	err = res.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `negative size not valid`)
+	c.Check(err, gc.ErrorMatches, `bad file info: negative size`)
 }


### PR DESCRIPTION
Negative resource revisions allow us to indicate that no revision is set.  This is what we already do for charm revisions.