### PR TITLE
bugfix charmdir: commands are called relative from the current folder…

### DIFF
--- a/charmdir.go
+++ b/charmdir.go
@@ -433,7 +433,7 @@ func (dir *CharmDir) MaybeGenerateVersionString() (string, string, error) {
 
 	vcsType := cmdArgs[0]
 	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
-	// We need to make sure that the wd will be the one we call the commands from.
+	// We need to make sure that the working directory will be the one we execute the commands from.
 	cmd.Dir = dir.Path
 	// version string value is written to stdout if successful.
 	out, err := cmd.Output()

--- a/charmdir.go
+++ b/charmdir.go
@@ -433,6 +433,8 @@ func (dir *CharmDir) MaybeGenerateVersionString() (string, string, error) {
 
 	vcsType := cmdArgs[0]
 	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
+	// We need to make sure that the wd will be the one we call the commands from.
+	cmd.Dir = dir.Path
 	// version string value is written to stdout if successful.
 	out, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
… given not the one we want

## Description
Fixes the bug where deploying a local charm leads to a confusing error message  
```
23:43:24 WARN  juju.charm charmdir.go:253 "git" version string generation failed : exit status 128
This means that the charm version won't show in juju status.
```
Further bug description and reasoning can be found here: https://bugs.launchpad.net/juju/+bug/1789447
https://bugs.launchpad.net/juju/+bug/1789447/comments/4

tl;dr `exec.Command.dir` has to be set in order to execute the commands from the expected directory

If not set it can lead to the following:
```
{
	"_id" : "6cd66a77-46a8-4b33-8167-8201c36b0bfa:local:bionic/postgresql-3",
	"model-uuid" : "6cd66a77-46a8-4b33-8167-8201c36b0bfa",
	"url" : "local:bionic/postgresql-3",
	"charm-version" : "juju-2.6.9-970-gccfa7c4d9f-dirty",
	"life" : 0,
....
}
```
## QA Steps
1. Create a Model `juju add-model postgres`
2. Download a local charm ```git clone -b built \
    https://git.launchpad.net/postgresql-charm postgresql```
3. cd into a folder without ".git"  `cd ~/gitlessFolder` 
4. deploy the local charm `juju deploy ~/charmfolder/pgrescharm` 