### PR TITLE
url: allow ending slash in ParseURL

### DIFF
--- a/url.go
+++ b/url.go
@@ -127,6 +127,9 @@ func MustParseURL(url string) *URL {
 //
 // A missing schema is assumed to be 'cs'.
 func ParseURL(url string) (*URL, error) {
+
+	url = strings.TrimSuffix(url, "/")
+
 	// Check if we're dealing with a v1 or v2 URL.
 	u, err := gourl.Parse(url)
 	if err != nil {

--- a/url_test.go
+++ b/url_test.go
@@ -245,7 +245,7 @@ func (s *URLSuite) TestParseURL(c *gc.C) {
 		}
 		url, uerr := charm.ParseURL(t.s)
 		if t.err != "" {
-			t.err = strings.Replace(t.err, "$URL", regexp.QuoteMeta(fmt.Sprintf("%q", t.s)), -1)
+			t.err = strings.Replace(t.err, "$URL", regexp.QuoteMeta(fmt.Sprintf("%q", strings.TrimSuffix(t.s, "/"))), -1)
 			c.Check(uerr, gc.ErrorMatches, t.err)
 			c.Check(url, gc.IsNil)
 			continue


### PR DESCRIPTION
Bug: https://github.com/juju/charmstore-client/issues/40