### PR TITLE
Refactor version handling for charmdir usage

### DIFF
--- a/meta_test.go
+++ b/meta_test.go
@@ -1548,6 +1548,10 @@ func (s *MetaSuite) TestParseResourceMetaNil(c *gc.C) {
 
 type dummyCharm struct{}
 
+func (c *dummyCharm) Version() string {
+	panic("unused")
+}
+
 func (c *dummyCharm) Config() *charm.Config {
 	panic("unused")
 }


### PR DESCRIPTION
## Summary
bugfix: adds version to charmdir interface
charmdir: adds version file parsing to
refactor: version parsing is done from the beginning instead during archiveTo

## Disclaimer
one thing I am not 100% sure is, by extracting the version generation from "archiveTo" to the initial "charmdir" creation, any updates which happen between "creation" and "archiveTo" would not be added. I am not sure whether there can be any updates anyway and should be. I will add this to the PR as "disclaimer" to think about it while going through.

One could be 100% sure and just recreate the `versionstring` by calling the function again in `archiveTo`. For now I did not include this as part of discussion.

I did, on purpose, not add the Version method to the interface as this would mean to change multiple other repos as. It would make sense but it would lead to a lot of pr's which I wanted to keep out for now.


## Description
Currently, the version for `charmDir` only gets created when `archiveTo` is called.
There can be cases that we have no vcs, but a version file located like in the `charmArchives`

This PR should address this issue by doing:
- refactor when we create the version number 
- add a way to parse the version file
- add a more sophisticated error message
