### PR TITLE
Support multiple endpoints in Offer specs

### DIFF
--- a/bundledata.go
+++ b/bundledata.go
@@ -312,11 +312,11 @@ type ApplicationSpec struct {
 }
 
 // OfferSpec describes an offer for a particular application. It currently only
-// holds information about the offered endpoint but we may opt to expand it in
+// holds information about the offered endpoints but we may opt to expand it in
 // the future to additional information (e.g. the ACL that can interact with
 // this offer).
 type OfferSpec struct {
-	Endpoint string `bson:"endpoint" json:"endpoint", yaml:"endpoint"`
+	Endpoints []string `bson:"endpoints" json:"endpoints", yaml:"endpoints"`
 }
 
 // ReadBundleData reads bundle data from the given reader.
@@ -613,8 +613,10 @@ func (verifier *bundleDataVerifier) verifyApplications() {
 				verifier.addErrorf("invalid offer name %q in application %q", offerName, name)
 			}
 
-			if !validOfferEndpointName.MatchString(oSpec.Endpoint) {
-				verifier.addErrorf("invalid endpoint name %q for offer %q in application %q", oSpec.Endpoint, offerName, name)
+			for _, endpoint := range oSpec.Endpoints {
+				if !validOfferEndpointName.MatchString(endpoint) {
+					verifier.addErrorf("invalid endpoint name %q for offer %q in application %q", endpoint, offerName, name)
+				}
 			}
 		}
 		if verifier.charms != nil {

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -257,9 +257,12 @@ applications:
       num_units: 1
       offers:
         offer1:
-          endpoint: "apache-website"
+          endpoints: 
+            - "apache-website"
+            - "apache-proxy"
         offer2:
-          endpoint: "apache-website"
+          endpoints: 
+            - "apache-website"
 `,
 	expectedBD: &charm.BundleData{
 		Applications: map[string]*charm.ApplicationSpec{
@@ -268,10 +271,15 @@ applications:
 				NumUnits: 1,
 				Offers: map[string]*charm.OfferSpec{
 					"offer1": &charm.OfferSpec{
-						Endpoint: "apache-website",
+						Endpoints: []string{
+							"apache-website",
+							"apache-proxy",
+						},
 					},
 					"offer2": &charm.OfferSpec{
-						Endpoint: "apache-website",
+						Endpoints: []string{
+							"apache-website",
+						},
 					},
 				},
 			},
@@ -493,7 +501,8 @@ applications:
         trust: true
         offers:
           $bad-name:
-            endpoint: "nope!"
+            endpoints:
+              - "nope!"
 `,
 	errors: []string{
 		`invalid offer name "$bad-name" in application "aws-integrator"`,


### PR DESCRIPTION
According to the [docs](https://discourse.jujucharms.com/t/cross-model-relations/1150), offers may include multiple endpoints. This PR updates the `OfferSpec` type to reflect this.