### PR TITLE
version file check: example how version check can be done

### DIFF
--- a/charmdir_test.go
+++ b/charmdir_test.go
@@ -309,16 +309,14 @@ func (s *CharmSuite) TestArchiveToWithVersionStringError(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer loggo.RemoveWriter("versionstring-test")
 
+	msg := fmt.Sprintf("%q version string generation failed : exit status 128\nThis means that the charm version won't show in juju status. Charm path %q", "git", dir.Path)
+
 	_, _, err = dir.MaybeGenerateVersionString(loggo.Logger{})
-	c.Assert(err, gc.ErrorMatches, "exit status 128")
+	c.Assert(err, gc.ErrorMatches, msg)
 
 	err = dir.ArchiveTo(file)
 	_ = file.Close()
 	c.Assert(err, jc.ErrorIsNil)
-
-	msg := `
-"git" version string generation failed : exit status 128
-This means that the charm version won't show in juju status.`[1:]
 
 	c.Assert(tw.Log(), jc.LogMatches, jc.SimpleMessages{{
 		loggo.WARNING, msg,
@@ -581,7 +579,8 @@ func (s *CharmSuite) TestMaybeGenerateVersionStringError(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	version, vcsType, err := dir.MaybeGenerateVersionString(loggo.Logger{})
-	c.Assert(err, gc.ErrorMatches, "exit status 128")
+	msg := fmt.Sprintf("%q version string generation failed : exit status 128\nThis means that the charm version won't show in juju status. Charm path %q", "git", dir.Path)
+	c.Assert(err, gc.ErrorMatches, msg)
 	c.Assert(version, gc.Equals, "")
 	c.Assert(vcsType, gc.Equals, "git")
 }


### PR DESCRIPTION
This PR is only used as a discussion point to changing the way we find the version of charms.

Unsure about the way we do the err handling.
Still needs to adapt the unit tests
uses cmd quite a lot (I don't like)

## Problem Current Implementation
- Does not take into consideration if the charm is a subdir of a versioned charm

## Possible Solution 1
- Try each vcs
- solves the above problem
### Disadvantage
- Makes more sophisticated err handling difficult. Let's say a `git describe ...` fails for some reason the code just thinks it is not related to git and "tries" the next one
   - We can either log on every fail case -> convolute Log 
   - We do not log -> missing information for case it fails but actually is under git

## Possible Solution 2
- Try each vcs
- for each vcs (especially git) have a own func which handles err and as well as does a check whether it exists or not


## Unsure
- each implementation calls cmd in worst case get's calls multiple times