### PR TITLE
Add ActionSpec parameter to describe if an action is non-blocking.

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -35,6 +35,7 @@ func NewActions() *Actions {
 // http://json-schema.org/draft-04/schema# (see http://json-schema.org/latest/json-schema-core.html)
 type ActionSpec struct {
 	Description string
+	NonBlocking bool
 	Params      map[string]interface{}
 }
 
@@ -117,6 +118,7 @@ func ReadActionsYaml(r io.Reader) (*Actions, error) {
 		}
 
 		desc := "No description"
+		nonBlocking := false
 		thisActionSchema := map[string]interface{}{
 			"description": desc,
 			"type":        "object",
@@ -141,6 +143,13 @@ func ReadActionsYaml(r io.Reader) (*Actions, error) {
 					return nil, errors.Errorf("value for schema key %q must be a string", key)
 				}
 				thisActionSchema[key] = typed
+			case "nonblocking":
+				// These fields must be a YAML boolean
+				typed, ok := value.(bool)
+				if !ok {
+					return nil, errors.Errorf("value for schema key %q must be a YAML boolean", key)
+				}
+				nonBlocking = typed
 			case "required":
 				typed, ok := value.([]interface{})
 				if !ok {
@@ -182,6 +191,7 @@ func ReadActionsYaml(r io.Reader) (*Actions, error) {
 		// Now assign the resulting schema to the final entry for the result.
 		result.ActionSpecs[name] = ActionSpec{
 			Description: desc,
+			NonBlocking: nonBlocking,
 			Params:      thisActionSchema,
 		}
 	}

--- a/actions_test.go
+++ b/actions_test.go
@@ -315,6 +315,7 @@ func (s *ActionsSuite) TestReadGoodActionsYaml(c *gc.C) {
 		yaml: `
 snapshot:
    description: Take a snapshot of the database.
+   nonblocking: true
    params:
       outfile:
          description: "The file to write out to."
@@ -324,6 +325,7 @@ snapshot:
 		expectedActions: &Actions{map[string]ActionSpec{
 			"snapshot": {
 				Description: "Take a snapshot of the database.",
+				NonBlocking: true,
 				Params: map[string]interface{}{
 					"title":       "snapshot",
 					"description": "Take a snapshot of the database.",
@@ -344,6 +346,7 @@ snapshot:
 		yaml: `
 snapshot:
    description: "Take a snapshot of the database."
+   nonblocking: false
    params:
       outfile:
          description: "The file to write out to."
@@ -413,6 +416,7 @@ remote-sync:
 		yaml: `
 snapshot:
    description: "Take a snapshot of the database."
+   nonblocking: false
    params:
       outfile:
          description: "The file to write out to."
@@ -430,6 +434,7 @@ snapshot:
 		expectedActions: &Actions{map[string]ActionSpec{
 			"snapshot": {
 				Description: "Take a snapshot of the database.",
+				NonBlocking: false,
 				Params: map[string]interface{}{
 					"title":       "snapshot",
 					"description": "Take a snapshot of the database.",
@@ -656,8 +661,19 @@ snapshot:
    other-key: ["some", "values"],
 `,
 		expectedError: "yaml: line 16: did not find expected key",
+	}, {
+		description: "A schema with an empty \"params\" key fails to parse",
+		yaml: `
+snapshot:
+   description: Take a snapshot of the database.
+   nonblocking: 5
+   params:
+     outfile:
+         description: "The file to write out to."
+         type: "string"
+`,
+		expectedError: "value for schema key \"nonblocking\" must be a YAML boolean",
 	}}
-
 	for i, test := range badActionsYamlTests {
 		c.Logf("test %d: %s", i, test.description)
 		reader := bytes.NewReader([]byte(test.yaml))


### PR DESCRIPTION
Actions can now be specified as `blocking` the default or `non-blocking` with the default `blocking`. This is controlled by setting a property `NonBlocking: true`, for example, in an action's specification in a charm definition.   