### PR TITLE
Add .tox directory to defaultJujuIgnore

### DIFF
--- a/charmdir.go
+++ b/charmdir.go
@@ -30,6 +30,7 @@ var defaultJujuIgnore = `
 .svn
 .hg
 .bzr
+.tox
 
 /build/
 /revision


### PR DESCRIPTION
This patch adds .tox directory to defaultJujuIgnore var preventing
charm repackage error when running functional tests.

Closes-Bug: 1829267