### PR TITLE
add BundleData.UnmarshaledWithServices method

### DIFF
--- a/bundledata.go
+++ b/bundledata.go
@@ -38,6 +38,7 @@ func (lbd *legacyBundleData) setBundleData(bd *BundleData) error {
 		// We account for the fact that the YAML may contain a legacy entry
 		// for "services" instead of "applications".
 		lbd.Applications = lbd.LegacyServices
+		lbd.unmarshaledWithServices = true
 	}
 	*bd = BundleData(lbd.noMethodsBundleData)
 	return nil
@@ -115,6 +116,17 @@ type BundleData struct {
 
 	// Short paragraph explaining what the bundle is useful for.
 	Description string `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
+
+	// unmarshaledWithServices holds whether the original marshaled data held a
+	// legacy "services" field rather than the "applications" field.
+	unmarshaledWithServices bool
+}
+
+// UnmarshaledWithServices reports whether the bundle data was
+// unmarshaled from a representation that used the legacy "services"
+// field rather than the "applications" field.
+func (d *BundleData) UnmarshaledWithServices() bool {
+	return d.unmarshaledWithServices
 }
 
 // MachineSpec represents a notional machine that will be mapped

--- a/charmarchive.go
+++ b/charmarchive.go
@@ -122,7 +122,6 @@ func readCharmArchive(zopen zipOpener) (archive *CharmArchive, err error) {
 		if _, ok := err.(*noCharmArchiveFile); !ok {
 			return nil, err
 		}
-		b.revision = b.meta.OldRevision
 	} else {
 		_, err = fmt.Fscan(reader, &b.revision)
 		if err != nil {

--- a/charmarchive_test.go
+++ b/charmarchive_test.go
@@ -292,14 +292,15 @@ func (s *CharmArchiveSuite) TestCharmArchiveRevisionFile(c *gc.C) {
 	archive := extCharmArchiveDir(c, charmDir)
 	c.Assert(archive.Revision(), gc.Equals, 0)
 
-	// Missing revision file with old revision in metadata
+	// Missing revision file with obsolete old revision in metadata;
+	// the revision is ignored.
 	file, err := os.OpenFile(filepath.Join(charmDir, "metadata.yaml"), os.O_WRONLY|os.O_APPEND, 0)
 	c.Assert(err, gc.IsNil)
 	_, err = file.Write([]byte("\nrevision: 1234\n"))
 	c.Assert(err, gc.IsNil)
 
 	archive = extCharmArchiveDir(c, charmDir)
-	c.Assert(archive.Revision(), gc.Equals, 1234)
+	c.Assert(archive.Revision(), gc.Equals, 0)
 
 	// Revision file with bad content
 	err = ioutil.WriteFile(revPath, []byte("garbage"), 0666)

--- a/charmdir.go
+++ b/charmdir.go
@@ -85,8 +85,6 @@ func ReadCharmDir(path string) (dir *CharmDir, err error) {
 		if err != nil {
 			return nil, errors.New("invalid revision file")
 		}
-	} else {
-		dir.revision = dir.meta.OldRevision
 	}
 
 	return dir, nil

--- a/charmdir_test.go
+++ b/charmdir_test.go
@@ -268,7 +268,8 @@ func (s *CharmDirSuite) TestDirRevisionFile(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(dir.Revision(), gc.Equals, 0)
 
-	// Missing revision file with old revision in metadata
+	// Missing revision file with obsolete old revision in metadata ignores
+	// the old revision field.
 	file, err := os.OpenFile(filepath.Join(charmDir, "metadata.yaml"), os.O_WRONLY|os.O_APPEND, 0)
 	c.Assert(err, gc.IsNil)
 	_, err = file.Write([]byte("\nrevision: 1234\n"))
@@ -276,7 +277,7 @@ func (s *CharmDirSuite) TestDirRevisionFile(c *gc.C) {
 
 	dir, err = charm.ReadCharmDir(charmDir)
 	c.Assert(err, gc.IsNil)
-	c.Assert(dir.Revision(), gc.Equals, 1234)
+	c.Assert(dir.Revision(), gc.Equals, 0)
 
 	// Revision file with bad content
 	err = ioutil.WriteFile(revPath, []byte("garbage"), 0666)

--- a/export_test.go
+++ b/export_test.go
@@ -19,3 +19,7 @@ var (
 func MissingSeriesError() error {
 	return missingSeriesError
 }
+
+func (bd *BundleData) ClearUnmarshaledWithServices() {
+	bd.unmarshaledWithServices = false
+}

--- a/url.go
+++ b/url.go
@@ -373,6 +373,26 @@ func (u *URL) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// MarshalText implements encoding.TextMarshaler by
+// returning u.String()
+func (u *URL) MarshalText() ([]byte, error) {
+	if u == nil {
+		return nil, nil
+	}
+	return []byte(u.String()), nil
+}
+
+// UnmarshalText implements encoding.TestUnmarshaler by
+// parsing the data with ParseURL.
+func (u *URL) UnmarshalText(data []byte) error {
+	url, err := ParseURL(string(data))
+	if err != nil {
+		return err
+	}
+	*u = *url
+	return nil
+}
+
 // Quote translates a charm url string into one which can be safely used
 // in a file path.  ASCII letters, ASCII digits, dot and dash stay the
 // same; other characters are translated to their hex representation


### PR DESCRIPTION
This allows code to know when a bundle has been
unmarshaled from the old format.

Also test marshaling/unmarshaling more fully for
all supported codecs, and remove the obsolete
Meta.Version and Meta.Format fields that have been
deprecated for a long time. We still accept those
fields for backward compatibility but they're ignored.