### PR TITLE
1640223 action name numeric characters

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -17,7 +17,7 @@ import (
 
 var prohibitedSchemaKeys = map[string]bool{"$ref": true, "$schema": true}
 
-var actionNameRule = regexp.MustCompile("^[a-z](?:[a-z-]*[a-z])?$")
+var actionNameRule = regexp.MustCompile("^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
 
 // Actions defines the available actions for the charm.  Additional params
 // may be added as metadata at a future time (e.g. version.)

--- a/actions_test.go
+++ b/actions_test.go
@@ -485,6 +485,29 @@ snapshot:
 					"type":        "object",
 					"properties":  map[string]interface{}{},
 				}}}},
+	}, {
+		description: "A simple snapshot actions YAML with numeric characters.",
+		yaml: `
+snapshot-01:
+   description: Take database first snapshot.
+   params:
+      outfile-01:
+         description: "The file to write out to."
+         type: string
+   required: ["outfile"]
+`,
+		expectedActions: &Actions{map[string]ActionSpec{
+			"snapshot-01": {
+				Description: "Take database first snapshot.",
+				Params: map[string]interface{}{
+					"title":       "snapshot-01",
+					"description": "Take database first snapshot.",
+					"type":        "object",
+					"properties": map[string]interface{}{
+						"outfile-01": map[string]interface{}{
+							"description": "The file to write out to.",
+							"type":        "string"}},
+					"required": []interface{}{"outfile"}}}}},
 	}}
 
 	// Beginning of testing loop


### PR DESCRIPTION
[Launchpad 1640223](https://bugs.launchpad.net/juju/+bug/1640223)

  - [x] Create test to check numeric characters in names. 
  - [x] Modify `actionNameRule` to allow numeric characters. 
