### PR TITLE
SAAS and Application name clashes

### DIFF
--- a/bundledata.go
+++ b/bundledata.go
@@ -541,6 +541,9 @@ var (
 
 func (verifier *bundleDataVerifier) verifySaas() {
 	for name, saas := range verifier.bd.Saas {
+		if _, ok := verifier.bd.Applications[name]; ok {
+			verifier.addErrorf("application %[1]q already exists with SAAS %[1]q name", name)
+		}
 		if !validOfferName.MatchString(name) {
 			verifier.addErrorf("invalid SAAS name %q found", name)
 		}
@@ -580,6 +583,9 @@ func (verifier *bundleDataVerifier) verifyApplications() {
 	for name, app := range verifier.bd.Applications {
 		if app.Charm == "" {
 			verifier.addErrorf("empty charm path")
+		}
+		if _, ok := verifier.bd.Saas[name]; ok {
+			verifier.addErrorf("SAAS %[1]q already exists with application %[1]q name", name)
 		}
 		// Charm may be a local directory or a charm URL.
 		var curl *URL

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -556,6 +556,8 @@ relations:
 		`invalid relation syntax "mediawiki/db"`,
 		`invalid series bad series for machine "0"`,
 		`ambiguous relation "riak" refers to a application and a SAAS in this bundle`,
+		`SAAS "riak" already exists with application "riak" name`,
+		`application "riak" already exists with SAAS "riak" name`,
 	},
 }, {
 	about: "mediawiki should be ok",


### PR DESCRIPTION
Ensure that we don't get application and SAAS name clashes when
verifying the bundle data