### PR TITLE
Ensure paths in charm archives use /

### DIFF
--- a/charmdir.go
+++ b/charmdir.go
@@ -231,6 +231,10 @@ func (zp *zipPacker) visit(path string, fi os.FileInfo, err error) error {
 	if err != nil {
 		return err
 	}
+	// Replace any Windows path separators with "/".
+	// zip file spec 4.4.17.1 says that separators are always "/" even on Windows.
+	relpath = filepath.ToSlash(relpath)
+
 	method := zip.Deflate
 	hidden := len(relpath) > 1 && relpath[0] == '.'
 	if fi.IsDir() {


### PR DESCRIPTION
When making a charm (zip) archive from a local charm directory, any relative paths on Windows contain the Windows path separator. Convert to "/" before adding to the archive as per zip file spec 4.4.17.1