### PR TITLE
Bundle data with SAAS

### DIFF
--- a/bundledata.go
+++ b/bundledata.go
@@ -176,8 +176,7 @@ func (d *BundleData) UnmarshaledWithServices() bool {
 // SaasSpec represents a single software as a service (SAAS) node.
 // This will be mapped to consuming of offers from a bundle deployment.
 type SaasSpec struct {
-	Source string `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
-	URL    string `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
+	URL string `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
 }
 
 // MachineSpec represents a notional machine that will be mapped
@@ -547,10 +546,6 @@ func (verifier *bundleDataVerifier) verifySaas() {
 		}
 		if saas == nil {
 			continue
-		}
-		if saas.Source != "" && !names.IsValidControllerName(saas.Source) {
-			// source here could be "local" or a controller name
-			verifier.addErrorf("invalid source %q for SAAS %s", saas.Source, name)
 		}
 		if saas.URL != "" && !IsValidOfferURL(saas.URL) {
 			verifier.addErrorf("invalid offer URL %q for SAAS %s", saas.URL, name)

--- a/bundledata.go
+++ b/bundledata.go
@@ -136,6 +136,11 @@ type BundleData struct {
 	// not referred to by a unit placement directive.
 	Machines map[string]*MachineSpec `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
 
+	// Saas holds one entry for each software as a service (SAAS) for cross
+	// model relation (CMR). These will be mapped to the consuming side when
+	// deploying a bundle.
+	Saas map[string]*SaasSpec `bson:"saas,omitempty" json:"saas,omitempty" yaml:"saas,omitempty"`
+
 	// Series holds the default series to use when
 	// the bundle chooses charms.
 	Series string `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
@@ -166,6 +171,13 @@ type BundleData struct {
 // field rather than the "applications" field.
 func (d *BundleData) UnmarshaledWithServices() bool {
 	return d.unmarshaledWithServices
+}
+
+// SaasSpec represents a single software as a service (SAAS) node.
+// This will be mapped to consuming of offers from a bundle deployment.
+type SaasSpec struct {
+	Source string `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
+	URL    string `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
 }
 
 // MachineSpec represents a notional machine that will be mapped
@@ -500,6 +512,7 @@ func (bd *BundleData) verifyBundle(
 	if bd.Series != "" && !IsValidSeries(bd.Series) {
 		verifier.addErrorf("bundle declares an invalid series %q", bd.Series)
 	}
+	verifier.verifySaas()
 	verifier.verifyMachines()
 	verifier.verifyApplications()
 	verifier.verifyRelations()
@@ -526,6 +539,24 @@ var (
 	validOfferName         = regexp.MustCompile("^" + names.ApplicationSnippet + "$")
 	validOfferEndpointName = regexp.MustCompile("^" + names.RelationSnippet + "$")
 )
+
+func (verifier *bundleDataVerifier) verifySaas() {
+	for name, saas := range verifier.bd.Saas {
+		if !validOfferName.MatchString(name) {
+			verifier.addErrorf("invalid SAAS name %q found", name)
+		}
+		if saas == nil {
+			continue
+		}
+		if saas.Source != "" && !names.IsValidControllerName(saas.Source) {
+			// source here could be "local" or a controller name
+			verifier.addErrorf("invalid source %q for SAAS %s", saas.Source, name)
+		}
+		if saas.URL != "" && !IsValidOfferURL(saas.URL) {
+			verifier.addErrorf("invalid offer URL %q for SAAS %s", saas.URL, name)
+		}
+	}
+}
 
 func (verifier *bundleDataVerifier) verifyMachines() {
 	for id, m := range verifier.bd.Machines {

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -297,7 +297,6 @@ applications:
 	data: `
 saas:
     apache2:
-        source: local
         url: production:admin/info.apache
 applications:
     apache2:
@@ -307,8 +306,7 @@ applications:
 	expectedBD: &charm.BundleData{
 		Saas: map[string]*charm.SaasSpec{
 			"apache2": {
-				Source: "local",
-				URL:    "production:admin/info.apache",
+				URL: "production:admin/info.apache",
 			},
 		},
 		Applications: map[string]*charm.ApplicationSpec{
@@ -429,7 +427,6 @@ series: "9wrong"
 
 saas:
     apache2:
-        source: Bogus
         url: '!some-bogus/url'
 machines:
     0:
@@ -500,7 +497,6 @@ relations:
 `,
 	errors: []string{
 		`bundle declares an invalid series "9wrong"`,
-		`invalid source "Bogus" for SAAS apache2`,
 		`invalid offer URL "!some-bogus/url" for SAAS apache2`,
 		`invalid storage name "no_underscores" in application "ceph"`,
 		`invalid storage "invalid-storage" in application "ceph-osd": bad storage constraint`,

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -257,14 +257,14 @@ applications:
       num_units: 1
       offers:
         offer1:
-          endpoints: 
+          endpoints:
             - "apache-website"
             - "apache-proxy"
-          acl: 
+          acl:
             admin: "admin"
             foo: "consume"
         offer2:
-          endpoints: 
+          endpoints:
             - "apache-website"
 `,
 	expectedBD: &charm.BundleData{
@@ -289,6 +289,32 @@ applications:
 						},
 					},
 				},
+			},
+		},
+	},
+}, {
+	about: "saas offerings",
+	data: `
+saas:
+    apache2:
+        source: local
+        url: production:admin/info.apache
+applications:
+    apache2:
+      charm: "cs:apache2-26"
+      num_units: 1
+`,
+	expectedBD: &charm.BundleData{
+		Saas: map[string]*charm.SaasSpec{
+			"apache2": {
+				Source: "local",
+				URL:    "production:admin/info.apache",
+			},
+		},
+		Applications: map[string]*charm.ApplicationSpec{
+			"apache2": {
+				Charm:    "cs:apache2-26",
+				NumUnits: 1,
 			},
 		},
 	},
@@ -401,12 +427,16 @@ var verifyErrorsTests = []struct {
 	data: `
 series: "9wrong"
 
+saas:
+    apache2:
+        source: Bogus
+        url: '!some-bogus/url'
 machines:
     0:
-         constraints: 'bad constraints'
-         annotations:
-             foo: bar
-         series: 'bad series'
+        constraints: 'bad constraints'
+        annotations:
+            foo: bar
+        series: 'bad series'
     bogus:
     3:
 applications:
@@ -470,6 +500,8 @@ relations:
 `,
 	errors: []string{
 		`bundle declares an invalid series "9wrong"`,
+		`invalid source "Bogus" for SAAS apache2`,
+		`invalid offer URL "!some-bogus/url" for SAAS apache2`,
 		`invalid storage name "no_underscores" in application "ceph"`,
 		`invalid storage "invalid-storage" in application "ceph-osd": bad storage constraint`,
 		`machine "3" is not referred to by a placement directive`,

--- a/offerurl.go
+++ b/offerurl.go
@@ -1,0 +1,170 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package charm
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/juju/errors"
+	names "gopkg.in/juju/names.v2"
+)
+
+// OfferURL represents the location of an offered application and its
+// associated exported endpoints.
+type OfferURL struct {
+	// Source represents where the offer is hosted.
+	// If empty, the model is another model in the same controller.
+	Source string // "<controller-name>" or "<jaas>" or ""
+
+	// User is the user whose namespace in which the offer is made.
+	// Where a model is specified, the user is the model owner.
+	User string
+
+	// ModelName is the name of the model providing the exported endpoints.
+	// It is only used for local URLs or for specifying models in the same
+	// controller.
+	ModelName string
+
+	// ApplicationName is the name of the application providing the exported endpoints.
+	ApplicationName string
+}
+
+// Path returns the path component of the URL.
+func (u *OfferURL) Path() string {
+	var parts []string
+	if u.User != "" {
+		parts = append(parts, u.User)
+	}
+	if u.ModelName != "" {
+		parts = append(parts, u.ModelName)
+	}
+	path := strings.Join(parts, "/")
+	path = fmt.Sprintf("%s.%s", path, u.ApplicationName)
+	if u.Source == "" {
+		return path
+	}
+	return fmt.Sprintf("%s:%s", u.Source, path)
+}
+
+func (u *OfferURL) String() string {
+	return u.Path()
+}
+
+// AsLocal returns a copy of the URL with an empty (local) source.
+func (u *OfferURL) AsLocal() *OfferURL {
+	localURL := *u
+	localURL.Source = ""
+	return &localURL
+}
+
+// HasEndpoint returns whether this offer URL includes an
+// endpoint name in the application name.
+func (u *OfferURL) HasEndpoint() bool {
+	return strings.Contains(u.ApplicationName, ":")
+}
+
+// modelApplicationRegexp parses urls of the form controller:user/model.application[:relname]
+var modelApplicationRegexp = regexp.MustCompile(`(/?((?P<user>[^/]+)/)?(?P<model>[^.]*)(\.(?P<application>[^:]*(:.*)?))?)?`)
+
+// IsValidOfferURL ensures that a URL string is a valid OfferURL.
+func IsValidOfferURL(urlStr string) bool {
+	_, err := ParseOfferURL(urlStr)
+	return err == nil
+}
+
+// ParseOfferURL parses the specified URL string into an OfferURL.
+// The URL string is of one of the forms:
+//  <model-name>.<application-name>
+//  <model-name>.<application-name>:<relation-name>
+//  <user>/<model-name>.<application-name>
+//  <user>/<model-name>.<application-name>:<relation-name>
+//  <controller>:<user>/<model-name>.<application-name>
+//  <controller>:<user>/<model-name>.<application-name>:<relation-name>
+func ParseOfferURL(urlStr string) (*OfferURL, error) {
+	return parseOfferURL(urlStr)
+}
+
+// parseOfferURL parses the specified URL string into an OfferURL.
+func parseOfferURL(urlStr string) (*OfferURL, error) {
+	urlParts, err := parseOfferURLParts(urlStr, false)
+	if err != nil {
+		return nil, err
+	}
+	url := OfferURL(*urlParts)
+	return &url, nil
+}
+
+// OfferURLParts contains various attributes of a URL.
+type OfferURLParts OfferURL
+
+// ParseOfferURLParts parses a partial URL, filling out what parts are supplied.
+// This method is used to generate a filter used to query matching offer URLs.
+func ParseOfferURLParts(urlStr string) (*OfferURLParts, error) {
+	return parseOfferURLParts(urlStr, true)
+}
+
+var endpointRegexp = regexp.MustCompile(`^[a-zA-Z0-9]+$`)
+
+func maybeParseSource(urlStr string) (source, rest string) {
+	parts := strings.Split(urlStr, ":")
+	switch len(parts) {
+	case 3:
+		return parts[0], parts[1] + ":" + parts[2]
+	case 2:
+		if endpointRegexp.MatchString(parts[1]) {
+			return "", urlStr
+		}
+		return parts[0], parts[1]
+	}
+	return "", urlStr
+}
+
+func parseOfferURLParts(urlStr string, allowIncomplete bool) (*OfferURLParts, error) {
+	var result OfferURLParts
+	source, urlParts := maybeParseSource(urlStr)
+
+	valid := !strings.HasPrefix(urlStr, ":")
+	valid = valid && modelApplicationRegexp.MatchString(urlParts)
+	if valid {
+		result.Source = source
+		result.User = modelApplicationRegexp.ReplaceAllString(urlParts, "$user")
+		result.ModelName = modelApplicationRegexp.ReplaceAllString(urlParts, "$model")
+		result.ApplicationName = modelApplicationRegexp.ReplaceAllString(urlParts, "$application")
+	}
+	if !valid || strings.Contains(result.ModelName, "/") || strings.Contains(result.ApplicationName, "/") {
+		// TODO(wallyworld) - update error message when we support multi-controller and JAAS CMR
+		return nil, errors.Errorf("application offer URL has invalid form, must be [<user/]<model>.<appname>: %q", urlStr)
+	}
+	if !allowIncomplete && result.ModelName == "" {
+		return nil, errors.Errorf("application offer URL is missing model")
+	}
+	if !allowIncomplete && result.ApplicationName == "" {
+		return nil, errors.Errorf("application offer URL is missing application")
+	}
+
+	// Application name part may contain a relation name part, so strip that bit out
+	// before validating the name.
+	appName := strings.Split(result.ApplicationName, ":")[0]
+	// Validate the resulting URL part values.
+	if result.User != "" && !names.IsValidUser(result.User) {
+		return nil, errors.NotValidf("user name %q", result.User)
+	}
+	if result.ModelName != "" && !names.IsValidModelName(result.ModelName) {
+		return nil, errors.NotValidf("model name %q", result.ModelName)
+	}
+	if appName != "" && !names.IsValidApplication(appName) {
+		return nil, errors.NotValidf("application name %q", appName)
+	}
+	return &result, nil
+}
+
+// MakeURL constructs an offer URL from the specified components.
+func MakeURL(user, model, application, controller string) string {
+	base := fmt.Sprintf("%s/%s.%s", user, model, application)
+	if controller == "" {
+		return base
+	}
+	return fmt.Sprintf("%s:%s", controller, base)
+}

--- a/offerurl_test.go
+++ b/offerurl_test.go
@@ -1,0 +1,179 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package charm_test
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	charm "gopkg.in/juju/charm.v6"
+)
+
+type OfferURLSuite struct{}
+
+var _ = gc.Suite(&OfferURLSuite{})
+
+var offerURLTests = []struct {
+	s, err string
+	exact  string
+	url    *charm.OfferURL
+}{{
+	s:   "controller:user/modelname.applicationname",
+	url: &charm.OfferURL{"controller", "user", "modelname", "applicationname"},
+}, {
+	s:   "controller:user/modelname.applicationname:rel",
+	url: &charm.OfferURL{"controller", "user", "modelname", "applicationname:rel"},
+}, {
+	s:   "modelname.applicationname",
+	url: &charm.OfferURL{"", "", "modelname", "applicationname"},
+}, {
+	s:   "modelname.applicationname:rel",
+	url: &charm.OfferURL{"", "", "modelname", "applicationname:rel"},
+}, {
+	s:   "user/modelname.applicationname:rel",
+	url: &charm.OfferURL{"", "user", "modelname", "applicationname:rel"},
+}, {
+	s:     "/modelname.applicationname",
+	url:   &charm.OfferURL{"", "", "modelname", "applicationname"},
+	exact: "modelname.applicationname",
+}, {
+	s:     "/modelname.applicationname:rel",
+	url:   &charm.OfferURL{"", "", "modelname", "applicationname:rel"},
+	exact: "modelname.applicationname:rel",
+}, {
+	s:   "user/modelname.applicationname",
+	url: &charm.OfferURL{"", "user", "modelname", "applicationname"},
+}, {
+	s:   "controller:modelname",
+	err: `application offer URL is missing application`,
+}, {
+	s:   "controller:user/modelname",
+	err: `application offer URL is missing application`,
+}, {
+	s:   "model",
+	err: `application offer URL is missing application`,
+}, {
+	s:   "/user/model",
+	err: `application offer URL is missing application`,
+}, {
+	s:   "model.application@bad",
+	err: `application name "application@bad" not valid`,
+}, {
+	s:   "user[bad/model.application",
+	err: `user name "user\[bad" not valid`,
+}, {
+	s:   "user/[badmodel.application",
+	err: `model name "\[badmodel" not valid`,
+}}
+
+func (s *OfferURLSuite) TestParseURL(c *gc.C) {
+	for i, t := range offerURLTests {
+		c.Logf("test %d: %q", i, t.s)
+		url, err := charm.ParseOfferURL(t.s)
+
+		match := t.s
+		if t.exact != "" {
+			match = t.exact
+		}
+		if t.url != nil {
+			c.Assert(err, gc.IsNil)
+			c.Check(url, gc.DeepEquals, t.url)
+			c.Check(url.String(), gc.Equals, match)
+		}
+		if t.err != "" {
+			t.err = strings.Replace(t.err, "$URL", regexp.QuoteMeta(fmt.Sprintf("%q", t.s)), -1)
+			c.Check(err, gc.ErrorMatches, t.err)
+			c.Check(url, gc.IsNil)
+		}
+	}
+}
+
+var urlPartsTests = []struct {
+	s, err string
+	url    *charm.OfferURLParts
+}{{
+	s:   "controller:/user/modelname.applicationname",
+	url: &charm.OfferURLParts{"controller", "user", "modelname", "applicationname"},
+}, {
+	s:   "user/modelname.applicationname",
+	url: &charm.OfferURLParts{"", "user", "modelname", "applicationname"},
+}, {
+	s:   "user/modelname",
+	url: &charm.OfferURLParts{"", "user", "modelname", ""},
+}, {
+	s:   "modelname.application",
+	url: &charm.OfferURLParts{"", "", "modelname", "application"},
+}, {
+	s:   "controller:/modelname",
+	url: &charm.OfferURLParts{"controller", "", "modelname", ""},
+}, {
+	s:   "controller:",
+	url: &charm.OfferURLParts{Source: "controller"},
+}, {
+	s:   "",
+	url: &charm.OfferURLParts{},
+}, {
+	s:   "user/prod/applicationname/extra",
+	err: `application offer URL has invalid form, must be \[<user/\]<model>.<appname>: "user/prod/applicationname/extra"`,
+}, {
+	s:   "controller:/user/modelname.application@bad",
+	err: `application name "application@bad" not valid`,
+}, {
+	s:   "controller:/user[bad/modelname.application",
+	err: `user name "user\[bad" not valid`,
+}, {
+	s:   ":foo",
+	err: `application offer URL has invalid form, must be \[<user/\]<model>.<appname>: $URL`,
+}}
+
+func (s *OfferURLSuite) TestParseURLParts(c *gc.C) {
+	for i, t := range urlPartsTests {
+		c.Logf("test %d: %q", i, t.s)
+		url, err := charm.ParseOfferURLParts(t.s)
+
+		if t.url != nil {
+			c.Check(err, gc.IsNil)
+			c.Check(url, gc.DeepEquals, t.url)
+		}
+		if t.err != "" {
+			t.err = strings.Replace(t.err, "$URL", regexp.QuoteMeta(fmt.Sprintf("%q", t.s)), -1)
+			c.Assert(err, gc.ErrorMatches, t.err)
+			c.Assert(url, gc.IsNil)
+		}
+	}
+}
+
+func (s *OfferURLSuite) TestHasEndpoint(c *gc.C) {
+	url, err := charm.ParseOfferURL("model.application:endpoint")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(url.HasEndpoint(), jc.IsTrue)
+	url, err = charm.ParseOfferURL("model.application")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(url.HasEndpoint(), jc.IsFalse)
+	url, err = charm.ParseOfferURL("controller:/user/model.application:thing")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(url.HasEndpoint(), jc.IsTrue)
+	url, err = charm.ParseOfferURL("controller:/user/model.application")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(url.HasEndpoint(), jc.IsFalse)
+}
+
+func (s *OfferURLSuite) TestMakeURL(c *gc.C) {
+	url := charm.MakeURL("user", "model", "app", "")
+	c.Assert(url, gc.Equals, "user/model.app")
+	url = charm.MakeURL("user", "model", "app", "ctrl")
+	c.Assert(url, gc.Equals, "ctrl:user/model.app")
+}
+
+func (s *OfferURLSuite) TestAsLocal(c *gc.C) {
+	url, err := charm.ParseOfferURL("source:model.application:endpoint")
+	c.Assert(err, jc.ErrorIsNil)
+	expected, err := charm.ParseOfferURL("model.application:endpoint")
+	c.Assert(err, jc.ErrorIsNil)
+	original := *url
+	c.Assert(url.AsLocal(), gc.DeepEquals, expected)
+	c.Assert(*url, gc.DeepEquals, original)
+}


### PR DESCRIPTION
The following adds a SAAS spec to the bundle data so that we can
start consuming the right information.

```yaml
series: bionic
saas:
    apache2:
        source: local
        url: production:admin/info.apache2
```

Drive by: removed trailing white spaces.