### PR TITLE
Helper for splitting static and overlay bundle bits

### DIFF
--- a/bundledata.go
+++ b/bundledata.go
@@ -192,7 +192,7 @@ type MachineSpec struct {
 type ApplicationSpec struct {
 	// Charm holds the charm URL of the charm to
 	// use for the given application.
-	Charm string
+	Charm string `bson:",omitempty" yaml:",omitempty" json:",omitempty"`
 
 	// Series is the series to use when deploying a local charm,
 	// if the charm does not specify a default or the default
@@ -310,7 +310,7 @@ type ApplicationSpec struct {
 
 	// Offers holds one entry for each exported offer for this application
 	// where the key is the offer name.
-	Offers map[string]*OfferSpec `bson:"offers,omitempty" json:"offers,omitempty" yaml:"offers,omitempty"`
+	Offers map[string]*OfferSpec `bson:"offers,omitempty" json:"offers,omitempty" yaml:"offers,omitempty" source:"overlay-only"`
 
 	// Plan specifies the plan under which the application is to be deployed.
 	// If "default", the default plan will be used for the charm
@@ -325,11 +325,11 @@ type ApplicationSpec struct {
 // OfferSpec describes an offer for a particular application.
 type OfferSpec struct {
 	// The list of endpoints exposed via the offer.
-	Endpoints []string `bson:"endpoints" json:"endpoints" yaml:"endpoints"`
+	Endpoints []string `bson:"endpoints" json:"endpoints" yaml:"endpoints" source:"overlay-only"`
 
 	// The access control list for this offer. The keys are users and the
 	// values are access permissions.
-	ACL map[string]string `bson:"acl,omitempty" json:"acl,omitempty" yaml:"acl,omitempty"`
+	ACL map[string]string `bson:"acl,omitempty" json:"acl,omitempty" yaml:"acl,omitempty" source:"overlay-only"`
 }
 
 // ReadBundleData reads bundle data from the given reader.

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -14,6 +14,7 @@ github.com/juju/utils	git	bf9cc5bdd62dabc40b7f634b39a5e2dc44d44c45	2018-08-20T21
 github.com/juju/version	git	b64dbd566305c836274f0268fa59183a52906b36	2018-01-08T02:23:36Z
 github.com/kr/pretty	git	73f6ac0b30a98e433b289500d779f50c1a6f0712	2018-05-06T08:33:45Z
 github.com/kr/text	git	e2ffdb16a802fe2bb95e2e35ff34f0e53aeef34f	2018-05-06T08:24:08Z
+github.com/mohae/deepcopy	git	c48cc78d482608239f6c4c92a4abd87eb8761c90	2017-09-29T03:49:55Z
 golang.org/x/crypto	git	b8fe1690c61389d7d2a8074a507d1d40c5d30448	2019-01-31T18:25:04Z
 golang.org/x/net	git	d26f9f9a57f3fab6a695bec0d84433c2c50f8bbf	2019-01-25T09:10:13Z
 gopkg.in/check.v1	git	788fd78401277ebd861206a03c884797c6ec5541	2018-06-28T17:31:08Z

--- a/overlay.go
+++ b/overlay.go
@@ -249,9 +249,9 @@ func clearOverlayFields(ctx *visitorContext, val reflect.Value, typ reflect.Type
 	for i := 0; i < typ.NumField(); i++ {
 		structField := typ.Field(i)
 
-		// Skip non-exportable fields
+		// Skip non-exportable and empty fields
 		v := val.Field(i)
-		if !v.CanInterface() {
+		if !v.CanInterface() || isZero(v) {
 			continue
 		}
 
@@ -274,9 +274,9 @@ func clearNonOverlayFields(ctx *visitorContext, val reflect.Value, typ reflect.T
 	for i := 0; i < typ.NumField(); i++ {
 		structField := typ.Field(i)
 
-		// Skip non-exportable fields
+		// Skip non-exportable and empty fields
 		v := val.Field(i)
-		if !v.CanInterface() {
+		if !v.CanInterface() || isZero(v) {
 			continue
 		}
 

--- a/overlay.go
+++ b/overlay.go
@@ -1,0 +1,238 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package charm
+
+import (
+	"bytes"
+	"encoding/gob"
+	"reflect"
+)
+
+// ExtractBaseAndOverlayParts splits the bundle data into a base and
+// overlay-specific bundle so that their union yields bd. To decide whether a
+// field is overlay-specific, the implementation uses reflection and
+// recursively scans the BundleData fields looking for fields annotated with
+// the "overlay-only: true" tag.
+//
+// To produce the base bundle, the original bundle is filtered and all
+// overlay-specific values are set to the zero value for their type. To produce
+// the overlay-specific bundle, we once again filter the original bundle but
+// this time zero out fields that do not contain any descendant fields that are
+// overlay-specific.
+//
+// To clarify how this method works let's consider a bundle created via the
+// yaml blob below:
+//
+//   applications:
+//     apache2:
+//       charm: cs:apache2-26
+//       offers:
+//         my-offer:
+//           endpoints:
+//           - apache-website
+//           - website-cache
+//         my-other-offer:
+//           endpoints:
+//           - apache-website
+//   series: bionic
+//
+// The "offers" and "endpoints" attributes are overlay-specific fields. If we
+// were to run this method and then marshal the results back to yaml we would
+// get:
+//
+// The base bundle:
+//
+//   applications:
+//     apache2:
+//       charm: cs:apache2-26
+//   series: bionic
+//
+// The overlay-specific bundle:
+//
+//   applications:
+//     apache2:
+//       offers:
+//         my-offer:
+//           endpoints:
+//           - apache-website
+//           - website-cache
+//         my-other-offer:
+//           endpoints:
+//           - apache-website
+//
+// The two bundles returned by this method are copies of the original bundle
+// data and can thus be safely manipulated by the caller.
+func ExtractBaseAndOverlayParts(bd *BundleData) (base, overlay *BundleData, err error) {
+	if base, err = cloneBundleData(bd); err != nil {
+		return nil, nil, err
+	}
+
+	if overlay, err = cloneBundleData(bd); err != nil {
+		return nil, nil, err
+	}
+
+	_ = visitField(&visitorContext{structVisitor: clearOverlayFields}, base)
+	_ = visitField(&visitorContext{structVisitor: clearNonOverlayFields}, overlay)
+	return base, overlay, nil
+}
+
+// cloneBundleData uses the gob package to perform a deep copy of bd.
+func cloneBundleData(bd *BundleData) (*BundleData, error) {
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(bd); err != nil {
+		return nil, err
+	}
+
+	var clone *BundleData
+	if err := gob.NewDecoder(&buf).Decode(&clone); err != nil {
+		return nil, err
+	}
+
+	clone.unmarshaledWithServices = bd.unmarshaledWithServices
+	return clone, nil
+}
+
+type visitorContext struct {
+	structVisitor func(ctx *visitorContext, val reflect.Value, typ reflect.Type) bool
+
+	// An optional pre/post visitor for indexable items (slices, maps)
+	indexedElemPreVisitor  func(index interface{})
+	indexedElemPostVisitor func(index interface{})
+}
+
+// visitField invokes ctx.structVisitor(val) if v is a struct and returns back
+// the visitor's result. On the other hand, if val is a slice or a map,
+// visitField invoke specialized functions that support iterating such types.
+func visitField(ctx *visitorContext, val interface{}) bool {
+	typ := reflect.TypeOf(val)
+	v := reflect.ValueOf(val)
+
+	// De-reference pointers
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+		typ = v.Type()
+	}
+
+	switch typ.Kind() {
+	case reflect.Struct:
+		return ctx.structVisitor(ctx, v, typ)
+	case reflect.Map:
+		return visitFieldsInMap(ctx, v)
+	case reflect.Slice:
+		return visitFieldsInSlice(ctx, v)
+	}
+
+	// v is not a struct or something we can iterate to reach a struct
+	return false
+}
+
+// visitFieldsInMap iterates the map specified by val and recursively visits
+// each map element. The returned value is the logical OR of the responses
+// returned by visiting all map elements.
+func visitFieldsInMap(ctx *visitorContext, val reflect.Value) (result bool) {
+	for _, key := range val.MapKeys() {
+		v := val.MapIndex(key)
+		if !v.CanInterface() {
+			continue
+		}
+
+		if ctx.indexedElemPreVisitor != nil {
+			ctx.indexedElemPreVisitor(key)
+		}
+
+		result = visitField(ctx, v.Interface()) || result
+
+		if ctx.indexedElemPostVisitor != nil {
+			ctx.indexedElemPostVisitor(key)
+		}
+	}
+
+	return result
+}
+
+// visitFieldsInSlice iterates the slice specified by val and recursively
+// visits each element. The returned value is the logical OR of the responses
+// returned by visiting all slice elements.
+func visitFieldsInSlice(ctx *visitorContext, val reflect.Value) (result bool) {
+	for i := 0; i < val.Len(); i++ {
+		v := val.Index(i)
+		if !v.CanInterface() {
+			continue
+		}
+
+		if ctx.indexedElemPreVisitor != nil {
+			ctx.indexedElemPreVisitor(i)
+		}
+
+		result = visitField(ctx, v.Interface()) || result
+
+		if ctx.indexedElemPostVisitor != nil {
+			ctx.indexedElemPostVisitor(i)
+		}
+	}
+
+	return result
+}
+
+// clearOverlayFields is an implementation of structVisitor. It recursively
+// visits all fields in the val struct and sets the ones that are tagged as
+// overlay-only to the zero value for their particular type.
+func clearOverlayFields(ctx *visitorContext, val reflect.Value, typ reflect.Type) (retainAncestors bool) {
+	for i := 0; i < typ.NumField(); i++ {
+		structField := typ.Field(i)
+
+		// Skip non-exportable fields
+		v := val.Field(i)
+		if !v.CanInterface() {
+			continue
+		}
+
+		// No need to recurse further down; just erase the field
+		if isOverlayField(structField) {
+			v.Set(reflect.Zero(v.Type()))
+			continue
+		}
+
+		_ = visitField(ctx, v.Interface())
+		retainAncestors = true
+	}
+	return retainAncestors
+}
+
+// clearNonOverlayFields is an implementation of structVisitor. It recursively
+// visits all fields in the val struct and sets any field that does not contain
+// any overlay-only descendants to the zero value for its particular type.
+func clearNonOverlayFields(ctx *visitorContext, val reflect.Value, typ reflect.Type) (retainAncestors bool) {
+	for i := 0; i < typ.NumField(); i++ {
+		structField := typ.Field(i)
+
+		// Skip non-exportable fields
+		v := val.Field(i)
+		if !v.CanInterface() {
+			continue
+		}
+
+		// If this is an overlay field we need to preserve it and all
+		// its ancestor fields up to the root. However, we still need
+		// to visit its descendants in case we need to clear additional
+		// non-overlay fields further down the tree.
+		isOverlayField := isOverlayField(structField)
+		if isOverlayField {
+			retainAncestors = true
+		}
+
+		if retain := visitField(ctx, v.Interface()); !isOverlayField && !retain {
+			v.Set(reflect.Zero(v.Type()))
+			continue
+		}
+
+		retainAncestors = true
+	}
+	return retainAncestors
+}
+
+// isOverlayField returns true if a struct field is tagged as overlay-only.
+func isOverlayField(structField reflect.StructField) bool {
+	return structField.Tag.Get("source") == "overlay-only"
+}

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -84,6 +84,56 @@ applications:
 	c.Assert("\n"+string(overlayYaml), gc.Equals, expOverlay)
 }
 
+func (*bundleDataOverlaySuite) TestExtractBaseAndOverlayPartsWithNoOverlayFields(c *gc.C) {
+	data := `
+bundle: kubernetes
+applications:
+  mysql:
+    charm: cs:mysql
+    scale: 1
+  wordpress:
+    charm: cs:wordpress
+    scale: 2
+relations:
+- - wordpress:db
+  - mysql:mysql
+`
+
+	expBase := `
+bundle: kubernetes
+applications:
+  mysql:
+    charm: cs:mysql
+    series: kubernetes
+    num_units: 1
+  wordpress:
+    charm: cs:wordpress
+    series: kubernetes
+    num_units: 2
+relations:
+- - wordpress:db
+  - mysql:mysql
+`
+
+	expOverlay := `
+{}
+`
+
+	bd, err := charm.ReadBundleData(strings.NewReader(data))
+	c.Assert(err, gc.IsNil)
+
+	base, overlay, err := charm.ExtractBaseAndOverlayParts(bd)
+	c.Assert(err, jc.ErrorIsNil)
+
+	baseYaml, err := yaml.Marshal(base)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert("\n"+string(baseYaml), gc.Equals, expBase)
+
+	overlayYaml, err := yaml.Marshal(overlay)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert("\n"+string(overlayYaml), gc.Equals, expOverlay)
+}
+
 func (*bundleDataOverlaySuite) TestVerifyNoOverlayFieldsPresent(c *gc.C) {
 	data := `
 applications:

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -1,0 +1,84 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package charm_test
+
+import (
+	"strings"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	yaml "gopkg.in/yaml.v2"
+
+	"gopkg.in/juju/charm.v6"
+)
+
+type bundleDataOverlaySuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&bundleDataOverlaySuite{})
+
+func (*bundleDataOverlaySuite) TestExtractBaseAndOverlayParts(c *gc.C) {
+	data := `
+applications:
+  apache2:
+    charm: cs:apache2-26
+    offers:
+      my-offer:
+        endpoints:
+        - apache-website
+        - website-cache
+        acl:
+          admin: admin
+          foo: consume
+      my-other-offer:
+        endpoints:
+        - apache-website
+saas:
+    apache2:
+        url: production:admin/info.apache
+series: bionic
+`
+
+	expBase := `
+applications:
+  apache2:
+    charm: cs:apache2-26
+saas:
+  apache2:
+    url: production:admin/info.apache
+series: bionic
+`
+
+	expOverlay := `
+applications:
+  apache2:
+    offers:
+      my-offer:
+        endpoints:
+        - apache-website
+        - website-cache
+        acl:
+          admin: admin
+          foo: consume
+      my-other-offer:
+        endpoints:
+        - apache-website
+`
+
+	bd, err := charm.ReadBundleData(strings.NewReader(data))
+	c.Assert(err, gc.IsNil)
+
+	base, overlay, err := charm.ExtractBaseAndOverlayParts(bd)
+	c.Assert(err, jc.ErrorIsNil)
+
+	baseYaml, err := yaml.Marshal(base)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert("\n"+string(baseYaml), gc.Equals, expBase)
+
+	overlayYaml, err := yaml.Marshal(overlay)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert("\n"+string(overlayYaml), gc.Equals, expOverlay)
+}


### PR DESCRIPTION
This PR introduces a helper for splitting a BundleData instance into a static (or shared) bundle and an overlay-specific bundle that when merged together yield the original BundleData.

The following CMR-related fields of `Application` and `SaasSpec` have been annotated with a `source:"overlay-only"` tag as part of this PR:

- Application.Offers
- Application.Offers.Endpoints
- Application.Offers.ACL

The PR also includes  a second helper called `VerifyNoOverlayFieldsPresent`. This can be used to verify that a static bundle does not contain any overlay-specific bits.

## How it works

The helper relies on the fact that all BundleData (and friends) define their fields with the `omitempty` modifier for all supported serialization outputs (bson, json and yaml). This allows us to produce the two bundles by duplicating the original bundle and zeroing the fields that we don't need.

This is achieved by tagging fields that should only be included in overlays with `source:"overlay-only"`. The helper will recursively process the BundleData struct fields and:

- For **base** bundles: set any fields that are overlay-specific to their zero value.
- For **overlay** bundles: set any fields that do not contain **any** descendant overlay-specific field to their zero value.

## Example

```yaml
applications:
  apache2:
    charm: cs:apache2-26
    offers:
      my-offer:
        endpoints:
        - apache-website
        - website-cache
      my-other-offer:
        endpoints:
        - apache-website
saas:
    keystone:
        url: production:admin/info.keystone
series: bionic
```

If we annotate `offer`, `endpoints` and `saas.URL` as overlay-only we get

Base bundle:
```yaml
applications:
  apache2:
    charm: cs:apache2-26
saas:
    keystone:
        url: production:admin/info.keystone
series: bionic
```

Overlay bundle:
```yaml
applications:
  apache2:
    offers:
      my-offer:
        endpoints:
        - apache-website
        - website-cache
      my-other-offer:
        endpoints:
        - apache-website
```