### PR TITLE
Support parsing of multiseries charms

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -268,7 +268,14 @@ func ReadMeta(r io.Reader) (meta *Meta, err error) {
 		meta.OldRevision = int(m["revision"].(int64))
 	}
 	if series, ok := m["series"]; ok && series != nil {
-		meta.Series = series.(string)
+		multiseries, ok := series.([]interface{})
+		if ok {
+			if len(multiseries) > 0 {
+				meta.Series = multiseries[0].(string)
+			}
+		} else {
+			meta.Series = series.(string)
+		}
 	}
 	meta.Storage = parseStorage(m["storage"])
 	meta.PayloadClasses = parsePayloadClasses(m["payloads"])
@@ -672,7 +679,7 @@ var charmSchema = schema.FieldMap(
 		"subordinate": schema.Bool(),
 		"categories":  schema.List(schema.String()),
 		"tags":        schema.List(schema.String()),
-		"series":      schema.String(),
+		"series":      schema.OneOf(schema.String(), schema.List(schema.String())),
 		"storage":     schema.StringMap(storageSchema),
 		"payloads":    schema.StringMap(payloadClassSchema),
 	},

--- a/meta_test.go
+++ b/meta_test.go
@@ -278,6 +278,28 @@ func (s *MetaSuite) TestInvalidSeries(c *gc.C) {
 	}
 }
 
+var multiSeriesTests = []struct{
+	yamllist string
+	result string
+}{
+	{`["trusty", "precise"]`, "trusty"},
+	{`["trusty", "xenial"]`, "trusty"},
+	{`["wonky", "trusty", "happy"]`, "wonky"},
+	{`[]`, ""},
+}
+
+// TestMultiSeries validates that new style multi series charms are parsed
+// and pick the first listed series.
+func (s *MetaSuite) TestMultiSeries(c *gc.C) {
+	for _, test := range multiSeriesTests {
+		c.Logf("test %q", test.yamllist)
+		meta, err := charm.ReadMeta(strings.NewReader(
+			fmt.Sprintf("%s\nseries: %s\n", dummyMetadata, test.yamllist)))
+		c.Assert(err, gc.IsNil)
+		c.Check(meta.Series, gc.Equals, test.result)
+	}
+}
+
 func (s *MetaSuite) TestCheckMismatchedRelationName(c *gc.C) {
 	// This  Check case cannot be covered by the above
 	// TestRelationsConstraints tests.


### PR DESCRIPTION
Fixes lp:1563607 by accepting charms that declare multiple series.
When a charm has a metadata.yaml containing a list of supported
series, the first is taken as the charm's default series.

Charms are always reserialised with a single series. Juju 2.0 is
required for full multiseries charm support.