### PR TITLE
Add new preferred charm/bundle url format

### DIFF
--- a/meta_test.go
+++ b/meta_test.go
@@ -514,12 +514,12 @@ func (s *MetaSuite) TestSeries(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Check(meta.Series, gc.HasLen, 0)
 	charmMeta := fmt.Sprintf("%s\nseries:", dummyMetadata)
-	for _, seriesName := range []string{"precise", "trusty", "plan9"} {
+	for _, seriesName := range []string{"precise", "trusty", "centos7"} {
 		charmMeta = fmt.Sprintf("%s\n    - %s", charmMeta, seriesName)
 	}
 	meta, err = charm.ReadMeta(strings.NewReader(charmMeta))
 	c.Assert(err, gc.IsNil)
-	c.Assert(meta.Series, gc.DeepEquals, []string{"precise", "trusty", "plan9"})
+	c.Assert(meta.Series, gc.DeepEquals, []string{"precise", "trusty", "centos7"})
 }
 
 func (s *MetaSuite) TestInvalidSeries(c *gc.C) {
@@ -877,7 +877,7 @@ extra-bindings:
 categories: [c1, c1]
 tags: [t1, t2]
 series:
-    - someseries
+    - saucy
 resources:
     foo:
         description: 'a description'

--- a/url.go
+++ b/url.go
@@ -47,16 +47,14 @@ type URL struct {
 	Series   string // "precise" or "" if unset
 }
 
+const bundleSeries = "bundle"
+
 var ErrUnresolvedUrl error = fmt.Errorf("charm or bundle url series is not resolved")
 
 var (
-	validSeries = set.NewStrings(series.SupportedSeries()...)
+	validSeries = set.NewStrings(series.SupportedSeries()...).Union(set.NewStrings(bundleSeries))
 	validName   = regexp.MustCompile("^[a-z][a-z0-9]*(-[a-z0-9]*[a-z][a-z0-9]*)*$")
 )
-
-func init() {
-	validSeries.Add("bundle")
-}
 
 // IsValidSeries reports whether series is a valid series in charm or bundle
 // URLs.
@@ -381,7 +379,7 @@ func (u URL) String() string {
 	}
 	// Name is required.
 	parts = append(parts, u.Name)
-	if u.Series != "" {
+	if u.Series != "" && u.Series != bundleSeries {
 		parts = append(parts, u.Series)
 	}
 	if u.Revision >= 0 {

--- a/url.go
+++ b/url.go
@@ -44,7 +44,7 @@ type URL struct {
 	User     string // "joe".
 	Name     string // "wordpress".
 	Revision int    // -1 if unset, N otherwise.
-	Series   string // "precise" or "" if unset
+	Series   string // "precise" or "" if unset; "bundle" if it's a bundle.
 }
 
 const bundleSeries = "bundle"
@@ -222,14 +222,6 @@ func parseV1URL(url *gourl.URL, originalURL string) (*URL, error) {
 		return nil, fmt.Errorf("URL has invalid charm or bundle name: %q", originalURL)
 	}
 	return &r, nil
-}
-
-func convertRevision(revision string, url *gourl.URL) (int, error) {
-	result, err := strconv.Atoi(revision)
-	if err != nil {
-		return -1, fmt.Errorf("charm or bundle URL has malformed revision: %q in %q", revision, url)
-	}
-	return result, nil
 }
 
 func parseV3URL(url *gourl.URL) (*URL, error) {

--- a/url.go
+++ b/url.go
@@ -49,9 +49,9 @@ type URL struct {
 
 const bundleSeries = "bundle"
 
-var ErrUnresolvedUrl error = fmt.Errorf("charm or bundle url series is not resolved")
-
 var (
+	ErrUnresolvedUrl error = fmt.Errorf("charm or bundle url series is not resolved")
+
 	validSeries = set.NewStrings(series.SupportedSeries()...).Union(set.NewStrings(bundleSeries))
 	validName   = regexp.MustCompile("^[a-z][a-z0-9]*(-[a-z0-9]*[a-z][a-z0-9]*)*$")
 )

--- a/url_test.go
+++ b/url_test.go
@@ -517,6 +517,11 @@ func (s *URLSuite) TestJSONGarbage(c *gc.C) {
 	}
 }
 
+func (*URLSuite) TestPath(c *gc.C) {
+	c.Check(charm.MustParseURL("cs:user/name/quantal/4").Path(), gc.Equals, "~user/quantal/name-4")
+	c.Check(charm.MustParseURL("cs:user/name/quantal").Path(), gc.Equals, "~user/quantal/name")
+}
+
 type QuoteSuite struct{}
 
 var _ = gc.Suite(&QuoteSuite{})

--- a/url_test.go
+++ b/url_test.go
@@ -25,29 +25,37 @@ var urlTests = []struct {
 	exact  string
 	url    *charm.URL
 }{{
-	s:   "cs:~user/series/name",
-	url: &charm.URL{"cs", "user", "name", -1, "series"},
+	s:     "cs:~user/trusty/name",
+	exact: "cs:user/name/trusty",
+	url:   &charm.URL{"cs", "user", "name", -1, "trusty"},
 }, {
-	s:   "cs:~user/series/name-0",
-	url: &charm.URL{"cs", "user", "name", 0, "series"},
+	s:     "cs:~user/wily/name-0",
+	exact: "cs:user/name/wily/0",
+	url:   &charm.URL{"cs", "user", "name", 0, "wily"},
 }, {
-	s:   "cs:series/name",
-	url: &charm.URL{"cs", "", "name", -1, "series"},
+	s:     "cs:raring/name",
+	exact: "cs:name/raring",
+	url:   &charm.URL{"cs", "", "name", -1, "raring"},
 }, {
-	s:   "cs:series/name-42",
-	url: &charm.URL{"cs", "", "name", 42, "series"},
+	s:     "cs:xenial/name-42",
+	exact: "cs:name/xenial/42",
+	url:   &charm.URL{"cs", "", "name", 42, "xenial"},
 }, {
-	s:   "local:series/name-1",
-	url: &charm.URL{"local", "", "name", 1, "series"},
+	s:     "local:precise/name-1",
+	exact: "local:name/precise/1",
+	url:   &charm.URL{"local", "", "name", 1, "precise"},
 }, {
-	s:   "local:series/name",
-	url: &charm.URL{"local", "", "name", -1, "series"},
+	s:     "local:saucy/name",
+	exact: "local:name/saucy",
+	url:   &charm.URL{"local", "", "name", -1, "saucy"},
 }, {
-	s:   "local:series/n0-0n-n0",
-	url: &charm.URL{"local", "", "n0-0n-n0", -1, "series"},
+	s:     "local:utopic/n0-0n-n0",
+	exact: "local:n0-0n-n0/utopic",
+	url:   &charm.URL{"local", "", "n0-0n-n0", -1, "utopic"},
 }, {
-	s:   "cs:~user/name",
-	url: &charm.URL{"cs", "user", "name", -1, ""},
+	s:     "cs:~user/name",
+	exact: "cs:user/name",
+	url:   &charm.URL{"cs", "user", "name", -1, ""},
 }, {
 	s:   "cs:name",
 	url: &charm.URL{"cs", "", "name", -1, ""},
@@ -55,81 +63,81 @@ var urlTests = []struct {
 	s:   "local:name",
 	url: &charm.URL{"local", "", "name", -1, ""},
 }, {
-	s:     "http://jujucharms.com/u/user/name/series/1",
-	url:   &charm.URL{"cs", "user", "name", 1, "series"},
-	exact: "cs:~user/series/name-1",
+	s:     "http://jujucharms.com/u/user/name/vivid/1",
+	url:   &charm.URL{"cs", "user", "name", 1, "vivid"},
+	exact: "cs:user/name/vivid/1",
 }, {
-	s:     "http://www.jujucharms.com/u/user/name/series/1",
-	url:   &charm.URL{"cs", "user", "name", 1, "series"},
-	exact: "cs:~user/series/name-1",
+	s:     "http://www.jujucharms.com/u/user/name/precise/1",
+	url:   &charm.URL{"cs", "user", "name", 1, "precise"},
+	exact: "cs:user/name/precise/1",
 }, {
-	s:     "https://www.jujucharms.com/u/user/name/series/1",
-	url:   &charm.URL{"cs", "user", "name", 1, "series"},
-	exact: "cs:~user/series/name-1",
+	s:     "https://www.jujucharms.com/u/user/name/quantal/1",
+	url:   &charm.URL{"cs", "user", "name", 1, "quantal"},
+	exact: "cs:user/name/quantal/1",
 }, {
-	s:     "https://jujucharms.com/u/user/name/series/1",
-	url:   &charm.URL{"cs", "user", "name", 1, "series"},
-	exact: "cs:~user/series/name-1",
+	s:     "https://jujucharms.com/u/user/name/raring/1",
+	url:   &charm.URL{"cs", "user", "name", 1, "raring"},
+	exact: "cs:user/name/raring/1",
 }, {
-	s:     "https://jujucharms.com/u/user/name/series",
-	url:   &charm.URL{"cs", "user", "name", -1, "series"},
-	exact: "cs:~user/series/name",
+	s:     "https://jujucharms.com/u/user/name/saucy",
+	url:   &charm.URL{"cs", "user", "name", -1, "saucy"},
+	exact: "cs:user/name/saucy",
 }, {
 	s:     "https://jujucharms.com/u/user/name/1",
 	url:   &charm.URL{"cs", "user", "name", 1, ""},
-	exact: "cs:~user/name-1",
+	exact: "cs:user/name/1",
 }, {
 	s:     "https://jujucharms.com/u/user/name",
 	url:   &charm.URL{"cs", "user", "name", -1, ""},
-	exact: "cs:~user/name",
+	exact: "cs:user/name",
 }, {
 	s:     "https://jujucharms.com/name",
 	url:   &charm.URL{"cs", "", "name", -1, ""},
 	exact: "cs:name",
 }, {
-	s:     "https://jujucharms.com/name/series",
-	url:   &charm.URL{"cs", "", "name", -1, "series"},
-	exact: "cs:series/name",
+	s:     "https://jujucharms.com/name/utopic",
+	url:   &charm.URL{"cs", "", "name", -1, "utopic"},
+	exact: "cs:name/utopic",
 }, {
 	s:     "https://jujucharms.com/name/1",
 	url:   &charm.URL{"cs", "", "name", 1, ""},
-	exact: "cs:name-1",
+	exact: "cs:name/1",
 }, {
-	s:     "https://jujucharms.com/name/series/1",
-	url:   &charm.URL{"cs", "", "name", 1, "series"},
-	exact: "cs:series/name-1",
+	s:     "https://jujucharms.com/name/vivid/1",
+	url:   &charm.URL{"cs", "", "name", 1, "vivid"},
+	exact: "cs:name/vivid/1",
 }, {
-	s:     "https://jujucharms.com/u/user/name/series/1/",
-	url:   &charm.URL{"cs", "user", "name", 1, "series"},
-	exact: "cs:~user/series/name-1",
+	s:     "https://jujucharms.com/u/user/name/wily/1/",
+	url:   &charm.URL{"cs", "user", "name", 1, "wily"},
+	exact: "cs:user/name/wily/1",
 }, {
-	s:     "https://jujucharms.com/u/user/name/series/",
-	url:   &charm.URL{"cs", "user", "name", -1, "series"},
-	exact: "cs:~user/series/name",
+	s:     "https://jujucharms.com/u/user/name/xenial/",
+	url:   &charm.URL{"cs", "user", "name", -1, "xenial"},
+	exact: "cs:user/name/xenial",
 }, {
 	s:     "https://jujucharms.com/u/user/name/1/",
 	url:   &charm.URL{"cs", "user", "name", 1, ""},
-	exact: "cs:~user/name-1",
+	exact: "cs:user/name/1",
 }, {
 	s:     "https://jujucharms.com/u/user/name/",
 	url:   &charm.URL{"cs", "user", "name", -1, ""},
-	exact: "cs:~user/name",
+	exact: "cs:user/name",
 }, {
 	s:     "https://jujucharms.com/name/",
 	url:   &charm.URL{"cs", "", "name", -1, ""},
 	exact: "cs:name",
 }, {
-	s:     "https://jujucharms.com/name/series/",
-	url:   &charm.URL{"cs", "", "name", -1, "series"},
-	exact: "cs:series/name",
+	s:     "https://jujucharms.com/name/precise/",
+	url:   &charm.URL{"cs", "", "name", -1, "precise"},
+	exact: "cs:name/precise",
 }, {
 	s:     "https://jujucharms.com/name/1/",
 	url:   &charm.URL{"cs", "", "name", 1, ""},
-	exact: "cs:name-1",
+	exact: "cs:name/1",
 }, {
-	s:     "https://jujucharms.com/name/series/1/",
-	url:   &charm.URL{"cs", "", "name", 1, "series"},
-	exact: "cs:series/name-1",
+	s:     "https://jujucharms.com/name/quantal/1/",
+	url:   &charm.URL{"cs", "", "name", 1, "quantal"},
+	exact: "cs:name/quantal/1",
 }, {
 	s:   "https://jujucharms.com/",
 	err: `URL has invalid charm or bundle name: $URL`,
@@ -143,65 +151,68 @@ var urlTests = []struct {
 	s:   "https://jujucharms.com/u/badwolf",
 	err: "charm or bundle URL $URL malformed, expected \"/u/<user>/<name>\"",
 }, {
-	s:   "https://jujucharms.com/name/series/badwolf",
+	s:   "https://jujucharms.com/name/raring/badwolf",
 	err: "charm or bundle URL has malformed revision: \"badwolf\" in $URL",
 }, {
-	s:   "https://jujucharms.com/name/bad.wolf/42",
+	s:   "https://jujucharms.com/name/badwolf/42",
 	err: `charm or bundle URL has invalid series: $URL`,
 }, {
-	s:   "https://badwolf@jujucharms.com/name/series/42",
+	s:   "https://badwolf@jujucharms.com/name/saucy/42",
 	err: `charm or bundle URL $URL has unrecognized parts`,
 }, {
-	s:   "https://jujucharms.com/name/series/42#bad-wolf",
+	s:   "https://jujucharms.com/name/trusty/42#bad-wolf",
 	err: `charm or bundle URL $URL has unrecognized parts`,
 }, {
-	s:   "https://jujucharms.com/name/series/42?bad=wolf",
+	s:   "https://jujucharms.com/name//42?bad=wolf",
 	err: `charm or bundle URL $URL has unrecognized parts`,
 }, {
-	s:   "bs:~user/series/name-1",
+	s:   "bs:~user/utopic/name-1",
 	err: `charm or bundle URL has invalid schema: $URL`,
 }, {
 	s:   ":foo",
 	err: `cannot parse charm or bundle URL: $URL`,
 }, {
-	s:   "cs:~1/series/name-1",
+	s:   "cs:~1/vivid/name-1",
 	err: `charm or bundle URL has invalid user name: $URL`,
 }, {
 	s:   "cs:~user",
 	err: `URL without charm or bundle name: $URL`,
 }, {
-	s:   "cs:~user/1/name-1",
+	s:   "cs:~user/unknown/name-1",
 	err: `charm or bundle URL has invalid series: $URL`,
 }, {
-	s:   "cs:~user/series/name-1-2",
+	s:   "cs:~user/wily/name-1-2",
 	err: `URL has invalid charm or bundle name: $URL`,
 }, {
-	s:   "cs:~user/series/name-1-name-2",
+	s:   "cs:~user/xenial/name-1-name-2",
 	err: `URL has invalid charm or bundle name: $URL`,
 }, {
-	s:   "cs:~user/series/name--name-2",
+	s:   "cs:~user/precise/name--name-2",
 	err: `URL has invalid charm or bundle name: $URL`,
 }, {
 	s:   "cs:foo-1-2",
 	err: `URL has invalid charm or bundle name: $URL`,
 }, {
-	s:   "cs:~user/series/huh/name-1",
+	s:   "cs:~user/quantal/huh/name-1",
 	err: `charm or bundle URL has invalid form: $URL`,
 }, {
-	s:   "cs:~user/production/series/name-1",
+	s:   "cs:~user/production/raring/name-1",
+	err: `charm or bundle URL has invalid form: $URL`,
+}, {
+	s:   "cs:~user/development/saucy/badwolf/name-1",
 	err: `charm or bundle URL has invalid form: $URL`,
 }, {
 	s:   "cs:/name",
 	err: `charm or bundle URL has invalid series: $URL`,
 }, {
-	s:   "local:~user/series/name",
+	s:   "local:~user/trusty/name",
 	err: `local charm or bundle URL with user name: $URL`,
 }, {
 	s:   "local:~user/name",
 	err: `local charm or bundle URL with user name: $URL`,
 }, {
 	s:     "precise/wordpress",
-	exact: "cs:precise/wordpress",
+	exact: "cs:wordpress/precise",
 	url:   &charm.URL{"cs", "", "wordpress", -1, "precise"},
 }, {
 	s:     "foo",
@@ -209,7 +220,7 @@ var urlTests = []struct {
 	url:   &charm.URL{"cs", "", "foo", -1, ""},
 }, {
 	s:     "foo-1",
-	exact: "cs:foo-1",
+	exact: "cs:foo/1",
 	url:   &charm.URL{"cs", "", "foo", 1, ""},
 }, {
 	s:     "n0-n0-n0",
@@ -224,15 +235,67 @@ var urlTests = []struct {
 	exact: "local:foo",
 	url:   &charm.URL{"local", "", "foo", -1, ""},
 }, {
-	s:     "series/foo",
-	exact: "cs:series/foo",
-	url:   &charm.URL{"cs", "", "foo", -1, "series"},
+	s:     "vivid/foo",
+	exact: "cs:foo/vivid",
+	url:   &charm.URL{"cs", "", "foo", -1, "vivid"},
 }, {
-	s:   "series/foo/bar",
-	err: `charm or bundle URL has invalid form: "series/foo/bar"`,
+	s:   "wily/foo/bar",
+	err: `charm or bundle URL has invalid form: "wily/foo/bar"`,
 }, {
 	s:   "cs:foo/~blah",
-	err: `URL has invalid charm or bundle name: "cs:foo/~blah"`,
+	err: `charm or bundle URL has invalid series: $URL`,
+}, {
+	s:     "babbageclunk/mysql/xenial/20",
+	exact: "cs:babbageclunk/mysql/xenial/20",
+	url:   &charm.URL{"cs", "babbageclunk", "mysql", 20, "xenial"},
+}, {
+	s:     "babbageclunk/mysql/wily",
+	exact: "cs:babbageclunk/mysql/wily",
+	url:   &charm.URL{"cs", "babbageclunk", "mysql", -1, "wily"},
+}, {
+	s:     "babbageclunk/mysql/10",
+	exact: "cs:babbageclunk/mysql/10",
+	url:   &charm.URL{"cs", "babbageclunk", "mysql", 10, ""},
+}, {
+	s:     "mysql/quantal/15",
+	exact: "cs:mysql/quantal/15",
+	url:   &charm.URL{"cs", "", "mysql", 15, "quantal"},
+}, {
+	s:     "babbageclunk/mysql",
+	exact: "cs:babbageclunk/mysql",
+	url:   &charm.URL{"cs", "babbageclunk", "mysql", -1, ""},
+}, {
+	s:     "mysql/trusty",
+	exact: "cs:mysql/trusty",
+	url:   &charm.URL{"cs", "", "mysql", -1, "trusty"},
+}, {
+	s:     "mysql/15",
+	exact: "cs:mysql/15",
+	url:   &charm.URL{"cs", "", "mysql", 15, ""},
+}, {
+	s:     "mysql",
+	exact: "cs:mysql",
+	url:   &charm.URL{"cs", "", "mysql", -1, ""},
+}, {
+	s:   "wily/mysql/vivid",
+	err: "charm or bundle URL has invalid form: $URL",
+}, {
+	s:   "1",
+	err: `URL has invalid charm or bundle name: $URL`,
+}, {
+	// 	s:   "vivid",
+	// 	err: `URL has invalid charm or bundle name: $URL`,
+	// }, {
+	s:   "vivid/1",
+	err: `URL has invalid charm or bundle name: $URL`,
+}, {
+	s:   "something/nbabbageclunk/mysql/vivid/1",
+	err: "charm or bundle URL has invalid form: $URL",
+}, {
+	// Bundle URLs that come back from the charm store look like this:
+	s:     "cs:bundle/mediawiki-single-1",
+	exact: "cs:mediawiki-single/bundle/1",
+	url:   &charm.URL{"cs", "", "mediawiki-single", 1, "bundle"},
 }}
 
 func (s *URLSuite) TestParseURL(c *gc.C) {
@@ -267,27 +330,27 @@ func (s *URLSuite) TestParseURL(c *gc.C) {
 var inferTests = []struct {
 	vague, exact string
 }{
-	{"foo", "cs:defseries/foo"},
-	{"foo-1", "cs:defseries/foo-1"},
-	{"n0-n0-n0", "cs:defseries/n0-n0-n0"},
-	{"cs:foo", "cs:defseries/foo"},
-	{"local:foo", "local:defseries/foo"},
-	{"series/foo", "cs:series/foo"},
-	{"cs:series/foo", "cs:series/foo"},
-	{"local:series/foo", "local:series/foo"},
-	{"cs:~user/foo", "cs:~user/defseries/foo"},
-	{"cs:~user/series/foo", "cs:~user/series/foo"},
-	{"local:~user/series/foo", "local:~user/series/foo"},
-	{"bs:foo", "bs:defseries/foo"},
-	{"cs:~1/foo", "cs:~1/defseries/foo"},
-	{"cs:foo-1-2", "cs:defseries/foo-1-2"},
+	{"foo", "cs:saucy/foo"},
+	{"foo-1", "cs:saucy/foo-1"},
+	{"n0-n0-n0", "cs:saucy/n0-n0-n0"},
+	{"cs:foo", "cs:saucy/foo"},
+	{"local:foo", "local:saucy/foo"},
+	{"quantal/foo", "cs:quantal/foo"},
+	{"cs:quantal/foo", "cs:quantal/foo"},
+	{"local:quantal/foo", "local:quantal/foo"},
+	{"cs:~user/foo", "cs:~user/saucy/foo"},
+	{"cs:~user/quantal/foo", "cs:~user/quantal/foo"},
+	{"local:~user/quantal/foo", "local:~user/quantal/foo"},
+	{"bs:foo", "bs:saucy/foo"},
+	{"cs:~1/foo", "cs:~1/saucy/foo"},
+	{"cs:foo-1-2", "cs:saucy/foo-1-2"},
 }
 
 func (s *URLSuite) TestInferURL(c *gc.C) {
 	for i, t := range inferTests {
 		c.Logf("test %d", i)
-		comment := gc.Commentf("InferURL(%q, %q)", t.vague, "defseries")
-		inferred, ierr := charm.InferURL(t.vague, "defseries")
+		comment := gc.Commentf("InferURL(%q, %q)", t.vague, "saucy")
+		inferred, ierr := charm.InferURL(t.vague, "saucy")
 		parsed, perr := charm.ParseURL(t.exact)
 		if perr == nil {
 			c.Check(inferred, gc.DeepEquals, parsed, comment)
@@ -302,7 +365,7 @@ func (s *URLSuite) TestInferURL(c *gc.C) {
 			c.Check(ierr.Error(), gc.Matches, expect+".*", comment)
 		}
 	}
-	u, err := charm.InferURL("~blah", "defseries")
+	u, err := charm.InferURL("~blah", "saucy")
 	c.Assert(u, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "URL without charm or bundle name: .*")
 }
@@ -315,9 +378,9 @@ var inferNoDefaultSeriesTests = []struct {
 	{"foo-1", "", false},
 	{"cs:foo", "", false},
 	{"cs:~user/foo", "", false},
-	{"series/foo", "cs:series/foo", true},
-	{"cs:series/foo", "cs:series/foo", true},
-	{"cs:~user/series/foo", "cs:~user/series/foo", true},
+	{"vivid/foo", "cs:vivid/foo", true},
+	{"cs:raring/foo", "cs:raring/foo", true},
+	{"cs:~user/utopic/foo", "cs:~user/utopic/foo", true},
 }
 
 func (s *URLSuite) TestInferURLNoDefaultSeries(c *gc.C) {
@@ -358,11 +421,11 @@ var validTests = []struct {
 	{charm.IsValidSeries, "pre cise", false},
 	{charm.IsValidSeries, "pre-cise", false},
 	{charm.IsValidSeries, "pre^cise", false},
-	{charm.IsValidSeries, "prec1se", true},
+	{charm.IsValidSeries, "prec1se", false},
 	{charm.IsValidSeries, "-precise", false},
 	{charm.IsValidSeries, "precise-", false},
 	{charm.IsValidSeries, "precise-1", false},
-	{charm.IsValidSeries, "precise1", true},
+	{charm.IsValidSeries, "precise1", false},
 	{charm.IsValidSeries, "pre-c1se", false},
 }
 
@@ -374,8 +437,8 @@ func (s *URLSuite) TestValidCheckers(c *gc.C) {
 }
 
 func (s *URLSuite) TestMustParseURL(c *gc.C) {
-	url := charm.MustParseURL("cs:series/name")
-	c.Assert(url, gc.DeepEquals, &charm.URL{"cs", "", "name", -1, "series"})
+	url := charm.MustParseURL("cs:precise/name")
+	c.Assert(url, gc.DeepEquals, &charm.URL{"cs", "", "name", -1, "precise"})
 	f := func() { charm.MustParseURL("local:@@/name") }
 	c.Assert(f, gc.PanicMatches, "charm or bundle URL has invalid series: .*")
 	f = func() { charm.MustParseURL("cs:~user") }
@@ -385,10 +448,10 @@ func (s *URLSuite) TestMustParseURL(c *gc.C) {
 }
 
 func (s *URLSuite) TestWithRevision(c *gc.C) {
-	url := charm.MustParseURL("cs:series/name")
+	url := charm.MustParseURL("cs:raring/name")
 	other := url.WithRevision(1)
-	c.Assert(url, gc.DeepEquals, &charm.URL{"cs", "", "name", -1, "series"})
-	c.Assert(other, gc.DeepEquals, &charm.URL{"cs", "", "name", 1, "series"})
+	c.Assert(url, gc.DeepEquals, &charm.URL{"cs", "", "name", -1, "raring"})
+	c.Assert(other, gc.DeepEquals, &charm.URL{"cs", "", "name", 1, "raring"})
 
 	// Should always copy. The opposite behavior is error prone.
 	c.Assert(other.WithRevision(1), gc.Not(gc.Equals), other)
@@ -419,7 +482,7 @@ func (s *URLSuite) TestURLCodecs(c *gc.C) {
 		type doc struct {
 			URL *charm.URL `json:",omitempty" bson:",omitempty" yaml:",omitempty"`
 		}
-		url := charm.MustParseURL("cs:series/name")
+		url := charm.MustParseURL("cs:quantal/name")
 		v0 := doc{url}
 		data, err := codec.Marshal(v0)
 		c.Assert(err, gc.IsNil)
@@ -435,7 +498,7 @@ func (s *URLSuite) TestURLCodecs(c *gc.C) {
 		var vs strDoc
 		err = codec.Unmarshal(data, &vs)
 		c.Assert(err, gc.IsNil)
-		c.Assert(vs.URL, gc.Equals, "cs:series/name")
+		c.Assert(vs.URL, gc.Equals, "cs:name/quantal")
 
 		data, err = codec.Marshal(doc{})
 		c.Assert(err, gc.IsNil)

--- a/url_test.go
+++ b/url_test.go
@@ -294,7 +294,7 @@ var urlTests = []struct {
 }, {
 	// Bundle URLs that come back from the charm store look like this:
 	s:     "cs:bundle/mediawiki-single-1",
-	exact: "cs:mediawiki-single/bundle/1",
+	exact: "cs:mediawiki-single/1",
 	url:   &charm.URL{"cs", "", "mediawiki-single", 1, "bundle"},
 }}
 


### PR DESCRIPTION
Fixes http://pad.lv/1584193.

The new format is user/name/series/revision, with all of the fields but
name being optional.

In the code this is called the V3 format. V1 is the
cs:~user/series/name-revision format, and V2 are full jujucharms urls
such as https://jujucharms.com/u/aisrael/mysql-benchmark/trusty/5. The
code still supports the old formats for backwards compatibility.

To distinguish between the V2 url series/name and the V3 url user/name
we need to use a list of series from juju/util/series.

The charmstore API doesn't yet support the url format that the UI does,
so url.Path() returns the url in the V1 format so that we can request charm info.
String() returns the preferred V3 format for displaying to the user.

As discussed in the bug, I've suppressed the "bundle" series in the display
version of the url - it's needed in the structure so the deploy command can 
detect bundles and perform different deployment actions.