### PR TITLE
Don't indicate that all series are supported by old style charms.

### DIFF
--- a/charm.go
+++ b/charm.go
@@ -42,16 +42,16 @@ func ReadCharm(path string) (charm Charm, err error) {
 }
 
 // SeriesForCharm takes a requested series and a list of series supported by a
-// charm and returns the series which is relevant.
-// If the requested series is empty, then the first supported series is used,
-// otherwise the requested series is validated against the supported series.
+// charm and returns the series which is relevant. If the requested series is
+// empty, then the first supported series is used, otherwise the requested
+// series is validated against the supported series. If no series are supported
+// SeriesForCharm returns an error; it is incorrect usage for supportedSeries to
+// be the empty slice since it should always be possible to determine the
+// supported series of a charm.
 func SeriesForCharm(requestedSeries string, supportedSeries []string) (string, error) {
 	// Old charm with no supported series.
 	if len(supportedSeries) == 0 {
-		if requestedSeries == "" {
-			return "", missingSeriesError
-		}
-		return requestedSeries, nil
+		return "", missingSeriesError
 	}
 	// Use the charm default.
 	if requestedSeries == "" {
@@ -67,9 +67,9 @@ func SeriesForCharm(requestedSeries string, supportedSeries []string) (string, e
 
 // missingSeriesError is used to denote that SeriesForCharm could not determine
 // a series because a legacy charm did not declare any.
-var missingSeriesError = fmt.Errorf("series not specified and charm does not define any")
+var missingSeriesError = fmt.Errorf("no supported series were specified for charm")
 
-// IsMissingSeriesError returns true if err is an missingSeriesError.
+// IsMissingSeriesError returns true if err is a missingSeriesError.
 func IsMissingSeriesError(err error) bool {
 	return err == missingSeriesError
 }

--- a/charm_test.go
+++ b/charm_test.go
@@ -63,11 +63,9 @@ func (s *CharmSuite) TestSeriesToUse(c *gc.C) {
 		seriesToUse     string
 		err             string
 	}{{
-		series: "",
-		err:    "series not specified and charm does not define any",
-	}, {
-		series:      "trusty",
-		seriesToUse: "trusty",
+		series:          "",
+		supportedSeries: []string{},
+		err:             `no supported series were specified for charm`,
 	}, {
 		series:          "trusty",
 		supportedSeries: []string{"precise", "trusty"},
@@ -126,17 +124,17 @@ func checkDummy(c *gc.C, f charm.Charm, path string) {
 	lpc, ok := f.(charm.LXDProfiler)
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(lpc.LXDProfile(), jc.DeepEquals, &charm.LXDProfile{
-			Config: map[string]string{
-				"security.nesting":    "true",
-				"security.privileged": "true",
+		Config: map[string]string{
+			"security.nesting":    "true",
+			"security.privileged": "true",
+		},
+		Description: "sample lxdprofile for testing",
+		Devices: map[string]map[string]string{
+			"tun": {
+				"path": "/dev/net/tun",
+				"type": "unix-char",
 			},
-			Description: "sample lxdprofile for testing",
-			Devices: map[string]map[string]string{
-				"tun": {
-					"path": "/dev/net/tun",
-					"type": "unix-char",
-				},
-			},
+		},
 	})
 	switch f := f.(type) {
 	case *charm.CharmArchive:


### PR DESCRIPTION
The `SeriesForCharm` function would simply return the requested series when no series were supported by the charm. This leads errors in `juju`. No usage of `SeriesForCharm` relies on the suspect behavior.