### PR TITLE
WIP: add lxdprofilecharm interface

### DIFF
--- a/charm_test.go
+++ b/charm_test.go
@@ -123,6 +123,21 @@ func checkDummy(c *gc.C, f charm.Charm, path string) {
 								"type":        "string",
 								"default":     "foo.bz2",
 							}}}}}})
+	lpc, ok := f.(charm.LXDProfiler)
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(lpc.LXDProfile(), jc.DeepEquals, &charm.LXDProfile{
+			Config: map[string]string{
+				"security.nesting":    "true",
+				"security.privileged": "true",
+			},
+			Description: "sample lxdprofile for testing",
+			Devices: map[string]map[string]string{
+				"tun": {
+					"path": "/dev/net/tun",
+					"type": "unix-char",
+				},
+			},
+	})
 	switch f := f.(type) {
 	case *charm.CharmArchive:
 		c.Assert(f.Path, gc.Equals, path)

--- a/charmarchive_test.go
+++ b/charmarchive_test.go
@@ -39,6 +39,7 @@ var dummyManifest = []string{
 	"empty/.gitkeep",
 	"hooks",
 	"hooks/install",
+	"lxd-profile.yaml",
 	"metadata.yaml",
 	"revision",
 	"src",

--- a/charmdir.go
+++ b/charmdir.go
@@ -33,6 +33,7 @@ type CharmDir struct {
 	config     *Config
 	metrics    *Metrics
 	actions    *Actions
+	lxdProfile *LXDProfile
 	revision   int
 	ignoreDirs []string
 }
@@ -106,6 +107,19 @@ func ReadCharmDir(path string) (dir *CharmDir, err error) {
 		}
 	}
 
+	file, err = os.Open(dir.join("lxd-profile.yaml"))
+	if _, ok := err.(*os.PathError); ok {
+		dir.lxdProfile = NewLXDProfile()
+	} else if err != nil {
+		return nil, err
+	} else {
+		dir.lxdProfile, err = ReadLXDProfile(file)
+		file.Close()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return dir, nil
 }
 
@@ -144,6 +158,12 @@ func (dir *CharmDir) Metrics() *Metrics {
 // for the charm expanded in dir.
 func (dir *CharmDir) Actions() *Actions {
 	return dir.actions
+}
+
+// LXDProfile returns the LXDProfile representing the lxd-profile.yaml file
+// for the charm expanded in dir.
+func (dir *CharmDir) LXDProfile() *LXDProfile {
+	return dir.lxdProfile
 }
 
 // SetRevision changes the charm revision number. This affects

--- a/internal/test-charm-repo/quantal/dummy/lxd-profile.yaml
+++ b/internal/test-charm-repo/quantal/dummy/lxd-profile.yaml
@@ -1,0 +1,9 @@
+name: "test"
+description: "sample lxdprofile for testing"
+config:
+  security.nesting: "true"
+  security.privileged: "true"
+devices:
+  tun:
+    path: /dev/net/tun
+    type: unix-char

--- a/lxdprofile.go
+++ b/lxdprofile.go
@@ -1,0 +1,74 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package charm
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/set"
+	"gopkg.in/yaml.v2"
+)
+
+type LXDProfiler interface {
+	// LXDProfile returns the LXDProfile found in lxd-profile.yaml of the charm
+	LXDProfile() *LXDProfile
+}
+
+// LXDProfile is the same as ProfilePut defined in github.com/lxc/lxd/shared/api/profile.go
+type LXDProfile struct {
+	Config      map[string]string            `json:"config" yaml:"config"`
+	Description string                       `json:"description" yaml:"description"`
+	Devices     map[string]map[string]string `json:"devices" yaml:"devices"`
+}
+
+func NewLXDProfile() *LXDProfile {
+	return &LXDProfile{}
+}
+
+// ReadLXDProfile reads in a LXDProfile from a charm's lxd-profile.yaml.
+// It is not validated at this point so that the caller can choose to override
+// any validation.
+func ReadLXDProfile(r io.Reader) (*LXDProfile, error) {
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	var profile LXDProfile
+	if err := yaml.Unmarshal(data, &profile); err != nil {
+		return nil, errors.Annotate(err, "failed to unmarshall lxd-profile.yaml")
+	}
+	return &profile, nil
+}
+
+// ValidateConfigDevices validates the Config and Devices properties of the LXDProfile.
+// WhiteList devices: unix-char, unix-block, gpu, usb.
+// BlackList config: boot*, limits* and migration*.
+// An empty profile will not return an error.
+func (profile *LXDProfile) ValidateConfigDevices() error {
+	for _, val := range profile.Devices {
+		goodDevs := set.NewStrings("unix-char", "unix-block", "gpu", "usb")
+		if devType, ok := val["type"]; ok {
+			if !goodDevs.Contains(devType) {
+				return fmt.Errorf("invalid lxd-profile.yaml: contains device type %q", devType)
+			}
+		}
+	}
+	for key, _ := range profile.Config {
+		if strings.HasPrefix(key, "boot") ||
+			strings.HasPrefix(key, "limits") ||
+			strings.HasPrefix(key, "migration") {
+			return fmt.Errorf("invalid lxd-profile.yaml: contains config value %q", key)
+		}
+	}
+	return nil
+}
+
+// Empty returns true if neither devices nor config have been defined in the profile.
+func (profile *LXDProfile) Empty() bool {
+	return len(profile.Devices) < 1 && len(profile.Config) < 1
+}

--- a/lxdprofile_test.go
+++ b/lxdprofile_test.go
@@ -1,0 +1,164 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package charm_test
+
+import (
+	"strings"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"gopkg.in/juju/charm.v7-unstable"
+)
+
+type ProfileSuite struct{}
+
+var _ = gc.Suite(&ProfileSuite{})
+
+func (s *ProfileSuite) TestValidate(c *gc.C) {
+	var profileTests = []struct {
+		description   string
+		profile       *charm.LXDProfile
+		expectedError string
+	}{
+		{
+			description: "success",
+			profile: &charm.LXDProfile{
+				Config: map[string]string{
+					"security.nesting":     "true",
+					"security.privileged":  "true",
+					"linux.kernel_modules": "openvswitch,ip_tables,ip6_tables",
+				},
+				Description: "success",
+				Devices: map[string]map[string]string{
+					"tun": {
+						"path": "/dev/net/tun",
+						"type": "unix-char",
+					},
+					"sony": {
+						"type":      "usb",
+						"vendorid":  "0fce",
+						"productid": "51da",
+					},
+					"bdisk": {
+						"type":   "unix-block",
+						"source": "/dev/loop0",
+					},
+					"gpu": {
+						"type": "gpu",
+					},
+				},
+			},
+			expectedError: "",
+		}, {
+			description: "fail on boot config",
+			profile: &charm.LXDProfile{
+				Config: map[string]string{
+					"security.privileged":  "true",
+					"linux.kernel_modules": "openvswitch,ip_tables,ip6_tables",
+					"boot.autostart":       "true",
+				},
+			},
+			expectedError: "invalid lxd-profile.yaml: contains config value \"boot.autostart\"",
+		}, {
+			description: "fail on limits config",
+			profile: &charm.LXDProfile{
+				Config: map[string]string{
+					"security.privileged":  "true",
+					"linux.kernel_modules": "openvswitch,ip_tables,ip6_tables",
+					"limits.memory":        "256MB",
+				},
+			},
+			expectedError: "invalid lxd-profile.yaml: contains config value \"limits.memory\"",
+		}, {
+			description: "fail on migration config",
+			profile: &charm.LXDProfile{
+				Config: map[string]string{
+					"security.privileged":          "true",
+					"linux.kernel_modules":         "openvswitch,ip_tables,ip6_tables",
+					"migration.incremental.memory": "true",
+				},
+			},
+			expectedError: "invalid lxd-profile.yaml: contains config value \"migration.incremental.memory\"",
+		}, {
+			description: "fail on unix-disk device",
+			profile: &charm.LXDProfile{
+				Config: map[string]string{
+					"security.privileged":  "true",
+					"linux.kernel_modules": "openvswitch,ip_tables,ip6_tables",
+				},
+				Devices: map[string]map[string]string{
+					"bdisk": {
+						"type":   "unix-disk",
+						"source": "/dev/loop0",
+					},
+				},
+			},
+			expectedError: "invalid lxd-profile.yaml: contains device type \"unix-disk\"",
+		},
+	}
+	for i, test := range profileTests {
+		c.Logf("test %d: %s", i, test.description)
+		err := test.profile.ValidateConfigDevices()
+		if err != nil {
+			c.Assert(err.Error(), gc.Equals, test.expectedError)
+		} else {
+
+			c.Assert(err, jc.ErrorIsNil)
+		}
+	}
+
+}
+
+func (s *ProfileSuite) TestReadLXDProfile(c *gc.C) {
+	profile, err := charm.ReadLXDProfile(strings.NewReader(`
+config:
+  security.nesting: "true"
+  security.privileged: "true"
+  linux.kernel_modules: openvswitch,nbd,ip_tables,ip6_tables
+devices:
+  kvm:
+    path: /dev/kvm
+    type: unix-char
+  mem:
+    path: /dev/mem
+    type: unix-char
+  tun:
+    path: /dev/net/tun
+    type: unix-char
+`))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(profile, gc.NotNil)
+}
+
+func (s *ProfileSuite) TestLXDProfileEmptyFile(c *gc.C) {
+	profile, err := charm.ReadLXDProfile(strings.NewReader(`
+ 
+`))
+	c.Assert(profile, gc.DeepEquals, &charm.LXDProfile{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(profile.Empty(), jc.IsTrue)
+	c.Assert(profile.ValidateConfigDevices(), jc.ErrorIsNil)
+}
+
+func (s *ProfileSuite) TestReadLXDProfileFailUnmarshall(c *gc.C) {
+	profile, err := charm.ReadLXDProfile(strings.NewReader(`
+config:
+  security.nesting: "true"
+  security.privileged: "true"
+  linux.kernel_modules: openvswitch,nbd,ip_tables,ip6_tables
+ devices:
+  kvm:
+    path: /dev/kvm
+    type: unix-char
+  mem:
+    path: /dev/mem
+    type: unix-char
+  tun:
+    path: /dev/net/tun
+    type: unix-char
+`))
+	c.Assert(err, gc.ErrorMatches, "failed to unmarshall lxd-profile.yaml: yaml: .*")
+	c.Assert(profile, gc.IsNil)
+}

--- a/meta_test.go
+++ b/meta_test.go
@@ -1507,6 +1507,10 @@ func (c *dummyCharm) Actions() *charm.Actions {
 	panic("unused")
 }
 
+func (c *dummyCharm) LXDProfile() *charm.LXDProfile {
+	panic("unused")
+}
+
 func (c *dummyCharm) Revision() int {
 	panic("unused")
 }


### PR DESCRIPTION
Adding for the lxd profile work in juju.  Charms can now read and validate an included lxd-profile.yaml.