### PR TITLE
WIP: Allow owner prefixed term names.

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -241,7 +241,7 @@ func parseStringList(list interface{}) []string {
 	return result
 }
 
-var termNameRE = regexp.MustCompile("^[a-z]+([a-z0-9-]+)(/[0-9]+)?$")
+var termNameRE = regexp.MustCompile("^([a-z]+([a-z0-9-]+)/)?[a-z]+([a-z0-9-]+)(/[0-9]+)?$")
 
 func checkTerm(s string) error {
 	match := termNameRE.FindStringSubmatch(s)


### PR DESCRIPTION
Allows terms to contain an owner prefix component, `owner`/`term name`/`term revision`.

Not ready to land yet, this is on hold.