### PR TITLE
Add git info to the zip file in local charm deployments.

### DIFF
--- a/charmdir.go
+++ b/charmdir.go
@@ -228,7 +228,7 @@ func (zp *zipPacker) visit(path string, fi os.FileInfo, err error) error {
 		if relpath == "build" {
 			return filepath.SkipDir
 		}
-		if hidden {
+		if hidden && !strings.HasPrefix(relpath, ".git") {
 			return filepath.SkipDir
 		}
 		relpath += "/"
@@ -242,7 +242,7 @@ func (zp *zipPacker) visit(path string, fi os.FileInfo, err error) error {
 	if mode&os.ModeSymlink != 0 {
 		method = zip.Store
 	}
-	if hidden || relpath == "revision" {
+	if hidden && !strings.HasPrefix(relpath, ".git") || relpath == "revision" {
 		return nil
 	}
 	h := &zip.FileHeader{


### PR DESCRIPTION
This pull request attempt to facilitate the debugging of local charm deployments
including the git info on the zip file, making it easy to spot if there is any local difference
in the charm in place, or allowing to push new changes from the local debugging environment.

Signed-off-by: José Pekkarinen <jose.pekkarinen@canonical.com>