### PR TITLE
Rename docker to oci-image for resources.

### DIFF
--- a/meta_test.go
+++ b/meta_test.go
@@ -1335,7 +1335,7 @@ resources:
         type: file
         filename: other.zip
     image-resource:
-         type: docker
+         type: oci-image
          description: "An image"
 `))
 	c.Assert(err, gc.IsNil)
@@ -1354,7 +1354,7 @@ resources:
 		},
 		"image-resource": {
 			Name:        "image-resource",
-			Type:        resource.TypeDocker,
+			Type:        resource.TypeContainerImage,
 			Description: "An image",
 		},
 	})

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -186,7 +186,7 @@ func (s *ResourceSuite) TestValidateDockerType(c *gc.C) {
 	res := resource.Resource{
 		Meta: resource.Meta{
 			Name:        "my-resource",
-			Type:        resource.TypeDocker,
+			Type:        resource.TypeContainerImage,
 			Description: "One line that is useful when operators need to push it.",
 		},
 		Origin:   resource.OriginStore,

--- a/resource/type.go
+++ b/resource/type.go
@@ -11,12 +11,12 @@ import (
 const (
 	typeUnknown Type = iota
 	TypeFile
-	TypeDocker
+	TypeContainerImage
 )
 
 var types = map[Type]string{
-	TypeFile:  "file",
-	TypeDocker: "docker",
+	TypeFile:           "file",
+	TypeContainerImage: "oci-image",
 }
 
 // Type enumerates the recognized resource types.

--- a/resource/type_test.go
+++ b/resource/type_test.go
@@ -16,18 +16,11 @@ var _ = gc.Suite(&TypeSuite{})
 type TypeSuite struct{}
 
 func (s *TypeSuite) TestParseTypeOkay(c *gc.C) {
-	rt, err := resource.ParseType("file")
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Check(rt, gc.Equals, resource.TypeFile)
-}
-
-func (s *TypeSuite) TestParseTypeRecognized(c *gc.C) {
-	supported := []resource.Type{
-		resource.TypeFile,
-	}
-	for _, expected := range supported {
-		rt, err := resource.ParseType(expected.String())
+	for resourceType, expected := range map[string]resource.Type{
+		"file":      resource.TypeFile,
+		"oci-image": resource.TypeContainerImage,
+	} {
+		rt, err := resource.ParseType(resourceType)
 		c.Assert(err, jc.ErrorIsNil)
 
 		c.Check(rt, gc.Equals, expected)
@@ -52,7 +45,8 @@ func (s *TypeSuite) TestParseTypeUnsupported(c *gc.C) {
 
 func (s *TypeSuite) TestTypeStringSupported(c *gc.C) {
 	supported := map[resource.Type]string{
-		resource.TypeFile: "file",
+		resource.TypeFile:           "file",
+		resource.TypeContainerImage: "oci-image",
 	}
 	for rt, expected := range supported {
 		str := rt.String()
@@ -71,6 +65,7 @@ func (s *TypeSuite) TestTypeStringUnknown(c *gc.C) {
 func (s *TypeSuite) TestTypeValidateSupported(c *gc.C) {
 	supported := []resource.Type{
 		resource.TypeFile,
+		resource.TypeContainerImage,
 	}
 	for _, rt := range supported {
 		err := rt.Validate()


### PR DESCRIPTION
Renames the resource name that is exposed to charm authors from docker to oci-image.