### PR TITLE
Add local resource paths to applications specs.

### DIFF
--- a/bundledata.go
+++ b/bundledata.go
@@ -154,7 +154,7 @@ type ApplicationSpec struct {
 	// Resources is the set of resource revisions to deploy for the
 	// application. Bundles only support charm store resources and not ones
 	// that were uploaded to the controller.
-	Resources map[string]int `bson:",omitempty" yaml:",omitempty" json:",omitempty"`
+	Resources map[string]interface{} `bson:",omitempty" yaml:",omitempty" json:",omitempty"`
 
 	// NumUnits holds the number of units of the
 	// application that will be deployed.

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -62,6 +62,8 @@ applications:
         constraints: "mem=8g"
         bindings:
             db: db
+        resources:
+            data: "resources/data.tar"
 relations:
     - ["mediawiki:db", "mysql:db"]
     - ["mysql:foo", "mediawiki:bar"]
@@ -110,7 +112,7 @@ var parseTests = []struct {
 					"db":      "db",
 					"website": "public",
 				},
-				Resources: map[string]int{
+				Resources: map[string]interface{}{
 					"data": 3,
 				},
 			},
@@ -134,6 +136,7 @@ var parseTests = []struct {
 				EndpointBindings: map[string]string{
 					"db": "db",
 				},
+				Resources: map[string]interface{}{"data": "resources/data.tar"},
 			},
 		},
 		Machines: map[string]*charm.MachineSpec{
@@ -241,6 +244,15 @@ func (*bundleDataSuite) TestCodecRoundTrip(c *gc.C) {
 			var bd charm.BundleData
 			err = codec.Unmarshal(data, &bd)
 			c.Assert(err, gc.IsNil)
+
+			for _, app := range bd.Applications {
+				for resName, res := range app.Resources {
+					if val, ok := res.(float64); ok {
+						app.Resources[resName] = int(val)
+					}
+				}
+			}
+
 			c.Assert(&bd, jc.DeepEquals, test.expectedBD)
 		}
 	}


### PR DESCRIPTION
Charmers can now specify a path for the value of the resource property.