### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -94,7 +94,7 @@ func (spec *ActionSpec) InsertDefaults(target map[string]interface{}) (map[strin
 	return schema.InsertDefaults(target)
 }
 
-// ReadActions builds an Actions spec from a charm's actions.yaml.
+// ReadActionsYaml builds an Actions spec from a charm's actions.yaml.
 func ReadActionsYaml(r io.Reader) (*Actions, error) {
 	data, err := ioutil.ReadAll(r)
 	if err != nil {


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?