### PR TITLE
Allow SAAS to work with relations

### DIFF
--- a/bundledata.go
+++ b/bundledata.go
@@ -756,7 +756,12 @@ func (verifier *bundleDataVerifier) verifyRelations() {
 				relParseErr = true
 				continue
 			}
-			if _, ok := verifier.bd.Applications[ep.application]; !ok {
+			// with the introduction of the SAAS block to bundles, we should
+			// test that not only is the expected application is in the
+			// applications block, but if it's not, is it in the SAAS offering.
+			_, foundApp := verifier.bd.Applications[ep.application]
+			_, foundSaas := verifier.bd.Saas[ep.application]
+			if !foundApp && !foundSaas {
 				verifier.addErrorf("relation %q refers to application %q not defined in this bundle", relPair, ep.application)
 			}
 			epPair[i] = ep

--- a/bundledata.go
+++ b/bundledata.go
@@ -764,6 +764,9 @@ func (verifier *bundleDataVerifier) verifyRelations() {
 			if !foundApp && !foundSaas {
 				verifier.addErrorf("relation %q refers to application %q not defined in this bundle", relPair, ep.application)
 			}
+			if foundApp && foundSaas {
+				verifier.addErrorf("ambiguous relation %q refers to a application and a SAAS in this bundle", ep.application)
+			}
 			epPair[i] = ep
 		}
 		if relParseErr {

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -458,6 +458,8 @@ series: "9wrong"
 saas:
     apache2:
         url: '!some-bogus/url'
+    riak:
+        url: production:admin/info.riak
 machines:
     0:
         constraints: 'bad constraints'
@@ -524,6 +526,7 @@ relations:
     - ["mysql:db", "mediawiki:db"]
     - ["mediawiki/db", "mysql:db"]
     - ["wordpress", "mysql"]
+    - ["wordpress:db", "riak:db"]
 `,
 	errors: []string{
 		`bundle declares an invalid series "9wrong"`,
@@ -552,6 +555,7 @@ relations:
 		`invalid placement syntax "bad placement"`,
 		`invalid relation syntax "mediawiki/db"`,
 		`invalid series bad series for machine "0"`,
+		`ambiguous relation "riak" refers to a application and a SAAS in this bundle`,
 	},
 }, {
 	about: "mediawiki should be ok",

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -316,6 +316,36 @@ applications:
 			},
 		},
 	},
+}, {
+	about: "saas offerings with relations",
+	data: `
+saas:
+    mysql:
+        url: production:admin/info.mysql
+applications:
+    wordpress:
+      charm: "cs:trusty/wordpress-5"
+      num_units: 1
+relations:
+- - wordpress:db
+  - mysql:db
+`,
+	expectedBD: &charm.BundleData{
+		Saas: map[string]*charm.SaasSpec{
+			"mysql": {
+				URL: "production:admin/info.mysql",
+			},
+		},
+		Applications: map[string]*charm.ApplicationSpec{
+			"wordpress": {
+				Charm:    "cs:trusty/wordpress-5",
+				NumUnits: 1,
+			},
+		},
+		Relations: [][]string{
+			{"wordpress:db", "mysql:db"},
+		},
+	},
 }}
 
 func (*bundleDataSuite) TestParse(c *gc.C) {


### PR DESCRIPTION
The verifier needs to ensure that if the application name doesn't
exist in the application block, then check it in the SAAS block
also. That way we can still verify the bundle data ahead of time.