### PR TITLE
Add "trust" field to application/service spec

### DIFF
--- a/bundledata.go
+++ b/bundledata.go
@@ -300,6 +300,11 @@ type ApplicationSpec struct {
 	// Plan specifies the plan under which the application is to be deployed.
 	// If "default", the default plan will be used for the charm
 	Plan string `bson:"plan,omitempty" json:"plan,omitempty" yaml:"plan,omitempty"`
+
+	// RequiresTrust indicates that the application requires access to
+	// cloud credentials and must therefore be explicitly trusted by the
+	// operator before it can be deployed.
+	RequiresTrust bool `bson:"trust,omitempty" json:"trust,omitempty" yaml:"trust,omitempty"`
 }
 
 // ReadBundleData reads bundle data from the given reader.

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -230,6 +230,24 @@ applications:
 			},
 		},
 	},
+}, {
+	about: "application requiring explicit trust",
+	data: `
+applications:
+    aws-integrator:
+        charm: cs:~containers/aws-integrator
+        num_units: 1
+        trust: true
+`,
+	expectedBD: &charm.BundleData{
+		Applications: map[string]*charm.ApplicationSpec{
+			"aws-integrator": {
+				Charm:         "cs:~containers/aws-integrator",
+				NumUnits:      1,
+				RequiresTrust: true,
+			},
+		},
+	},
 }}
 
 func (*bundleDataSuite) TestParse(c *gc.C) {


### PR DESCRIPTION
This field is part of the bundle's yaml document and indicates that an
application requires access to cloud credentials and must be explicitly
trusted by the operator.