### PR TITLE
Only check file details for the filetype.

### DIFF
--- a/resource/resource.go
+++ b/resource/resource.go
@@ -40,8 +40,10 @@ func (res Resource) Validate() error {
 		return errors.Annotate(err, "bad revision")
 	}
 
-	if err := res.validateFileInfo(); err != nil {
-		return errors.Annotate(err, "bad file info")
+	if res.Type == TypeFile {
+		if err := res.validateFileInfo(); err != nil {
+			return errors.Annotate(err, "bad file info")
+		}
 	}
 
 	return nil

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -182,6 +182,21 @@ func (s *ResourceSuite) TestValidateMissingFingerprint(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `bad file info: missing fingerprint`)
 }
 
+func (s *ResourceSuite) TestValidateDockerType(c *gc.C) {
+	res := resource.Resource{
+		Meta: resource.Meta{
+			Name:        "my-resource",
+			Type:        resource.TypeDocker,
+			Description: "One line that is useful when operators need to push it.",
+		},
+		Origin:   resource.OriginStore,
+		Revision: 1,
+	}
+	err := res.Validate()
+
+	c.Check(err, jc.ErrorIsNil)
+}
+
 func (s *ResourceSuite) TestValidateBadSize(c *gc.C) {
 	fp, err := resource.NewFingerprint(fingerprint)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
When dealing with Docker resource types we don't need to validate the file details.