### PR TITLE
Reserve "juju" and "juju-*" actions

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -109,8 +109,11 @@ func ReadActionsYaml(r io.Reader) (*Actions, error) {
 		if valid := actionNameRule.MatchString(name); !valid {
 			return nil, fmt.Errorf("bad action name %s", name)
 		}
-		if reservedName(name) {
-			return nil, fmt.Errorf("reserved action name %s", name)
+		if reserved, reason := reservedName(name); reserved {
+			return nil, fmt.Errorf(
+				"cannot use action name %s: %s",
+				name, reason,
+			)
 		}
 
 		desc := "No description"

--- a/actions.go
+++ b/actions.go
@@ -109,6 +109,9 @@ func ReadActionsYaml(r io.Reader) (*Actions, error) {
 		if valid := actionNameRule.MatchString(name); !valid {
 			return nil, fmt.Errorf("bad action name %s", name)
 		}
+		if reservedName(name) {
+			return nil, fmt.Errorf("reserved action name %s", name)
+		}
 
 		desc := "No description"
 		thisActionSchema := map[string]interface{}{

--- a/actions_test.go
+++ b/actions_test.go
@@ -578,14 +578,14 @@ Snapshot:
 juju:
    description: A reserved action.
 `,
-		expectedError: "reserved action name juju",
+		expectedError: `cannot use action name juju: "juju" is a reserved name`,
 	}, {
 		description: `Reserved Action Name: "juju-run".`,
 		yaml: `
 juju-run:
    description: A reserved action.
 `,
-		expectedError: "reserved action name juju-run",
+		expectedError: `cannot use action name juju-run: the "juju-" prefix is reserved`,
 	}, {
 		description: "A non-string description fails to parse",
 		yaml: `

--- a/actions_test.go
+++ b/actions_test.go
@@ -573,6 +573,20 @@ Snapshot:
 
 		expectedError: "bad action name Snapshot",
 	}, {
+		description: `Reserved Action Name: "juju".`,
+		yaml: `
+juju:
+   description: A reserved action.
+`,
+		expectedError: "reserved action name juju",
+	}, {
+		description: `Reserved Action Name: "juju-run".`,
+		yaml: `
+juju-run:
+   description: A reserved action.
+`,
+		expectedError: "reserved action name juju-run",
+	}, {
 		description: "A non-string description fails to parse",
 		yaml: `
 snapshot:

--- a/meta.go
+++ b/meta.go
@@ -440,12 +440,12 @@ func (meta Meta) Check() error {
 			// Container-scoped require relations on subordinates are allowed
 			// to use the otherwise-reserved juju-* namespace.
 			if !meta.Subordinate || role != RoleRequirer || rel.Scope != ScopeContainer {
-				if reservedName(name) {
+				if reserved, _ := reservedName(name); reserved {
 					return fmt.Errorf("charm %q using a reserved relation name: %q", meta.Name, name)
 				}
 			}
 			if role != RoleRequirer {
-				if reservedName(rel.Interface) {
+				if reserved, _ := reservedName(rel.Interface); reserved {
 					return fmt.Errorf("charm %q relation %q using a reserved interface: %q", meta.Name, name, rel.Interface)
 				}
 			}
@@ -536,8 +536,14 @@ func (meta Meta) Check() error {
 	return nil
 }
 
-func reservedName(name string) bool {
-	return name == "juju" || strings.HasPrefix(name, "juju-")
+func reservedName(name string) (reserved bool, reason string) {
+	if name == "juju" {
+		return true, `"juju" is a reserved name`
+	}
+	if strings.HasPrefix(name, "juju-") {
+		return true, `the "juju-" prefix is reserved`
+	}
+	return false, ""
 }
 
 func parseRelations(relations interface{}, role RelationRole) map[string]Relation {


### PR DESCRIPTION
Just as we do for relation names, reserve the
action names "juju", and anything starting with
"juju-".