### PR TITLE
Prevent panic in visitField when a nil value is passed as an argument

### DIFF
--- a/overlay.go
+++ b/overlay.go
@@ -170,6 +170,9 @@ type visitorContext struct {
 // the visitor's result. On the other hand, if val is a slice or a map,
 // visitField invoke specialized functions that support iterating such types.
 func visitField(ctx *visitorContext, val interface{}) bool {
+	if val == nil {
+		return false
+	}
 	typ := reflect.TypeOf(val)
 	v := reflect.ValueOf(val)
 

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -278,6 +278,28 @@ series: bionic
 	c.Assert(errStrings, jc.DeepEquals, expErrors)
 }
 
+func (*bundleDataOverlaySuite) TestVerifyNoOverlayFieldsPresentOnNilOptionValue(c *gc.C) {
+	data := `
+# ssl_ca is left uninitialized so it resolves to nil
+ssl_ca: &ssl_ca
+
+applications:
+  apache2:
+    options:
+      foo: bar
+      ssl_ca: *ssl_ca
+series: bionic
+`
+
+	bd, err := charm.ReadBundleData(strings.NewReader(data))
+	c.Assert(err, gc.IsNil)
+
+	static, _, err := charm.ExtractBaseAndOverlayParts(bd)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(charm.VerifyNoOverlayFieldsPresent(static), gc.Equals, nil)
+}
+
 func (*bundleDataOverlaySuite) TestOverrideCharmAndSeries(c *gc.C) {
 	testBundleMergeResult(c, `
 applications:


### PR DESCRIPTION
Calling reflect.ValueOf() on a nil value and then invoking Kind() on the
returned reflected Type causes a panic.