### PR TITLE
Overlay merge rules

### DIFF
--- a/bundle.go
+++ b/bundle.go
@@ -3,7 +3,11 @@
 
 package charm
 
-import "os"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
 
 // The Bundle interface is implemented by any type that
 // may be handled as a bundle. It encapsulates all
@@ -26,4 +30,10 @@ func ReadBundle(path string) (Bundle, error) {
 		return ReadBundleDir(path)
 	}
 	return ReadBundleArchive(path)
+}
+
+// IsValidLocalCharmOrBundlePath returns true if path is valid for reading a
+// local charm or bundle.
+func IsValidLocalCharmOrBundlePath(path string) bool {
+	return strings.HasPrefix(path, ".") || filepath.IsAbs(path)
 }

--- a/bundledatasrc_test.go
+++ b/bundledatasrc_test.go
@@ -1,0 +1,131 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package charm
+
+import (
+	"archive/zip"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+)
+
+type BundleDataSourceSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&BundleDataSourceSuite{})
+
+func (s *BundleDataSourceSuite) TestReadBundleFromLocalFile(c *gc.C) {
+	path := bundleDirPath(c, "wordpress-multidoc")
+	src, err := LocalBundleDataSource(filepath.Join(path, "bundle.yaml"))
+	c.Assert(err, gc.IsNil)
+	assertBundleSourceProcessed(c, src)
+}
+
+func (s *BundleDataSourceSuite) TestReadBundleFromExplodedArchiveFolder(c *gc.C) {
+	path := bundleDirPath(c, "wordpress-multidoc")
+	src, err := LocalBundleDataSource(path)
+	c.Assert(err, gc.IsNil)
+	assertBundleSourceProcessed(c, src)
+}
+
+func (s *BundleDataSourceSuite) TestReadBundleFromArchive(c *gc.C) {
+	path := archiveBundleDirPath(c, "wordpress-multidoc")
+	src, err := LocalBundleDataSource(path)
+	c.Assert(err, gc.IsNil)
+	assertBundleSourceProcessed(c, src)
+}
+
+func (s *BundleDataSourceSuite) TestReadBundleFromStream(c *gc.C) {
+	r := strings.NewReader(`
+applications:
+  wordpress:
+    charm: wordpress
+  mysql:
+    charm: mysql
+    num_units: 1
+relations:
+  - ["wordpress:db", "mysql:server"]
+--- # overlay.yaml
+applications:
+  wordpress:
+    offers:
+      offer1:
+        endpoints:
+          - "some-endpoint"
+--- # overlay2.yaml
+applications:
+  wordpress:
+    offers:
+      offer1:
+        acl:
+          admin: "admin"
+          foo: "consume"
+`)
+
+	src, err := StreamBundleDataSource(r, "https://example.com")
+	c.Assert(err, gc.IsNil)
+	assertBundleSourceProcessed(c, src)
+}
+
+func assertBundleSourceProcessed(c *gc.C, src BundleDataSource) {
+	parts := src.Parts()
+	c.Assert(parts, gc.HasLen, 3)
+	assertFieldPresent(c, parts[1], "applications.wordpress.offers.offer1.endpoints")
+	assertFieldPresent(c, parts[2], "applications.wordpress.offers.offer1.acl.admin")
+}
+
+func assertFieldPresent(c *gc.C, part *BundleDataPart, path string) {
+	var (
+		segments             = strings.Split(path, ".")
+		next     interface{} = part.PresenseMap
+	)
+
+	for segIndex, segment := range segments {
+		c.Assert(next, gc.NotNil, gc.Commentf("incomplete path: %s", strings.Join(segments[:segIndex], ".")))
+		switch typ := next.(type) {
+		case FieldPresenseMap:
+			next = typ[segment]
+			c.Assert(next, gc.NotNil, gc.Commentf("incomplete path: %s", strings.Join(segments[:segIndex+1], ".")))
+		default:
+			c.Fatalf("unexpected type %T at path: %s", typ, strings.Join(segments[:segIndex], "."))
+		}
+	}
+}
+
+func bundleDirPath(c *gc.C, name string) string {
+	path := filepath.Join("internal/test-charm-repo/bundle", name)
+	assertIsDir(c, path)
+	return path
+}
+
+func assertIsDir(c *gc.C, path string) {
+	info, err := os.Stat(path)
+	c.Assert(err, gc.IsNil)
+	c.Assert(info.IsDir(), gc.Equals, true)
+}
+
+func archiveBundleDirPath(c *gc.C, name string) string {
+	src := filepath.Join("internal/test-charm-repo/bundle", name, "bundle.yaml")
+	srcYaml, err := ioutil.ReadFile(src)
+	c.Assert(err, gc.IsNil)
+
+	dstPath := filepath.Join(c.MkDir(), "bundle.zip")
+	f, err := os.Create(dstPath)
+	c.Assert(err, gc.IsNil)
+	defer func() { c.Assert(f.Close(), gc.IsNil) }()
+
+	zw := zip.NewWriter(f)
+	defer func() { c.Assert(zw.Close(), gc.IsNil) }()
+	w, err := zw.Create("bundle.yaml")
+	c.Assert(err, gc.IsNil)
+	_, err = w.Write(srcYaml)
+	c.Assert(err, gc.IsNil)
+
+	return dstPath
+}

