### PR TITLE
Handle nil BundleData when unmarshalling from bson

### DIFF
--- a/bundledata.go
+++ b/bundledata.go
@@ -65,9 +65,12 @@ func (bd *BundleData) UnmarshalYAML(f func(interface{}) error) error {
 func (bd *BundleData) SetBSON(raw bson.Raw) error {
 	// TODO(wallyworld) - bson deserialisation is not handling the inline directive,
 	// so we need to unmarshal the bundle data manually.
-	var b noMethodsBundleData
+	var b *noMethodsBundleData
 	if err := raw.Unmarshal(&b); err != nil {
 		return err
+	}
+	if b == nil {
+		return bson.SetZero
 	}
 
 	var bdc legacyBundleData
@@ -75,7 +78,7 @@ func (bd *BundleData) SetBSON(raw bson.Raw) error {
 		return err
 	}
 	// As per the above TODO, we manually set the inline data.
-	bdc.noMethodsBundleData = b
+	bdc.noMethodsBundleData = *b
 	return bdc.setBundleData(bd)
 }
 

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -306,6 +306,12 @@ func (s *bundleDataSuite) TestBsonMarshall(c *gc.C) {
 	}
 }
 
+func (s *bundleDataSuite) TestBsonNilData(c *gc.C) {
+	var bd charm.BundleData
+	err := bd.SetBSON(bson.Raw{10, []byte(nil)})
+	c.Assert(err, gc.Equals, bson.SetZero)
+}
+
 var verifyErrorsTests = []struct {
 	about  string
 	data   string

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -307,9 +307,15 @@ func (s *bundleDataSuite) TestBsonMarshall(c *gc.C) {
 }
 
 func (s *bundleDataSuite) TestBsonNilData(c *gc.C) {
-	var bd charm.BundleData
-	err := bd.SetBSON(bson.Raw{10, []byte(nil)})
-	c.Assert(err, gc.Equals, bson.SetZero)
+	bd := map[string]*charm.BundleData{
+		"test": nil,
+	}
+	data, err := bson.Marshal(bd)
+	c.Assert(err, jc.ErrorIsNil)
+	var result map[string]*charm.BundleData
+	err = bson.Unmarshal(data, &result)
+	c.Assert(err, gc.IsNil)
+	c.Assert(result["test"], gc.IsNil)
 }
 
 var verifyErrorsTests = []struct {


### PR DESCRIPTION
A small fix for bson unmarshall to properly return SetZero when there's no data.