### PR TITLE
Revert charm url v3

### DIFF
--- a/meta_test.go
+++ b/meta_test.go
@@ -522,12 +522,12 @@ func (s *MetaSuite) TestSeries(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Check(meta.Series, gc.HasLen, 0)
 	charmMeta := fmt.Sprintf("%s\nseries:", dummyMetadata)
-	for _, seriesName := range []string{"precise", "trusty", "centos7"} {
+	for _, seriesName := range []string{"precise", "trusty", "plan9"} {
 		charmMeta = fmt.Sprintf("%s\n    - %s", charmMeta, seriesName)
 	}
 	meta, err = charm.ReadMeta(strings.NewReader(charmMeta))
 	c.Assert(err, gc.IsNil)
-	c.Assert(meta.Series, gc.DeepEquals, []string{"precise", "trusty", "centos7"})
+	c.Assert(meta.Series, gc.DeepEquals, []string{"precise", "trusty", "plan9"})
 }
 
 func (s *MetaSuite) TestInvalidSeries(c *gc.C) {
@@ -885,7 +885,7 @@ extra-bindings:
 categories: [c1, c1]
 tags: [t1, t2]
 series:
-    - saucy
+    - someseries
 resources:
     foo:
         description: 'a description'

--- a/url.go
+++ b/url.go
@@ -52,9 +52,8 @@ const bundleSeries = "bundle"
 
 var (
 	ErrUnresolvedUrl error = errors.Errorf("charm or bundle url series is not resolved")
-
-	validSeries = set.NewStrings(series.SupportedSeries()...).Union(set.NewStrings(bundleSeries))
-	validName   = regexp.MustCompile("^[a-z][a-z0-9]*(-[a-z0-9]*[a-z][a-z0-9]*)*$")
+	validSeries            = set.NewStrings(series.SupportedSeries()...).Union(set.NewStrings(bundleSeries))
+	validName              = regexp.MustCompile("^[a-z][a-z0-9]*(-[a-z0-9]*[a-z][a-z0-9]*)*$")
 )
 
 // ValidateSchema returns an error if the schema is invalid.

--- a/url.go
+++ b/url.go
@@ -12,8 +12,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/utils/series"
-	"github.com/juju/utils/set"
+
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -26,43 +25,35 @@ type Location interface {
 }
 
 // URL represents a charm or bundle location:
-//   Preferred format:
-//     joe/wordpress/trusty/1
-//     joe/wordpress
-//     wordpress/saucy
-//     wordpress/1
 //
-//   Older formats, still accepted:
 //     cs:~joe/oneiric/wordpress
 //     cs:oneiric/wordpress-42
 //     local:oneiric/wordpress
 //     cs:~joe/wordpress
 //     cs:wordpress
 //     cs:precise/wordpress-20
+//     cs:development/precise/wordpress-20
+//     cs:~joe/development/wordpress
 //
 type URL struct {
 	Schema   string // "cs" or "local".
 	User     string // "joe".
 	Name     string // "wordpress".
 	Revision int    // -1 if unset, N otherwise.
-	Series   string // "precise" or "" if unset
+	Series   string // "precise" or "" if unset; "bundle" if it's a bundle.
 }
 
 var ErrUnresolvedUrl error = fmt.Errorf("charm or bundle url series is not resolved")
 
 var (
-	validSeries = set.NewStrings(series.SupportedSeries()...)
+	validSeries = regexp.MustCompile("^[a-z]+([a-z0-9]+)?$")
 	validName   = regexp.MustCompile("^[a-z][a-z0-9]*(-[a-z0-9]*[a-z][a-z0-9]*)*$")
 )
-
-func init() {
-	validSeries.Add("bundle")
-}
 
 // IsValidSeries reports whether series is a valid series in charm or bundle
 // URLs.
 func IsValidSeries(series string) bool {
-	return validSeries.Contains(series)
+	return validSeries.MatchString(series)
 }
 
 // ValidateSeries returns an error if the given series is invalid.
@@ -142,14 +133,14 @@ func ParseURL(url string) (*URL, error) {
 	case u.Opaque != "":
 		// Shortcut old-style URLs.
 		u.Path = u.Opaque
-		curl, err = parseNonWebURL(u, url)
+		curl, err = parseV1URL(u, url)
 	case u.Scheme == "http" || u.Scheme == "https":
-		// Shortcut web URLs.
+		// Shortcut new-style URLs.
 		curl, err = parseV2URL(u)
 	default:
 		// TODO: for now, fall through to parsing v1 references; this will be
 		// expanded to be more robust in the future.
-		curl, err = parseNonWebURL(u, url)
+		curl, err = parseV1URL(u, url)
 	}
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -160,23 +151,6 @@ func ParseURL(url string) (*URL, error) {
 	return curl, nil
 }
 
-func parseNonWebURL(url *gourl.URL, originalURL string) (*URL, error) {
-	parts := strings.Split(url.Path, "/")
-
-	// Special-case to handle ambiguity between series/name (V1) and user/name (V3).
-	if IsValidSeries(parts[0]) {
-		return parseV1URL(url, originalURL)
-	}
-	result, err := parseV3URL(url)
-	if err == nil {
-		return result, err
-	}
-	return parseV1URL(url, originalURL)
-}
-
-// parseV1URL accepts URLs of the form:
-//    cs:~username/series/name-revision
-// Any of the schema, username, series and revision can be omitted.
 func parseV1URL(url *gourl.URL, originalURL string) (*URL, error) {
 	var r URL
 	if url.Scheme != "" {
@@ -243,69 +217,6 @@ func parseV1URL(url *gourl.URL, originalURL string) (*URL, error) {
 	return &r, nil
 }
 
-func convertRevision(revision string, url *gourl.URL) (int, error) {
-	result, err := strconv.Atoi(revision)
-	if err != nil {
-		return -1, fmt.Errorf("charm or bundle URL has malformed revision: %q in %q", revision, url)
-	}
-	return result, nil
-}
-
-func parseV3URL(url *gourl.URL) (*URL, error) {
-	var r URL
-	r.Revision = -1
-	invalidName := errors.Errorf("URL has invalid charm or bundle name: %q", url)
-	unrecognizedParts := errors.Errorf("charm or bundle URL %q has unrecognized parts", url)
-
-	if url.Scheme != "" {
-		r.Schema = url.Scheme
-		if err := ValidateSchema(r.Schema); err != nil {
-			return nil, errors.Annotatef(err, "cannot parse URL %q", url)
-		}
-	}
-
-	parts := strings.Split(url.Path, "/")
-	if len(parts) < 1 {
-		return nil, invalidName
-	}
-	if len(parts) > 4 {
-		return nil, unrecognizedParts
-	}
-
-	last := len(parts) - 1
-	revision, err := strconv.Atoi(parts[last])
-	if err == nil {
-		last -= 1
-		r.Revision = revision
-	}
-	if last >= 0 && IsValidSeries(parts[last]) {
-		r.Series = parts[last]
-		last -= 1
-	}
-
-	// Name is required
-	if last < 0 || !IsValidName(parts[last]) {
-		return nil, invalidName
-	}
-	r.Name = parts[last]
-	last -= 1
-
-	if last >= 0 {
-		if !names.IsValidUser(parts[last]) {
-			return nil, errors.Errorf("charm or bundle URL has invalid user name: %q", url)
-		}
-		r.User = parts[last]
-		last -= 1
-	}
-
-	// Make sure we've used all the components.
-	if last != -1 {
-		return nil, unrecognizedParts
-	}
-
-	return &r, nil
-}
-
 func parseV2URL(url *gourl.URL) (*URL, error) {
 	var r URL
 	r.Schema = "cs"
@@ -351,24 +262,24 @@ func parseV2URL(url *gourl.URL) (*URL, error) {
 	return &r, nil
 }
 
-// Path returns the the path that should be used to request this
-// charm/bundle archive from the charm store. At the moment, this
-// needs to be the old-style ~user/series/name-rev format - the store
-// API doesn't recognise the newer user/name/series/rev urls.
-func (u URL) Path() string {
+func (r *URL) path() string {
 	var parts []string
-	if u.User != "" {
-		parts = append(parts, fmt.Sprintf("~%s", u.User))
+	if r.User != "" {
+		parts = append(parts, fmt.Sprintf("~%s", r.User))
 	}
-	if u.Series != "" {
-		parts = append(parts, u.Series)
+	if r.Series != "" {
+		parts = append(parts, r.Series)
 	}
-	if u.Revision >= 0 {
-		parts = append(parts, fmt.Sprintf("%s-%d", u.Name, u.Revision))
+	if r.Revision >= 0 {
+		parts = append(parts, fmt.Sprintf("%s-%d", r.Name, r.Revision))
 	} else {
-		parts = append(parts, u.Name)
+		parts = append(parts, r.Name)
 	}
 	return strings.Join(parts, "/")
+}
+
+func (r URL) Path() string {
+	return r.path()
 }
 
 // InferURL parses src as a reference, fills out the series in the
@@ -389,22 +300,8 @@ func InferURL(src, defaultSeries string) (*URL, error) {
 	return u, nil
 }
 
-// String returns the charm URL in the newer cs:user/name/series/rev
-// format (where everything except the name are optional).
 func (u URL) String() string {
-	var parts []string
-	if u.User != "" {
-		parts = append(parts, fmt.Sprintf("%s", u.User))
-	}
-	// Name is required.
-	parts = append(parts, u.Name)
-	if u.Series != "" {
-		parts = append(parts, u.Series)
-	}
-	if u.Revision >= 0 {
-		parts = append(parts, fmt.Sprintf("%d", u.Revision))
-	}
-	return fmt.Sprintf("%s:%s", u.Schema, strings.Join(parts, "/"))
+	return fmt.Sprintf("%s:%s", u.Schema, u.Path())
 }
 
 // GetBSON turns u into a bson.Getter so it can be saved directly

--- a/url.go
+++ b/url.go
@@ -43,12 +43,19 @@ type URL struct {
 	Series   string // "precise" or "" if unset; "bundle" if it's a bundle.
 }
 
-var ErrUnresolvedUrl error = fmt.Errorf("charm or bundle url series is not resolved")
-
 var (
-	validSeries = regexp.MustCompile("^[a-z]+([a-z0-9]+)?$")
-	validName   = regexp.MustCompile("^[a-z][a-z0-9]*(-[a-z0-9]*[a-z][a-z0-9]*)*$")
+	ErrUnresolvedUrl error = fmt.Errorf("charm or bundle url series is not resolved")
+	validSeries            = regexp.MustCompile("^[a-z]+([a-z0-9]+)?$")
+	validName              = regexp.MustCompile("^[a-z][a-z0-9]*(-[a-z0-9]*[a-z][a-z0-9]*)*$")
 )
+
+// ValidateSchema returns an error if the schema is invalid.
+func ValidateSchema(schema string) error {
+	if schema != "cs" && schema != "local" {
+		return errors.NotValidf("schema %q", schema)
+	}
+	return nil
+}
 
 // IsValidSeries reports whether series is a valid series in charm or bundle
 // URLs.

--- a/url_test.go
+++ b/url_test.go
@@ -25,37 +25,29 @@ var urlTests = []struct {
 	exact  string
 	url    *charm.URL
 }{{
-	s:     "cs:~user/trusty/name",
-	exact: "cs:user/name/trusty",
-	url:   &charm.URL{"cs", "user", "name", -1, "trusty"},
+	s:   "cs:~user/series/name",
+	url: &charm.URL{"cs", "user", "name", -1, "series"},
 }, {
-	s:     "cs:~user/wily/name-0",
-	exact: "cs:user/name/wily/0",
-	url:   &charm.URL{"cs", "user", "name", 0, "wily"},
+	s:   "cs:~user/series/name-0",
+	url: &charm.URL{"cs", "user", "name", 0, "series"},
 }, {
-	s:     "cs:raring/name",
-	exact: "cs:name/raring",
-	url:   &charm.URL{"cs", "", "name", -1, "raring"},
+	s:   "cs:series/name",
+	url: &charm.URL{"cs", "", "name", -1, "series"},
 }, {
-	s:     "cs:xenial/name-42",
-	exact: "cs:name/xenial/42",
-	url:   &charm.URL{"cs", "", "name", 42, "xenial"},
+	s:   "cs:series/name-42",
+	url: &charm.URL{"cs", "", "name", 42, "series"},
 }, {
-	s:     "local:precise/name-1",
-	exact: "local:name/precise/1",
-	url:   &charm.URL{"local", "", "name", 1, "precise"},
+	s:   "local:series/name-1",
+	url: &charm.URL{"local", "", "name", 1, "series"},
 }, {
-	s:     "local:saucy/name",
-	exact: "local:name/saucy",
-	url:   &charm.URL{"local", "", "name", -1, "saucy"},
+	s:   "local:series/name",
+	url: &charm.URL{"local", "", "name", -1, "series"},
 }, {
-	s:     "local:utopic/n0-0n-n0",
-	exact: "local:n0-0n-n0/utopic",
-	url:   &charm.URL{"local", "", "n0-0n-n0", -1, "utopic"},
+	s:   "local:series/n0-0n-n0",
+	url: &charm.URL{"local", "", "n0-0n-n0", -1, "series"},
 }, {
-	s:     "cs:~user/name",
-	exact: "cs:user/name",
-	url:   &charm.URL{"cs", "user", "name", -1, ""},
+	s:   "cs:~user/name",
+	url: &charm.URL{"cs", "user", "name", -1, ""},
 }, {
 	s:   "cs:name",
 	url: &charm.URL{"cs", "", "name", -1, ""},
@@ -63,81 +55,81 @@ var urlTests = []struct {
 	s:   "local:name",
 	url: &charm.URL{"local", "", "name", -1, ""},
 }, {
-	s:     "http://jujucharms.com/u/user/name/vivid/1",
-	url:   &charm.URL{"cs", "user", "name", 1, "vivid"},
-	exact: "cs:user/name/vivid/1",
+	s:     "http://jujucharms.com/u/user/name/series/1",
+	url:   &charm.URL{"cs", "user", "name", 1, "series"},
+	exact: "cs:~user/series/name-1",
 }, {
-	s:     "http://www.jujucharms.com/u/user/name/precise/1",
-	url:   &charm.URL{"cs", "user", "name", 1, "precise"},
-	exact: "cs:user/name/precise/1",
+	s:     "http://www.jujucharms.com/u/user/name/series/1",
+	url:   &charm.URL{"cs", "user", "name", 1, "series"},
+	exact: "cs:~user/series/name-1",
 }, {
-	s:     "https://www.jujucharms.com/u/user/name/quantal/1",
-	url:   &charm.URL{"cs", "user", "name", 1, "quantal"},
-	exact: "cs:user/name/quantal/1",
+	s:     "https://www.jujucharms.com/u/user/name/series/1",
+	url:   &charm.URL{"cs", "user", "name", 1, "series"},
+	exact: "cs:~user/series/name-1",
 }, {
-	s:     "https://jujucharms.com/u/user/name/raring/1",
-	url:   &charm.URL{"cs", "user", "name", 1, "raring"},
-	exact: "cs:user/name/raring/1",
+	s:     "https://jujucharms.com/u/user/name/series/1",
+	url:   &charm.URL{"cs", "user", "name", 1, "series"},
+	exact: "cs:~user/series/name-1",
 }, {
-	s:     "https://jujucharms.com/u/user/name/saucy",
-	url:   &charm.URL{"cs", "user", "name", -1, "saucy"},
-	exact: "cs:user/name/saucy",
+	s:     "https://jujucharms.com/u/user/name/series",
+	url:   &charm.URL{"cs", "user", "name", -1, "series"},
+	exact: "cs:~user/series/name",
 }, {
 	s:     "https://jujucharms.com/u/user/name/1",
 	url:   &charm.URL{"cs", "user", "name", 1, ""},
-	exact: "cs:user/name/1",
+	exact: "cs:~user/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name",
 	url:   &charm.URL{"cs", "user", "name", -1, ""},
-	exact: "cs:user/name",
+	exact: "cs:~user/name",
 }, {
 	s:     "https://jujucharms.com/name",
 	url:   &charm.URL{"cs", "", "name", -1, ""},
 	exact: "cs:name",
 }, {
-	s:     "https://jujucharms.com/name/utopic",
-	url:   &charm.URL{"cs", "", "name", -1, "utopic"},
-	exact: "cs:name/utopic",
+	s:     "https://jujucharms.com/name/series",
+	url:   &charm.URL{"cs", "", "name", -1, "series"},
+	exact: "cs:series/name",
 }, {
 	s:     "https://jujucharms.com/name/1",
 	url:   &charm.URL{"cs", "", "name", 1, ""},
-	exact: "cs:name/1",
+	exact: "cs:name-1",
 }, {
-	s:     "https://jujucharms.com/name/vivid/1",
-	url:   &charm.URL{"cs", "", "name", 1, "vivid"},
-	exact: "cs:name/vivid/1",
+	s:     "https://jujucharms.com/name/series/1",
+	url:   &charm.URL{"cs", "", "name", 1, "series"},
+	exact: "cs:series/name-1",
 }, {
-	s:     "https://jujucharms.com/u/user/name/wily/1/",
-	url:   &charm.URL{"cs", "user", "name", 1, "wily"},
-	exact: "cs:user/name/wily/1",
+	s:     "https://jujucharms.com/u/user/name/series/1/",
+	url:   &charm.URL{"cs", "user", "name", 1, "series"},
+	exact: "cs:~user/series/name-1",
 }, {
-	s:     "https://jujucharms.com/u/user/name/xenial/",
-	url:   &charm.URL{"cs", "user", "name", -1, "xenial"},
-	exact: "cs:user/name/xenial",
+	s:     "https://jujucharms.com/u/user/name/series/",
+	url:   &charm.URL{"cs", "user", "name", -1, "series"},
+	exact: "cs:~user/series/name",
 }, {
 	s:     "https://jujucharms.com/u/user/name/1/",
 	url:   &charm.URL{"cs", "user", "name", 1, ""},
-	exact: "cs:user/name/1",
+	exact: "cs:~user/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name/",
 	url:   &charm.URL{"cs", "user", "name", -1, ""},
-	exact: "cs:user/name",
+	exact: "cs:~user/name",
 }, {
 	s:     "https://jujucharms.com/name/",
 	url:   &charm.URL{"cs", "", "name", -1, ""},
 	exact: "cs:name",
 }, {
-	s:     "https://jujucharms.com/name/precise/",
-	url:   &charm.URL{"cs", "", "name", -1, "precise"},
-	exact: "cs:name/precise",
+	s:     "https://jujucharms.com/name/series/",
+	url:   &charm.URL{"cs", "", "name", -1, "series"},
+	exact: "cs:series/name",
 }, {
 	s:     "https://jujucharms.com/name/1/",
 	url:   &charm.URL{"cs", "", "name", 1, ""},
-	exact: "cs:name/1",
+	exact: "cs:name-1",
 }, {
-	s:     "https://jujucharms.com/name/quantal/1/",
-	url:   &charm.URL{"cs", "", "name", 1, "quantal"},
-	exact: "cs:name/quantal/1",
+	s:     "https://jujucharms.com/name/series/1/",
+	url:   &charm.URL{"cs", "", "name", 1, "series"},
+	exact: "cs:series/name-1",
 }, {
 	s:   "https://jujucharms.com/",
 	err: `cannot parse URL $URL: name "" not valid`,
@@ -151,68 +143,65 @@ var urlTests = []struct {
 	s:   "https://jujucharms.com/u/badwolf",
 	err: "charm or bundle URL $URL malformed, expected \"/u/<user>/<name>\"",
 }, {
-	s:   "https://jujucharms.com/name/raring/badwolf",
+	s:   "https://jujucharms.com/name/series/badwolf",
 	err: "charm or bundle URL has malformed revision: \"badwolf\" in $URL",
 }, {
-	s:   "https://jujucharms.com/name/badwolf/42",
-	err: `cannot parse URL $URL: series name "badwolf" not valid`,
+	s:   "https://jujucharms.com/name/bad.wolf/42",
+	err: `charm or bundle URL has invalid series: $URL`,
 }, {
-	s:   "https://badwolf@jujucharms.com/name/saucy/42",
+	s:   "https://badwolf@jujucharms.com/name/series/42",
 	err: `charm or bundle URL $URL has unrecognized parts`,
 }, {
-	s:   "https://jujucharms.com/name/trusty/42#bad-wolf",
+	s:   "https://jujucharms.com/name/series/42#bad-wolf",
 	err: `charm or bundle URL $URL has unrecognized parts`,
 }, {
-	s:   "https://jujucharms.com/name//42?bad=wolf",
+	s:   "https://jujucharms.com/name/series/42?bad=wolf",
 	err: `charm or bundle URL $URL has unrecognized parts`,
 }, {
-	s:   "bs:~user/utopic/name-1",
-	err: `cannot parse URL $URL: schema "bs" not valid`,
+	s:   "bs:~user/series/name-1",
+	err: `charm or bundle URL has invalid schema: $URL`,
 }, {
 	s:   ":foo",
 	err: `cannot parse charm or bundle URL: $URL`,
 }, {
-	s:   "cs:~1/vivid/name-1",
+	s:   "cs:~1/series/name-1",
 	err: `charm or bundle URL has invalid user name: $URL`,
 }, {
 	s:   "cs:~user",
 	err: `URL without charm or bundle name: $URL`,
 }, {
-	s:   "cs:~user/unknown/name-1",
-	err: `cannot parse URL $URL: series name "unknown" not valid`,
+	s:   "cs:~user/1/name-1",
+	err: `charm or bundle URL has invalid series: $URL`,
 }, {
-	s:   "cs:~user/wily/name-1-2",
-	err: `cannot parse URL $URL: name "name-1" not valid`,
+	s:   "cs:~user/series/name-1-2",
+	err: `URL has invalid charm or bundle name: $URL`,
 }, {
-	s:   "cs:~user/xenial/name-1-name-2",
-	err: `cannot parse URL $URL: name "name-1-name" not valid`,
+	s:   "cs:~user/series/name-1-name-2",
+	err: `URL has invalid charm or bundle name: $URL`,
 }, {
-	s:   "cs:~user/precise/name--name-2",
-	err: `cannot parse URL $URL: name "name--name" not valid`,
+	s:   "cs:~user/series/name--name-2",
+	err: `URL has invalid charm or bundle name: $URL`,
 }, {
 	s:   "cs:foo-1-2",
 	err: `cannot parse URL $URL: name "foo-1" not valid`,
 }, {
-	s:   "cs:~user/quantal/huh/name-1",
+	s:   "cs:~user/series/huh/name-1",
 	err: `charm or bundle URL has invalid form: $URL`,
 }, {
-	s:   "cs:~user/production/raring/name-1",
-	err: `charm or bundle URL has invalid form: $URL`,
-}, {
-	s:   "cs:~user/development/saucy/badwolf/name-1",
+	s:   "cs:~user/production/series/name-1",
 	err: `charm or bundle URL has invalid form: $URL`,
 }, {
 	s:   "cs:/name",
 	err: `cannot parse URL $URL: series name "" not valid`,
 }, {
-	s:   "local:~user/trusty/name",
+	s:   "local:~user/series/name",
 	err: `local charm or bundle URL with user name: $URL`,
 }, {
 	s:   "local:~user/name",
 	err: `local charm or bundle URL with user name: $URL`,
 }, {
 	s:     "precise/wordpress",
-	exact: "cs:wordpress/precise",
+	exact: "cs:precise/wordpress",
 	url:   &charm.URL{"cs", "", "wordpress", -1, "precise"},
 }, {
 	s:     "foo",
@@ -220,7 +209,7 @@ var urlTests = []struct {
 	url:   &charm.URL{"cs", "", "foo", -1, ""},
 }, {
 	s:     "foo-1",
-	exact: "cs:foo/1",
+	exact: "cs:foo-1",
 	url:   &charm.URL{"cs", "", "foo", 1, ""},
 }, {
 	s:     "n0-n0-n0",
@@ -235,64 +224,15 @@ var urlTests = []struct {
 	exact: "local:foo",
 	url:   &charm.URL{"local", "", "foo", -1, ""},
 }, {
-	s:     "vivid/foo",
-	exact: "cs:foo/vivid",
-	url:   &charm.URL{"cs", "", "foo", -1, "vivid"},
+	s:     "series/foo",
+	exact: "cs:series/foo",
+	url:   &charm.URL{"cs", "", "foo", -1, "series"},
 }, {
-	s:   "wily/foo/bar",
-	err: `charm or bundle URL has invalid form: "wily/foo/bar"`,
+	s:   "series/foo/bar",
+	err: `charm or bundle URL has invalid form: "series/foo/bar"`,
 }, {
 	s:   "cs:foo/~blah",
-	err: `cannot parse URL $URL: series name "foo" not valid`,
-}, {
-	s:     "babbageclunk/mysql/xenial/20",
-	exact: "cs:babbageclunk/mysql/xenial/20",
-	url:   &charm.URL{"cs", "babbageclunk", "mysql", 20, "xenial"},
-}, {
-	s:     "babbageclunk/mysql/wily",
-	exact: "cs:babbageclunk/mysql/wily",
-	url:   &charm.URL{"cs", "babbageclunk", "mysql", -1, "wily"},
-}, {
-	s:     "babbageclunk/mysql/10",
-	exact: "cs:babbageclunk/mysql/10",
-	url:   &charm.URL{"cs", "babbageclunk", "mysql", 10, ""},
-}, {
-	s:     "mysql/quantal/15",
-	exact: "cs:mysql/quantal/15",
-	url:   &charm.URL{"cs", "", "mysql", 15, "quantal"},
-}, {
-	s:     "babbageclunk/mysql",
-	exact: "cs:babbageclunk/mysql",
-	url:   &charm.URL{"cs", "babbageclunk", "mysql", -1, ""},
-}, {
-	s:     "mysql/trusty",
-	exact: "cs:mysql/trusty",
-	url:   &charm.URL{"cs", "", "mysql", -1, "trusty"},
-}, {
-	s:     "mysql/15",
-	exact: "cs:mysql/15",
-	url:   &charm.URL{"cs", "", "mysql", 15, ""},
-}, {
-	s:     "mysql",
-	exact: "cs:mysql",
-	url:   &charm.URL{"cs", "", "mysql", -1, ""},
-}, {
-	s:   "wily/mysql/vivid",
-	err: "charm or bundle URL has invalid form: $URL",
-}, {
-	s:   "1",
-	err: `cannot parse URL $URL: name "1" not valid`,
-}, {
-	s:   "vivid/1",
-	err: `cannot parse URL $URL: name "1" not valid`,
-}, {
-	s:   "something/nbabbageclunk/mysql/vivid/1",
-	err: "charm or bundle URL has invalid form: $URL",
-}, {
-	// Bundle URLs that come back from the charm store look like this:
-	s:     "cs:bundle/mediawiki-single-1",
-	exact: "cs:mediawiki-single/bundle/1",
-	url:   &charm.URL{"cs", "", "mediawiki-single", 1, "bundle"},
+	err: `URL has invalid charm or bundle name: "cs:foo/~blah"`,
 }}
 
 func (s *URLSuite) TestParseURL(c *gc.C) {
@@ -327,27 +267,27 @@ func (s *URLSuite) TestParseURL(c *gc.C) {
 var inferTests = []struct {
 	vague, exact string
 }{
-	{"foo", "cs:saucy/foo"},
-	{"foo-1", "cs:saucy/foo-1"},
-	{"n0-n0-n0", "cs:saucy/n0-n0-n0"},
-	{"cs:foo", "cs:saucy/foo"},
-	{"local:foo", "local:saucy/foo"},
-	{"quantal/foo", "cs:quantal/foo"},
-	{"cs:quantal/foo", "cs:quantal/foo"},
-	{"local:quantal/foo", "local:quantal/foo"},
-	{"cs:~user/foo", "cs:~user/saucy/foo"},
-	{"cs:~user/quantal/foo", "cs:~user/quantal/foo"},
-	{"local:~user/quantal/foo", "local:~user/quantal/foo"},
-	{"bs:foo", "bs:saucy/foo"},
-	{"cs:~1/foo", "cs:~1/saucy/foo"},
-	{"cs:foo-1-2", "cs:saucy/foo-1-2"},
+	{"foo", "cs:defseries/foo"},
+	{"foo-1", "cs:defseries/foo-1"},
+	{"n0-n0-n0", "cs:defseries/n0-n0-n0"},
+	{"cs:foo", "cs:defseries/foo"},
+	{"local:foo", "local:defseries/foo"},
+	{"series/foo", "cs:series/foo"},
+	{"cs:series/foo", "cs:series/foo"},
+	{"local:series/foo", "local:series/foo"},
+	{"cs:~user/foo", "cs:~user/defseries/foo"},
+	{"cs:~user/series/foo", "cs:~user/series/foo"},
+	{"local:~user/series/foo", "local:~user/series/foo"},
+	{"bs:foo", "bs:defseries/foo"},
+	{"cs:~1/foo", "cs:~1/defseries/foo"},
+	{"cs:foo-1-2", "cs:defseries/foo-1-2"},
 }
 
 func (s *URLSuite) TestInferURL(c *gc.C) {
 	for i, t := range inferTests {
 		c.Logf("test %d", i)
-		comment := gc.Commentf("InferURL(%q, %q)", t.vague, "saucy")
-		inferred, ierr := charm.InferURL(t.vague, "saucy")
+		comment := gc.Commentf("InferURL(%q, %q)", t.vague, "defseries")
+		inferred, ierr := charm.InferURL(t.vague, "defseries")
 		parsed, perr := charm.ParseURL(t.exact)
 		if perr == nil {
 			c.Check(inferred, gc.DeepEquals, parsed, comment)
@@ -362,7 +302,7 @@ func (s *URLSuite) TestInferURL(c *gc.C) {
 			c.Check(ierr.Error(), gc.Matches, expect+".*", comment)
 		}
 	}
-	u, err := charm.InferURL("~blah", "saucy")
+	u, err := charm.InferURL("~blah", "defseries")
 	c.Assert(u, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "URL without charm or bundle name: .*")
 }
@@ -375,9 +315,9 @@ var inferNoDefaultSeriesTests = []struct {
 	{"foo-1", "", false},
 	{"cs:foo", "", false},
 	{"cs:~user/foo", "", false},
-	{"vivid/foo", "cs:vivid/foo", true},
-	{"cs:raring/foo", "cs:raring/foo", true},
-	{"cs:~user/utopic/foo", "cs:~user/utopic/foo", true},
+	{"series/foo", "cs:series/foo", true},
+	{"cs:series/foo", "cs:series/foo", true},
+	{"cs:~user/series/foo", "cs:~user/series/foo", true},
 }
 
 func (s *URLSuite) TestInferURLNoDefaultSeries(c *gc.C) {
@@ -418,11 +358,11 @@ var validTests = []struct {
 	{charm.IsValidSeries, "pre cise", false},
 	{charm.IsValidSeries, "pre-cise", false},
 	{charm.IsValidSeries, "pre^cise", false},
-	{charm.IsValidSeries, "prec1se", false},
+	{charm.IsValidSeries, "prec1se", true},
 	{charm.IsValidSeries, "-precise", false},
 	{charm.IsValidSeries, "precise-", false},
 	{charm.IsValidSeries, "precise-1", false},
-	{charm.IsValidSeries, "precise1", false},
+	{charm.IsValidSeries, "precise1", true},
 	{charm.IsValidSeries, "pre-c1se", false},
 }
 
@@ -434,8 +374,8 @@ func (s *URLSuite) TestValidCheckers(c *gc.C) {
 }
 
 func (s *URLSuite) TestMustParseURL(c *gc.C) {
-	url := charm.MustParseURL("cs:precise/name")
-	c.Assert(url, gc.DeepEquals, &charm.URL{"cs", "", "name", -1, "precise"})
+	url := charm.MustParseURL("cs:series/name")
+	c.Assert(url, gc.DeepEquals, &charm.URL{"cs", "", "name", -1, "series"})
 	f := func() { charm.MustParseURL("local:@@/name") }
 	c.Assert(f, gc.PanicMatches, "cannot parse URL \"local:@@/name\": series name \"@@\" not valid")
 	f = func() { charm.MustParseURL("cs:~user") }
@@ -445,10 +385,10 @@ func (s *URLSuite) TestMustParseURL(c *gc.C) {
 }
 
 func (s *URLSuite) TestWithRevision(c *gc.C) {
-	url := charm.MustParseURL("cs:raring/name")
+	url := charm.MustParseURL("cs:series/name")
 	other := url.WithRevision(1)
-	c.Assert(url, gc.DeepEquals, &charm.URL{"cs", "", "name", -1, "raring"})
-	c.Assert(other, gc.DeepEquals, &charm.URL{"cs", "", "name", 1, "raring"})
+	c.Assert(url, gc.DeepEquals, &charm.URL{"cs", "", "name", -1, "series"})
+	c.Assert(other, gc.DeepEquals, &charm.URL{"cs", "", "name", 1, "series"})
 
 	// Should always copy. The opposite behavior is error prone.
 	c.Assert(other.WithRevision(1), gc.Not(gc.Equals), other)
@@ -479,7 +419,7 @@ func (s *URLSuite) TestURLCodecs(c *gc.C) {
 		type doc struct {
 			URL *charm.URL `json:",omitempty" bson:",omitempty" yaml:",omitempty"`
 		}
-		url := charm.MustParseURL("cs:quantal/name")
+		url := charm.MustParseURL("cs:series/name")
 		v0 := doc{url}
 		data, err := codec.Marshal(v0)
 		c.Assert(err, gc.IsNil)
@@ -495,7 +435,7 @@ func (s *URLSuite) TestURLCodecs(c *gc.C) {
 		var vs strDoc
 		err = codec.Unmarshal(data, &vs)
 		c.Assert(err, gc.IsNil)
-		c.Assert(vs.URL, gc.Equals, "cs:name/quantal")
+		c.Assert(vs.URL, gc.Equals, "cs:series/name")
 
 		data, err = codec.Marshal(doc{})
 		c.Assert(err, gc.IsNil)
@@ -512,11 +452,6 @@ func (s *URLSuite) TestJSONGarbage(c *gc.C) {
 		err := json.Unmarshal([]byte(value), new(struct{ URL *charm.URL }))
 		c.Check(err, gc.NotNil)
 	}
-}
-
-func (*URLSuite) TestPath(c *gc.C) {
-	c.Check(charm.MustParseURL("cs:user/name/quantal/4").Path(), gc.Equals, "~user/quantal/name-4")
-	c.Check(charm.MustParseURL("cs:user/name/quantal").Path(), gc.Equals, "~user/quantal/name")
 }
 
 type QuoteSuite struct{}

--- a/url_test.go
+++ b/url_test.go
@@ -291,7 +291,7 @@ var urlTests = []struct {
 }, {
 	// Bundle URLs that come back from the charm store look like this:
 	s:     "cs:bundle/mediawiki-single-1",
-	exact: "cs:mediawiki-single/1",
+	exact: "cs:mediawiki-single/bundle/1",
 	url:   &charm.URL{"cs", "", "mediawiki-single", 1, "bundle"},
 }}
 

--- a/url_test.go
+++ b/url_test.go
@@ -147,7 +147,7 @@ var urlTests = []struct {
 	err: "charm or bundle URL has malformed revision: \"badwolf\" in $URL",
 }, {
 	s:   "https://jujucharms.com/name/bad.wolf/42",
-	err: `charm or bundle URL has invalid series: $URL`,
+	err: `cannot parse URL $URL: series name "bad.wolf" not valid`,
 }, {
 	s:   "https://badwolf@jujucharms.com/name/series/42",
 	err: `charm or bundle URL $URL has unrecognized parts`,
@@ -159,7 +159,7 @@ var urlTests = []struct {
 	err: `charm or bundle URL $URL has unrecognized parts`,
 }, {
 	s:   "bs:~user/series/name-1",
-	err: `charm or bundle URL has invalid schema: $URL`,
+	err: `cannot parse URL $URL: schema "bs" not valid`,
 }, {
 	s:   ":foo",
 	err: `cannot parse charm or bundle URL: $URL`,
@@ -171,16 +171,16 @@ var urlTests = []struct {
 	err: `URL without charm or bundle name: $URL`,
 }, {
 	s:   "cs:~user/1/name-1",
-	err: `charm or bundle URL has invalid series: $URL`,
+	err: `cannot parse URL $URL: series name "1" not valid`,
 }, {
 	s:   "cs:~user/series/name-1-2",
-	err: `URL has invalid charm or bundle name: $URL`,
+	err: `cannot parse URL $URL: name "name-1" not valid`,
 }, {
 	s:   "cs:~user/series/name-1-name-2",
-	err: `URL has invalid charm or bundle name: $URL`,
+	err: `cannot parse URL $URL: name "name-1-name" not valid`,
 }, {
 	s:   "cs:~user/series/name--name-2",
-	err: `URL has invalid charm or bundle name: $URL`,
+	err: `cannot parse URL $URL: name "name--name" not valid`,
 }, {
 	s:   "cs:foo-1-2",
 	err: `cannot parse URL $URL: name "foo-1" not valid`,
@@ -232,7 +232,7 @@ var urlTests = []struct {
 	err: `charm or bundle URL has invalid form: "series/foo/bar"`,
 }, {
 	s:   "cs:foo/~blah",
-	err: `URL has invalid charm or bundle name: "cs:foo/~blah"`,
+	err: `cannot parse URL $URL: name "~blah" not valid`,
 }}
 
 func (s *URLSuite) TestParseURL(c *gc.C) {


### PR DESCRIPTION
This functionality is not in the charmstore and not yet consumed by Juju. Because the charmstore doesn't support v3 URLs yet, Juju cannot easily consume new versions of this library. For that reason, the v3 URL support is being forked and then reverted in this branch.