--- a/internal/test-charm-repo/bundle/wordpress-multidoc/README.md
+++ b/internal/test-charm-repo/bundle/wordpress-multidoc/README.md
@@ -1,0 +1,1 @@
+A dummy bundle

--- a/internal/test-charm-repo/bundle/wordpress-multidoc/bundle.yaml
+++ b/internal/test-charm-repo/bundle/wordpress-multidoc/bundle.yaml
@@ -1,0 +1,23 @@
+applications:
+  wordpress:
+    charm: wordpress
+  mysql:
+    charm: mysql
+    num_units: 1
+relations:
+  - ["wordpress:db", "mysql:server"]
+--- # overlay.yaml
+applications:
+  wordpress:
+    offers:
+      offer1:
+        endpoints:
+          - "some-endpoint"
+--- # overlay2.yaml
+applications:
+  wordpress:
+    offers:
+      offer1:
+        acl:
+          admin: "admin"
+          foo: "consume"

--- a/overlay.go
+++ b/overlay.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/juju/errors"
 	"github.com/mohae/deepcopy"
 )
 
@@ -165,6 +166,9 @@ func visitField(ctx *visitorContext, val interface{}) bool {
 	// De-reference pointers
 	if v.Kind() == reflect.Ptr {
 		v = v.Elem()
+		if v.Kind() == reflect.Invalid {
+			return false
+		}
 		typ = v.Type()
 	}
 
@@ -296,6 +300,8 @@ func isOverlayField(structField reflect.StructField) bool {
 // repo as it has not made its way to a stable Go release yet.
 func isZero(v reflect.Value) bool {
 	switch v.Kind() {
+	case reflect.Invalid:
+		return true
 	case reflect.Bool:
 		return !v.Bool()
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
@@ -329,5 +335,266 @@ func isZero(v reflect.Value) bool {
 		// This should never happens, but will act as a safeguard for
 		// later, as a default value doesn't makes sense here.
 		panic(fmt.Sprintf("unexpected value of type %s passed to isZero", v.Kind().String()))
+	}
+}
+
+// ReadAndMergeBundleData reads N bundle data sources, composes their contents
+// together and returns the result. The first bundle data source is treated as
+// a base bundle while subsequent bundle data sources are treated as overlays
+// which are sequentially merged onto the base bundle.
+//
+// Before returning the merged bundle, ReadAndMergeBundleData will also attempt
+// to resolve any include directives present in the machine annotations,
+// application options and annotations.
+//
+// When merging an overlay into a base bundle the following rules apply for the
+// BundleData struct fields:
+// - if an overlay specifies a bundle-level series, it overrides the base bundle
+//   series.
+// - overlay-defined relations are appended to the base bundle relations
+// - overlay-defined machines overwrite the base bundle machines.
+// - if an overlay defines an application that is not present in the base bundle,
+//   it will get appended to the application list.
+// - if an overlay defines an empty application or saas value, it will be removed
+//   from the base bundle together with any associated relations. For example, to
+//   remove an application named "mysql" the following overlay snippet can be
+//   provided:
+//     applications:
+//       mysql:
+//
+// - if an overlay defines an application that is also present in the base bundle
+//   the two application specs are merged together (see following rules)
+//
+// ApplicationSpec merge rules:
+// - if the overlay defines a value for a scalar or slice field, it will overwrite
+//   the value from the base spec (e.g. trust, series etc).
+// - if the overlay specifies a nil/empty value for a map field, then the map
+//   field of the base spec will be cleared.
+// - if the overlay specifies a non-empty value for a map field, its key/value
+//   tuples are iterated and:
+//   - if the value is nil/zero and the value is non-scalar, it is deleted from
+//     the base spec.
+//   - otherwise, the key/value is inserted into the base spec overwriting any
+//     existing entries.
+func ReadAndMergeBundleData(sources ...BundleDataSource) (*BundleData, error) {
+	var allParts []*BundleDataPart
+	var partSrcIndex []int
+	for srcIndex, src := range sources {
+		if src == nil {
+			continue
+		}
+
+		for _, part := range src.Parts() {
+			allParts = append(allParts, part)
+			partSrcIndex = append(partSrcIndex, srcIndex)
+		}
+	}
+
+	if len(allParts) == 0 {
+		return nil, errors.NotValidf("malformed bundle: bundle is empty")
+	}
+
+	// Treat the first part as the base bundle
+	base := allParts[0]
+	if err := VerifyNoOverlayFieldsPresent(base.Data); err != nil {
+		return nil, err
+	}
+
+	// Merge parts and resolve include directives
+	for index, part := range allParts {
+		if err := applyOverlay(base, part); err != nil {
+			return nil, err
+		}
+	}
+
+	return base.Data, nil
+}
+
+func applyOverlay(base, overlay *BundleDataPart) error {
+	if !overlay.PresenseMap.fieldPresent("applications") && len(overlay.Data.Applications) > 0 {
+		return errors.Errorf("bundle overlay file used deprecated 'services' key, this is not valid for bundle overlay files")
+	}
+
+	// Merge applications
+	if len(overlay.Data.Applications) != 0 {
+		if base.Data.Applications == nil {
+			base.Data.Applications = make(map[string]*ApplicationSpec, len(overlay.Data.Applications))
+		}
+		fpm := overlay.PresenseMap.forField("applications")
+		for srcAppName, srcAppSpec := range overlay.Data.Applications {
+			// If the overlay map points to an empty object, delete
+			// it from the base bundle
+			if isZero(reflect.ValueOf(srcAppSpec)) {
+				delete(base.Data.Applications, srcAppName)
+				base.Data.Relations = removeRelations(base.Data.Relations, srcAppName)
+				continue
+			}
+
+			// if this is a new application just append it; otherwise
+			// recursively merge the two application specs.
+			dstAppSpec, defined := base.Data.Applications[srcAppName]
+			if !defined {
+				base.Data.Applications[srcAppName] = srcAppSpec
+				continue
+			}
+
+			mergeStructs(dstAppSpec, srcAppSpec, fpm.forField(srcAppName))
+		}
+	}
+
+	// Merge SAAS blocks
+	if len(overlay.Data.Saas) != 0 {
+		if base.Data.Saas == nil {
+			base.Data.Saas = make(map[string]*SaasSpec, len(overlay.Data.Saas))
+		}
+
+		fpm := overlay.PresenseMap.forField("saas")
+		for srcSaasName, srcSaasSpec := range overlay.Data.Saas {
+			// If the overlay map points to an empty object, delete
+			// it from the base bundle
+			if isZero(reflect.ValueOf(srcSaasSpec)) {
+				delete(base.Data.Saas, srcSaasName)
+				base.Data.Relations = removeRelations(base.Data.Relations, srcSaasName)
+				continue
+			}
+
+			// if this is a new saas block just append it; otherwise
+			// recursively merge the two saas specs.
+			dstSaasSpec, defined := base.Data.Saas[srcSaasName]
+			if !defined {
+				base.Data.Saas[srcSaasName] = srcSaasSpec
+				continue
+			}
+
+			mergeStructs(dstSaasSpec, srcSaasSpec, fpm.forField(srcSaasName))
+		}
+	}
+
+	// If series is set in the config, it overrides the bundle.
+	if series := overlay.Data.Series; series != "" {
+		base.Data.Series = series
+	}
+
+	// Append any additional relations.
+	base.Data.Relations = append(base.Data.Relations, overlay.Data.Relations...)
+
+	// Override machine definitions.
+	if machines := overlay.Data.Machines; machines != nil {
+		base.Data.Machines = machines
+	}
+
+	return nil
+}
+
+// removeRelations removes any relation defined in data that references
+// the application appName.
+func removeRelations(data [][]string, appName string) [][]string {
+	var result [][]string
+	for _, relation := range data {
+		// Keep the dud relation in the set, it will be caught by the bundle
+		// verify code.
+		if len(relation) == 2 {
+			left, right := relation[0], relation[1]
+			if left == appName || strings.HasPrefix(left, appName+":") ||
+				right == appName || strings.HasPrefix(right, appName+":") {
+				continue
+			}
+		}
+		result = append(result, relation)
+	}
+	return result
+}
+
+// mergeStructs iterates the fields of srcStruct and merges them into the
+// equivalent fields of dstStruct using the following rules:
+//
+// - if src defines a value for a scalar or slice field, it will overwrite
+//   the value from the dst (e.g. trust, series etc).
+// - if the src specifies a nil/empty value for a map field, then the map
+//   field of dst will be cleared.
+// - if the src specifies a non-empty value for a map field, its key/value
+//   tuples are iterated and:
+//   - if the value is nil/zero and non-scalar, it is deleted from the dst map.
+//   - otherwise, the key/value is inserted into the dst map overwriting any
+//     existing entries.
+func mergeStructs(dstStruct, srcStruct interface{}, fpm FieldPresenseMap) {
+	dst := reflect.ValueOf(dstStruct)
+	src := reflect.ValueOf(srcStruct)
+	typ := src.Type()
+
+	// Dereference pointers
+	if src.Kind() == reflect.Ptr {
+		src = src.Elem()
+		typ = src.Type()
+	}
+	if dst.Kind() == reflect.Ptr {
+		dst = dst.Elem()
+	}
+	dstTyp := dst.Type()
+
+	// Sanity check
+	if typ.Kind() != reflect.Struct || typ != dstTyp {
+		panic(errors.Errorf("BUG: source/destination type mismatch; expected destination to be a %q; got %q", typ.Name(), dstTyp.Name()))
+	}
+
+	for i := 0; i < typ.NumField(); i++ {
+		// Skip non-exportable fields
+		structField := typ.Field(i)
+		srcVal := src.Field(i)
+		if !srcVal.CanInterface() {
+			continue
+		}
+
+		fieldName := yamlName(structField)
+		if !fpm.fieldPresent(fieldName) {
+			continue
+		}
+
+		switch srcVal.Kind() {
+		case reflect.Map:
+			// If a nil/empty map is provided then clear the destination map.
+			if isZero(srcVal) {
+				dst.Field(i).Set(reflect.MakeMap(srcVal.Type()))
+				continue
+			}
+
+			dstMap := dst.Field(i)
+			if dstMap.IsNil() {
+				dstMap.Set(reflect.MakeMap(srcVal.Type()))
+			}
+			for _, srcKey := range srcVal.MapKeys() {
+				// If the key points to an empty non-scalar value delete it from the dst map
+				srcMapVal := srcVal.MapIndex(srcKey)
+				if isZero(srcMapVal) && isNonScalar(srcMapVal) {
+					// Setting an empty value effectively deletes the key from the map
+					dstMap.SetMapIndex(srcKey, reflect.Value{})
+					continue
+				}
+
+				dstMap.SetMapIndex(srcKey, srcMapVal)
+			}
+		case reflect.Slice:
+			dst.Field(i).Set(srcVal)
+		default:
+			dst.Field(i).Set(srcVal)
+		}
+	}
+}
+
+// isNonScalar returns true if val is a non-scalar value such as a pointer,
+// struct, map or slice.
+func isNonScalar(val reflect.Value) bool {
+	kind := val.Kind()
+
+	if kind == reflect.Interface {
+		kind = reflect.TypeOf(val).Kind()
+	}
+
+	switch kind {
+	case reflect.Ptr, reflect.Struct,
+		reflect.Map, reflect.Slice, reflect.Array:
+		return true
+	default:
+		return false
 	}
 }

--- a/overlay_internal_test.go
+++ b/overlay_internal_test.go
@@ -1,0 +1,64 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package charm
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type removeRelationsSuite struct{}
+
+var (
+	_ = gc.Suite(&removeRelationsSuite{})
+
+	sampleRelations = [][]string{
+		{"kubernetes-master:kube-control", "kubernetes-worker:kube-control"},
+		{"kubernetes-master:etcd", "etcd:db"},
+		{"kubernetes-worker:kube-api-endpoint", "kubeapi-load-balancer:website"},
+		{"flannel", "etcd"}, // removed :endpoint
+		{"flannel:cni", "kubernetes-master:cni"},
+		{"flannel:cni", "kubernetes-worker:cni"},
+	}
+)
+
+func (*removeRelationsSuite) TestNil(c *gc.C) {
+	result := removeRelations(nil, "foo")
+	c.Assert(result, gc.HasLen, 0)
+}
+
+func (*removeRelationsSuite) TestEmpty(c *gc.C) {
+	result := removeRelations([][]string{}, "foo")
+	c.Assert(result, gc.HasLen, 0)
+}
+
+func (*removeRelationsSuite) TestAppNotThere(c *gc.C) {
+	result := removeRelations(sampleRelations, "foo")
+	c.Assert(result, jc.DeepEquals, sampleRelations)
+}
+
+func (*removeRelationsSuite) TestAppBadRelationsKept(c *gc.C) {
+	badRelations := [][]string{{"single value"}, {"three", "string", "values"}}
+	result := removeRelations(badRelations, "foo")
+	c.Assert(result, jc.DeepEquals, badRelations)
+}
+
+func (*removeRelationsSuite) TestRemoveFromRight(c *gc.C) {
+	result := removeRelations(sampleRelations, "etcd")
+	c.Assert(result, jc.DeepEquals, [][]string{
+		{"kubernetes-master:kube-control", "kubernetes-worker:kube-control"},
+		{"kubernetes-worker:kube-api-endpoint", "kubeapi-load-balancer:website"},
+		{"flannel:cni", "kubernetes-master:cni"},
+		{"flannel:cni", "kubernetes-worker:cni"},
+	})
+}
+
+func (*removeRelationsSuite) TestRemoveFromLeft(c *gc.C) {
+	result := removeRelations(sampleRelations, "flannel")
+	c.Assert(result, jc.DeepEquals, [][]string{
+		{"kubernetes-master:kube-control", "kubernetes-worker:kube-control"},
+		{"kubernetes-master:etcd", "etcd:db"},
+		{"kubernetes-worker:kube-api-endpoint", "kubeapi-load-balancer:website"},
+	})
+}

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -4,6 +4,8 @@
 package charm_test
 
 import (
+	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 
@@ -180,4 +182,368 @@ series: bionic
 	sort.Strings(errStrings)
 	sort.Strings(expErrors)
 	c.Assert(errStrings, jc.DeepEquals, expErrors)
+}
+
+func (*bundleDataOverlaySuite) TestOverrideCharmAndSeries(c *gc.C) {
+	testBundleMergeResult(c, `
+applications:
+  apache2:
+    charm: cs:apache2-26
+    num_units: 1
+---
+series: trusty
+applications:
+  apache2:
+    charm: cs:apache2-42
+    series: bionic
+`, `
+applications:
+  apache2:
+    charm: cs:apache2-42
+    series: bionic
+    num_units: 1
+series: trusty
+`,
+	)
+}
+
+func (*bundleDataOverlaySuite) TestAddAndOverrideResourcesStorageDevicesAndBindings(c *gc.C) {
+	testBundleMergeResult(c, `
+applications:
+  apache2:
+    charm: cs:apache2-26
+    resources:
+      res1: foo
+    storage:
+      dsk0: dsk0
+    devices:
+      dev0: dev0
+---
+applications:
+  apache2:
+    resources:
+      res1: bar
+      res2: new
+    storage:
+      dsk0: vol0
+      dsk1: new
+    devices:
+      dev0: net
+      dev1: new
+    bindings:
+      bnd0: new
+`, `
+applications:
+  apache2:
+    charm: cs:apache2-26
+    resources:
+      res1: bar
+      res2: new
+    storage:
+      dsk0: vol0
+      dsk1: new
+    devices:
+      dev0: net
+      dev1: new
+    bindings:
+      bnd0: new
+`,
+	)
+}
+
+func (*bundleDataOverlaySuite) TestAddAndOverrideOptionsAndAnnotations(c *gc.C) {
+	testBundleMergeResult(c, `
+applications:
+  apache2:
+    charm: cs:apache2-26
+    options:
+      opt1: foo
+      opt1: bar
+      mapOpt:
+        foo: bar
+---
+applications:
+  apache2:
+    options:
+      opt1: foo
+      opt2: ""
+      mapOpt:
+    annotations:
+      ann1: new
+`, `
+applications:
+  apache2:
+    charm: cs:apache2-26
+    options:
+      opt1: foo
+      opt2: ""
+    annotations:
+      ann1: new
+`,
+	)
+}
+
+func (*bundleDataOverlaySuite) TestOverrideUnitsTrustConstraintsAndExposeFlags(c *gc.C) {
+	testBundleMergeResult(c, `
+applications:
+  apache2:
+    charm: cs:apache2-26
+---
+applications:
+  apache2:
+    num_units: 4
+    to:
+    - lxd/0
+    - lxd/1
+    - lxd/2
+    - lxd/3
+    expose: true
+`, `
+applications:
+  apache2:
+    charm: cs:apache2-26
+    num_units: 4
+    to:
+    - lxd/0
+    - lxd/1
+    - lxd/2
+    - lxd/3
+    expose: true
+`,
+	)
+}
+
+func (*bundleDataOverlaySuite) TestAddModifyAndRemoveApplicationsAndRelations(c *gc.C) {
+	testBundleMergeResult(c, `
+applications:
+  apache2:
+    charm: cs:apache2-26
+  wordpress:
+    charm: cs:wordpress-2
+  dummy:
+    charm: cs:dummy
+relations:
+- - wordpress:www
+  - apache2:www
+---
+applications:
+  apache2:
+    charm: cs:apache2-42
+  wordpress: 
+relations:
+- - dummy:www
+  - apache2:www
+`, `
+applications:
+  apache2:
+    charm: cs:apache2-42
+  dummy:
+    charm: cs:dummy
+relations:
+- - dummy:www
+  - apache2:www
+`,
+	)
+}
+
+func (*bundleDataOverlaySuite) TestAddModifyAndRemoveSaasBlocksAndRelations(c *gc.C) {
+	testBundleMergeResult(c, `
+saas:
+  postgres:
+    url: jaas:admin/default.postgres
+applications:
+  wordpress:
+    charm: cs:wordpress-2
+relations:
+- - wordpress:db
+  - postgres:db
+---
+saas:
+  postgres: 
+  cockroachdb:
+    url: jaas:admin/default.cockroachdb
+`, `
+applications:
+  wordpress:
+    charm: cs:wordpress-2
+saas:
+  cockroachdb:
+    url: jaas:admin/default.cockroachdb
+`,
+	)
+}
+
+func (*bundleDataOverlaySuite) TestAddAndRemoveOffers(c *gc.C) {
+	testBundleMergeResult(c, `
+applications:
+  apache2:
+    charm: cs:apache2-26
+--- # offer blocks are overlay-specific
+applications:
+  apache2:
+    offers:
+      my-offer:
+        endpoints:
+        - apache-website
+        - website-cache
+        acl:
+          admin: admin
+          foo: consume
+      my-other-offer:
+        endpoints:
+        - apache-website
+--- 
+applications:
+  apache2:
+    offers:
+      my-other-offer:
+`, `
+applications:
+  apache2:
+    charm: cs:apache2-26
+    offers:
+      my-offer:
+        endpoints:
+        - apache-website
+        - website-cache
+        acl:
+          admin: admin
+          foo: consume
+`,
+	)
+}
+
+func (*bundleDataOverlaySuite) TestAddAndRemoveMachines(c *gc.C) {
+	testBundleMergeResult(c, `
+applications:
+  apache2:
+    charm: cs:apache2-26
+machines:
+  "0": {}
+  "1": {}
+---
+machines:
+  "2": {}
+`, `
+applications:
+  apache2:
+    charm: cs:apache2-26
+machines:
+  "2": {}
+`,
+	)
+}
+
+func (*bundleDataOverlaySuite) TestYAMLInterpolation(c *gc.C) {
+	base := `
+applications:
+    django:
+        expose: true
+        charm: cs:django
+        num_units: 1
+        options:
+            general: good
+        annotations:
+            key1: value1
+            key2: value2
+        to: [1]
+    memcached:
+        charm: xenial/mem-47
+        num_units: 1
+        options:
+            key: value
+relations:
+    - - "django"
+      - "memcached"
+machines:
+    1:
+        annotations: {foo: bar}`
+
+	removeDjango := `
+applications:
+    django:
+`
+
+	addWiki := `
+defaultwiki: &DEFAULTWIKI
+    charm: "cs:trusty/mediawiki-5"
+    num_units: 1
+    options: &WIKIOPTS
+        debug: false
+        name: Please set name of wiki
+        skin: vector
+
+applications:
+    wiki:
+        <<: *DEFAULTWIKI
+        options:
+            <<: *WIKIOPTS
+            name: The name override
+relations:
+    - - "wiki"
+      - "memcached"
+`
+
+	bd, err := charm.ReadAndMergeBundleData(
+		mustCreateStringDataSource(c, base),
+		mustCreateStringDataSource(c, removeDjango),
+		mustCreateStringDataSource(c, addWiki),
+	)
+	c.Assert(err, gc.IsNil)
+
+	merged, err := yaml.Marshal(bd)
+	c.Assert(err, gc.IsNil)
+
+	exp := `
+applications:
+  memcached:
+    charm: xenial/mem-47
+    num_units: 1
+    options:
+      key: value
+  wiki:
+    charm: cs:trusty/mediawiki-5
+    num_units: 1
+    options:
+      debug: false
+      name: The name override
+      skin: vector
+machines:
+  "1":
+    annotations:
+      foo: bar
+relations:
+- - wiki
+  - memcached
+`
+
+	c.Assert("\n"+string(merged), gc.Equals, exp)
+}
+
+// testBundleMergeResult reads and merges the bundle and any overlays in src,
+// serializes the merged bundle back to yaml and compares it with exp.
+func testBundleMergeResult(c *gc.C, src, exp string) {
+	bd, err := charm.ReadAndMergeBundleData(mustCreateStringDataSource(c, src))
+	c.Assert(err, gc.IsNil)
+
+	merged, err := yaml.Marshal(bd)
+	c.Assert(err, gc.IsNil)
+	c.Assert("\n"+string(merged), gc.Equals, exp)
+}
+
+func mustWriteFile(c *gc.C, path, content string) {
+	err := ioutil.WriteFile(path, []byte(content), os.ModePerm)
+	c.Assert(err, gc.IsNil)
+}
+
+func mustCreateLocalDataSource(c *gc.C, path string) charm.BundleDataSource {
+	ds, err := charm.LocalBundleDataSource(path)
+	c.Assert(err, gc.IsNil, gc.Commentf(path))
+	return ds
+}
+
+func mustCreateStringDataSource(c *gc.C, data string) charm.BundleDataSource {
+	ds, err := charm.StreamBundleDataSource(strings.NewReader(data), "")
+	c.Assert(err, gc.IsNil)
+	return ds
 }


### PR DESCRIPTION
This PR uses reflection to _re-implement_ the overlay -> base bundle merge logic that currently lives in the juju CLI. In my opinion, since the charms package contains the various bundle-related struct definitions it should also encapsulate the logic for applying overlays. In my view, the proposed implementation is a bit cleaner (less if blocks) and in contrast to the existing implementation it supports automatic merging of **all** application spec fields (e.g. trust, offers etc.).

## Working with multi-doc and standalone overlay files

The first part of the PR introduces a new set of abstractions for dealing with overlays which can now be either specified both as:
- **multi-doc** yaml documents (the new way)
- **standalone** yaml documents (the current way)

The key abstraction is a new interface called `BundleDataSource` which provides a `Parts` method that yields a list of `BundleDataPart` instances. Each `BbundleDataPart`  encapsulates a parsed `BundleData` instance and a field presence map which the overlay merging logic queries to figure out whether empty/nil `BundleData` fields were actually specified as such or were simply missing from the bundle data stream and therefore should be ignored when merging.

To make integration with the CLI code easier, the charms package provides two concrete implementations of the `BundleDataSource` interface:

- **LocalBundleDataSource** which reads a (potentially multi-doc) yaml file/folder/archive from disk.
- **StreamBundleDataSource** which reads a (potentially multi-doc) yaml stream from an `io.Reader`. This is primarily used for testing but external packages could leverage this for their own `BundleDataSource` implementations (e.g. to read data off an http response).

## Ok, so how do I get the final merged bundle?

The charms package provides a convenience helper function called `ReadAndMergeBundleData` that 
receives as input a slice of `BundleDataSource` instances. The function will fetch their contents, treat the **first** `bundleDataPart` as the base bundle and all other parts as overlays. The overlays will be sequentially applied to the base bundle and the final, merged bundle is returned back to the caller. 

Before the final bundle is returned to the caller, the helper will iterate the values of application options/annotations and machine annotations looking for the presence of special **include-directives** (identified via the prefix `include-file://` or `include-base64://`). Any include directives are resolved relative to the **base path** of the base bundle which is only non-empty for local bundle paths (yaml files or exploded archives) but _not_ for charm archives.

## Overlay merge rules

While the original CLI code seems to follow some straightforward patterns when merging maps, there are a few exceptions which need to be handled in a slightly different manner. This implementation attempts to re-produce the exact merge behavior and comes with a very verbose test to make sure everything works as expected ™️ 

When merging an overlay into a base bundle the following rules apply for the
BundleData struct fields:
- if an overlay specifies a bundle-level series, it overrides the base bundle
  series.
- overlay-defined relations are appended to the base bundle relations
- overlay-defined machines overwrite the base bundle machines.
- if an overlay defines an application that is not present in the base bundle,
  it will get appended to the application list.
- if an overlay defines an empty application value, it will be removed from base bundle together with any associated relations. For example, to remove an application named "mysql" the following overlay snippet can be  provided:
     ```yaml 
     applications:
        mysql:
     ```
- if an overlay defines an application that is also present in the base bundle
  the two application specs are merged together (see following rules)
- the above application-specific rules **also** apply when merging **sass** blocks.

ApplicationSpec merge rules:
- if the overlay defines a value for a scalar or slice field, it will overwrite
  the value from the base spec (e.g. trust, series etc).
- if the overlay specifies a nil/empty value for a map field, then the map
  field of the base spec will be cleared.
- if the overlay specifies a non-empty value for a map field, its key/value
  tuples are iterated and:
  - if the value is nil/zero and the type of the value is non-scalar, it is deleted from the base spec
  - otherwise, the key/value is inserted into the base spec overwriting any
    existing entries.