### PR TITLE
Use names.IsValidPayload() to validate the class name.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -3,7 +3,7 @@ github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
 github.com/juju/loggo	git	8477fc936adf0e382d680310047ca27e128a309a	2015-05-27T03:58:39Z
-github.com/juju/names	git	a6a253b0a94cc79e99a68d284b970ffce2a11ecd	2015-07-09T13:59:32Z
+github.com/juju/names	git	5d07cecf4b15803e8686ec95f853293ad3055d08	2016-05-23T20:37:53Z
 github.com/juju/schema	git	1e25943f8c6fd6815282d6f1ac87091d21e14e19	2016-03-01T11:16:46Z
 github.com/juju/testing	git	ee18040b46bb1f8c93438383bd51ec77eb8c02ab	2016-01-12T21:04:04Z
 github.com/juju/utils	git	ef8480bcaabae506777530725c81d83a4de2fb06	2016-01-12T23:14:21Z

--- a/payloads.go
+++ b/payloads.go
@@ -6,7 +6,9 @@ package charm
 import (
 	"fmt"
 
+	"github.com/juju/names"
 	"github.com/juju/schema"
+	"github.com/juju/utils"
 )
 
 var payloadClassSchema = schema.FieldMap(
@@ -60,8 +62,16 @@ func (pc PayloadClass) Validate() error {
 	if pc.Name == "" {
 		return fmt.Errorf("payload class missing name")
 	}
+	// For 1.25 compatibility, names.IsValidPayload() supports
+	// UUIDs for resource the "ID". However, resource classes in
+	// charm metadata should not be a UUID.
+	if !names.IsValidPayload(pc.Name) || utils.IsValidUUIDString(pc.Name) {
+		return fmt.Errorf("invalid payload class %q", pc.Name)
+	}
+
 	if pc.Type == "" {
 		return fmt.Errorf("payload class missing type")
 	}
+
 	return nil
 }

--- a/payloads.go
+++ b/payloads.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/names"
 	"github.com/juju/schema"
-	"github.com/juju/utils"
 )
 
 var payloadClassSchema = schema.FieldMap(
@@ -62,10 +61,7 @@ func (pc PayloadClass) Validate() error {
 	if pc.Name == "" {
 		return fmt.Errorf("payload class missing name")
 	}
-	// For 1.25 compatibility, names.IsValidPayload() supports
-	// UUIDs for resource the "ID". However, resource classes in
-	// charm metadata should not be a UUID.
-	if !names.IsValidPayload(pc.Name) || utils.IsValidUUIDString(pc.Name) {
+	if !names.IsValidPayload(pc.Name) {
 		return fmt.Errorf("invalid payload class %q", pc.Name)
 	}
 

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -15,14 +15,14 @@ var _ = gc.Suite(&payloadClassSuite{})
 type payloadClassSuite struct{}
 
 func (s *payloadClassSuite) TestParsePayloadClassOkay(c *gc.C) {
-	name := "myPayload"
+	name := "my-payload"
 	data := map[string]interface{}{
 		"type": "docker",
 	}
 	payloadClass := charm.ParsePayloadClass(name, data)
 
 	c.Check(payloadClass, jc.DeepEquals, charm.PayloadClass{
-		Name: "myPayload",
+		Name: "my-payload",
 		Type: "docker",
 	})
 }
@@ -41,18 +41,18 @@ func (s *payloadClassSuite) TestParsePayloadClassMissingName(c *gc.C) {
 }
 
 func (s *payloadClassSuite) TestParsePayloadClassEmpty(c *gc.C) {
-	name := "myPayload"
+	name := "my-payload"
 	var data map[string]interface{}
 	payloadClass := charm.ParsePayloadClass(name, data)
 
 	c.Check(payloadClass, jc.DeepEquals, charm.PayloadClass{
-		Name: "myPayload",
+		Name: "my-payload",
 	})
 }
 
 func (s *payloadClassSuite) TestValidateFull(c *gc.C) {
 	payloadClass := charm.PayloadClass{
-		Name: "myPayload",
+		Name: "my-payload",
 		Type: "docker",
 	}
 	err := payloadClass.Validate()
@@ -78,17 +78,17 @@ func (s *payloadClassSuite) TestValidateMissingName(c *gc.C) {
 
 func (s *payloadClassSuite) TestValidateBadName(c *gc.C) {
 	payloadClass := charm.PayloadClass{
-		Name: "my-payload",
+		Name: "my-###-payload",
 		Type: "docker",
 	}
 	err := payloadClass.Validate()
 
-	c.Check(err, gc.ErrorMatches, `invalid payload class "my-payload"`)
+	c.Check(err, gc.ErrorMatches, `invalid payload class "my-###-payload"`)
 }
 
 func (s *payloadClassSuite) TestValidateMissingType(c *gc.C) {
 	payloadClass := charm.PayloadClass{
-		Name: "myPayload",
+		Name: "my-payload",
 	}
 	err := payloadClass.Validate()
 

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -15,14 +15,14 @@ var _ = gc.Suite(&payloadClassSuite{})
 type payloadClassSuite struct{}
 
 func (s *payloadClassSuite) TestParsePayloadClassOkay(c *gc.C) {
-	name := "my-payload"
+	name := "myPayload"
 	data := map[string]interface{}{
 		"type": "docker",
 	}
 	payloadClass := charm.ParsePayloadClass(name, data)
 
 	c.Check(payloadClass, jc.DeepEquals, charm.PayloadClass{
-		Name: "my-payload",
+		Name: "myPayload",
 		Type: "docker",
 	})
 }
@@ -41,18 +41,18 @@ func (s *payloadClassSuite) TestParsePayloadClassMissingName(c *gc.C) {
 }
 
 func (s *payloadClassSuite) TestParsePayloadClassEmpty(c *gc.C) {
-	name := "my-payload"
+	name := "myPayload"
 	var data map[string]interface{}
 	payloadClass := charm.ParsePayloadClass(name, data)
 
 	c.Check(payloadClass, jc.DeepEquals, charm.PayloadClass{
-		Name: "my-payload",
+		Name: "myPayload",
 	})
 }
 
 func (s *payloadClassSuite) TestValidateFull(c *gc.C) {
 	payloadClass := charm.PayloadClass{
-		Name: "my-payload",
+		Name: "myPayload",
 		Type: "docker",
 	}
 	err := payloadClass.Validate()
@@ -76,9 +76,19 @@ func (s *payloadClassSuite) TestValidateMissingName(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `payload class missing name`)
 }
 
-func (s *payloadClassSuite) TestValidateMissingType(c *gc.C) {
+func (s *payloadClassSuite) TestValidateBadName(c *gc.C) {
 	payloadClass := charm.PayloadClass{
 		Name: "my-payload",
+		Type: "docker",
+	}
+	err := payloadClass.Validate()
+
+	c.Check(err, gc.ErrorMatches, `invalid payload class "my-payload"`)
+}
+
+func (s *payloadClassSuite) TestValidateMissingType(c *gc.C) {
+	payloadClass := charm.PayloadClass{
+		Name: "myPayload",
 	}
 	err := payloadClass.Validate()
 


### PR DESCRIPTION
The class name should align with the valid payload ID defined for payload tags.  Otherwise the name cannot be turned into a tag.