### PR TITLE
1640223 action name get function

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -19,7 +19,12 @@ var prohibitedSchemaKeys = map[string]bool{"$ref": true, "$schema": true}
 
 var actionNameRule = regexp.MustCompile("^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
 
-// Actions defines the available actions for the charm.  Additional params
+// Export `actionNameRule` variable to different contexts.
+func GetActionNameRule() *regexp.Regexp {
+	return actionNameRule
+}
+
+// Actions defines the available actions for the charm. Additional params
 // may be added as metadata at a future time (e.g. version.)
 type Actions struct {
 	ActionSpecs map[string]ActionSpec `yaml:"actions,omitempty" bson:",omitempty"`

--- a/actions_test.go
+++ b/actions_test.go
@@ -486,7 +486,7 @@ snapshot:
 					"properties":  map[string]interface{}{},
 				}}}},
 	}, {
-		description: "A simple snapshot actions YAML with numeric characters.",
+		description: "A simple snapshot actions YAML ending characters.",
 		yaml: `
 snapshot-01:
    description: Take database first snapshot.
@@ -505,6 +505,29 @@ snapshot-01:
 					"type":        "object",
 					"properties": map[string]interface{}{
 						"outfile-01": map[string]interface{}{
+							"description": "The file to write out to.",
+							"type":        "string"}},
+					"required": []interface{}{"outfile"}}}}},
+	}, {
+		description: "A simple snapshot actions YAML starting characters.",
+		yaml: `
+01-snapshot:
+   description: Take database first snapshot.
+   params:
+      01-outfile:
+         description: "The file to write out to."
+         type: string
+   required: ["outfile"]
+`,
+		expectedActions: &Actions{map[string]ActionSpec{
+			"01-snapshot": {
+				Description: "Take database first snapshot.",
+				Params: map[string]interface{}{
+					"title":       "01-snapshot",
+					"description": "Take database first snapshot.",
+					"type":        "object",
+					"properties": map[string]interface{}{
+						"01-outfile": map[string]interface{}{
 							"description": "The file to write out to.",
 							"type":        "string"}},
 					"required": []interface{}{"outfile"}}}}},
@@ -800,7 +823,7 @@ act:
   params:
     val:
       type: object
-      properties: 
+      properties:
         var:
           type: object
           properties:

--- a/actions_test.go
+++ b/actions_test.go
@@ -305,6 +305,23 @@ func (s *ActionsSuite) TestCleanseFail(c *gc.C) {
 	}
 }
 
+func (s *ActionsSuite) TestGetActionNameRule(c *gc.C) {
+
+	var regExCheck = [] struct {
+		description string
+		regExString string
+	}{{
+		description: "Check returned actionNameRule regex",
+		regExString: "^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$",
+	}}
+
+	for i, t := range regExCheck {
+		c.Logf("test %d: %v: %#v\n", i, t.description, t.regExString)
+		obtained := GetActionNameRule()
+		c.Assert(obtained.String(), gc.Equals, t.regExString)
+	}
+}
+
 func (s *ActionsSuite) TestReadGoodActionsYaml(c *gc.C) {
 	var goodActionsYamlTests = []struct {
 		description     string

--- a/actions_test.go
+++ b/actions_test.go
@@ -307,7 +307,7 @@ func (s *ActionsSuite) TestCleanseFail(c *gc.C) {
 
 func (s *ActionsSuite) TestGetActionNameRule(c *gc.C) {
 
-	var regExCheck = [] struct {
+	var regExCheck = []struct {
 		description string
 		regExString string
 	}{{
@@ -503,7 +503,7 @@ snapshot:
 					"properties":  map[string]interface{}{},
 				}}}},
 	}, {
-		description: "A simple snapshot actions YAML ending characters.",
+		description: "A simple snapshot actions YAML with names ending characters.",
 		yaml: `
 snapshot-01:
    description: Take database first snapshot.
@@ -526,7 +526,7 @@ snapshot-01:
 							"type":        "string"}},
 					"required": []interface{}{"outfile"}}}}},
 	}, {
-		description: "A simple snapshot actions YAML containing characters.",
+		description: "A simple snapshot actions YAML with names containing characters.",
 		yaml: `
 snapshot-0-foo:
    description: Take database first snapshot.
@@ -549,7 +549,7 @@ snapshot-0-foo:
 							"type":        "string"}},
 					"required": []interface{}{"outfile"}}}}},
 	}, {
-		description: "A simple snapshot actions YAML starting characters.",
+		description: "A simple snapshot actions YAML with names starting characters.",
 		yaml: `
 01-snapshot:
    description: Take database first snapshot.

--- a/actions_test.go
+++ b/actions_test.go
@@ -509,6 +509,29 @@ snapshot-01:
 							"type":        "string"}},
 					"required": []interface{}{"outfile"}}}}},
 	}, {
+		description: "A simple snapshot actions YAML containing characters.",
+		yaml: `
+snapshot-0-foo:
+   description: Take database first snapshot.
+   params:
+      outfile:
+         description: "The file to write out to."
+         type: string
+   required: ["outfile"]
+`,
+		expectedActions: &Actions{map[string]ActionSpec{
+			"snapshot-0-foo": {
+				Description: "Take database first snapshot.",
+				Params: map[string]interface{}{
+					"title":       "snapshot-0-foo",
+					"description": "Take database first snapshot.",
+					"type":        "object",
+					"properties": map[string]interface{}{
+						"outfile": map[string]interface{}{
+							"description": "The file to write out to.",
+							"type":        "string"}},
+					"required": []interface{}{"outfile"}}}}},
+	}, {
 		description: "A simple snapshot actions YAML starting characters.",
 		yaml: `
 01-snapshot:


### PR DESCRIPTION
[LP 1640223](https://bugs.launchpad.net/juju/+bug/1640223)

Variable `actionNameRule` is needed inside juju's repository
packages. By directly importing the variable in the juju package,
the code losses readability due to the fact that it doesn't
specify the origin of the variable.

With a function the intent of importing the variable from a different
scope is more clear.

  - [x] Code in `juju/juju/cmd/juju/action/run.go` without function `GetActionNameRule`:

          var keyRule = actionNameRule

    This passed the tests. But it doesn't specify what is actionNameRule nor where does it come from.

  - [x] Code in `juju/juju/cmd/juju/action/run.go` with function `GetActionNameRule`:

         import (
		    ...
            "gopkg.in/juju/charm.v6"
	        ...
         )

         var keyRule *regexp.Regexp = charm.GetActionNameRule()

   Here it explicitly imports `charm.v6` package and it specifies that `keyRule` will be a pointer to a regular expression. And it passes the tests. 

