### PR TITLE
move to v6

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -192,7 +192,6 @@ func ReadActionsYaml(r io.Reader) (*Actions, error) {
 // strings, and coerces acceptable maps to contain only maps with string keys.
 func cleanse(input interface{}) (interface{}, error) {
 	switch typedInput := input.(type) {
-
 	// In this case, recurse in.
 	case map[string]interface{}:
 		newMap := make(map[string]interface{})

--- a/bundle_test.go
+++ b/bundle_test.go
@@ -8,7 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charm.v6"
 )
 
 var _ = gc.Suite(&BundleSuite{})

--- a/bundlearchive_test.go
+++ b/bundlearchive_test.go
@@ -11,7 +11,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charm.v6"
 )
 
 var _ = gc.Suite(&BundleArchiveSuite{})

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -15,7 +15,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2/bson"
 
-	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charm.v6"
 )
 
 type bundleDataSuite struct {

--- a/bundledir_test.go
+++ b/bundledir_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charm.v6"
 )
 
 type BundleDirSuite struct {

--- a/charm_test.go
+++ b/charm_test.go
@@ -17,7 +17,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 
-	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charm.v6"
 )
 
 func Test(t *stdtesting.T) {

--- a/charmarchive_test.go
+++ b/charmarchive_test.go
@@ -19,7 +19,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 
-	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charm.v6"
 )
 
 type CharmArchiveSuite struct {

--- a/charmdir_test.go
+++ b/charmdir_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charm.v6"
 )
 
 type CharmDirSuite struct {

--- a/config_test.go
+++ b/config_test.go
@@ -12,7 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 
-	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charm.v6"
 )
 
 type ConfigSuite struct {

--- a/extra_bindings_test.go
+++ b/extra_bindings_test.go
@@ -7,7 +7,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charm.v6"
 )
 
 var _ = gc.Suite(&extraBindingsSuite{})

--- a/meta.go
+++ b/meta.go
@@ -18,8 +18,8 @@ import (
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/yaml.v2"
 
-	"gopkg.in/juju/charm.v6-unstable/hooks"
-	"gopkg.in/juju/charm.v6-unstable/resource"
+	"gopkg.in/juju/charm.v6/hooks"
+	"gopkg.in/juju/charm.v6/resource"
 )
 
 // RelationScope describes the scope of a relation.

--- a/meta_test.go
+++ b/meta_test.go
@@ -18,8 +18,8 @@ import (
 	"gopkg.in/yaml.v2"
 	yamlv2 "gopkg.in/yaml.v2"
 
-	"gopkg.in/juju/charm.v6-unstable"
-	"gopkg.in/juju/charm.v6-unstable/resource"
+	"gopkg.in/juju/charm.v6"
+	"gopkg.in/juju/charm.v6/resource"
 )
 
 func repoMeta(c *gc.C, name string) io.Reader {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -9,7 +9,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charm.v6"
 )
 
 // Keys returns a list of all defined metrics keys.

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -7,7 +7,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charm.v6"
 )
 
 var _ = gc.Suite(&payloadClassSuite{})

--- a/resource/fingerprint_test.go
+++ b/resource/fingerprint_test.go
@@ -12,7 +12,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/juju/charm.v6-unstable/resource"
+	"gopkg.in/juju/charm.v6/resource"
 )
 
 func newFingerprint(c *gc.C, data string) ([]byte, string) {

--- a/resource/meta_test.go
+++ b/resource/meta_test.go
@@ -8,7 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/juju/charm.v6-unstable/resource"
+	"gopkg.in/juju/charm.v6/resource"
 )
 
 var _ = gc.Suite(&MetaSuite{})

--- a/resource/origin_test.go
+++ b/resource/origin_test.go
@@ -9,7 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/juju/charm.v6-unstable/resource"
+	"gopkg.in/juju/charm.v6/resource"
 )
 
 type OriginSuite struct {

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -8,7 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/juju/charm.v6-unstable/resource"
+	"gopkg.in/juju/charm.v6/resource"
 )
 
 var fingerprint = []byte("123456789012345678901234567890123456789012345678")

--- a/resource/type_test.go
+++ b/resource/type_test.go
@@ -8,7 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/juju/charm.v6-unstable/resource"
+	"gopkg.in/juju/charm.v6/resource"
 )
 
 var _ = gc.Suite(&TypeSuite{})

--- a/resources.go
+++ b/resources.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/schema"
 
-	"gopkg.in/juju/charm.v6-unstable/resource"
+	"gopkg.in/juju/charm.v6/resource"
 )
 
 var resourceSchema = schema.FieldMap(

--- a/resources_test.go
+++ b/resources_test.go
@@ -7,7 +7,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charm.v6"
 )
 
 var _ = gc.Suite(&resourceSuite{})

--- a/url_test.go
+++ b/url_test.go
@@ -13,7 +13,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/yaml.v2"
 
-	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charm.v6"
 )
 
 type URLSuite struct{}


### PR DESCRIPTION
Move to stable v6 branch. This is an entirely automated change, made by running:

     govers gopkg.in/juju/charm.v6
