### PR TITLE
Add 'Channel' attribute to the bundle application spec

### DIFF
--- a/bundledata.go
+++ b/bundledata.go
@@ -193,6 +193,10 @@ type ApplicationSpec struct {
 	// use for the given application.
 	Charm string `bson:",omitempty" yaml:",omitempty" json:",omitempty"`
 
+	// Channel describes the preferred channel to use when deploying a
+	// remote charm.
+	Channel string `bson:"channel,omitempty" yaml:"channel,omitempty" json:"channel,omitempty"`
+
 	// Series is the series to use when deploying a local charm,
 	// if the charm does not specify a default or the default
 	// is not the desired value.

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -346,6 +346,24 @@ relations:
 			{"wordpress:db", "mysql:db"},
 		},
 	},
+}, {
+	about: "charm channel",
+	data: `
+applications:
+    wordpress:
+      charm: "cs:trusty/wordpress-5"
+      channel: edge
+      num_units: 1
+`,
+	expectedBD: &charm.BundleData{
+		Applications: map[string]*charm.ApplicationSpec{
+			"wordpress": {
+				Charm:    "cs:trusty/wordpress-5",
+				Channel:  "edge",
+				NumUnits: 1,
+			},
+		},
+	},
 }}
 
 func (*bundleDataSuite) TestParse(c *gc.C) {

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -165,6 +165,7 @@ applications:
           foo: consume
   wordpress:
     charm: cs:wordpress
+    channel: edge
     scale: 2
     options:
       foo: bar
@@ -182,6 +183,7 @@ applications:
     num_units: 1
   wordpress:
     charm: cs:wordpress
+    channel: edge
     series: kubernetes
     num_units: 2
     options:


### PR DESCRIPTION
This PR extends the `ApplicationSpec` type with a `Channel` attribute that bundle authors can use to override the channel where each bundle charm is pulled from.

Note: the PR does not add a validation step for channels as the valid list of channels currently lives in the `charmrepo` package which depends on the charm package. However, the charmrepo package URL resolving code will be updated with a separate PR to validate channels so validation will not be an issue.