### PR TITLE
Update test to match changed juju/version behaviour

### DIFF
--- a/meta_test.go
+++ b/meta_test.go
@@ -539,7 +539,7 @@ func (s *MetaSuite) TestMinJujuVersion(c *gc.C) {
 	charmMeta := fmt.Sprintf("%s\nmin-juju-version: ", dummyMetadata)
 	vals := []version.Number{
 		{Major: 1, Minor: 25},
-		{Major: 1, Minor: 25, Tag: "alpha1"},
+		{Major: 1, Minor: 25, Tag: "alpha"},
 		{Major: 1, Minor: 25, Patch: 1},
 	}
 	for _, ver := range vals {


### PR DESCRIPTION
Since commit [4ae6172](https://github.com/juju/version/commit/4ae6172c00626779a5a462c3e3d22fc0e889431a) (https://github.com/juju/version/pull/3), `version.Number.Tag` will never include any digits, so this test became incorrect.