### PR TITLE
logging fix, ensure git timeout handle, only read version on charmdir archiving 

### DIFF
--- a/charmdir.go
+++ b/charmdir.go
@@ -123,10 +123,6 @@ func ReadCharmDir(path string) (dir *CharmDir, err error) {
 		}
 	}
 
-	var dummyLogger = NopLogger{}
-	version, _, _ := dir.MaybeGenerateVersionString(dummyLogger)
-	dir.version = version
-
 	file, err = os.Open(dir.join("lxd-profile.yaml"))
 	if _, ok := err.(*os.PathError); ok {
 		dir.lxdProfile = NewLXDProfile()

--- a/charmdir_test.go
+++ b/charmdir_test.go
@@ -6,12 +6,14 @@ package charm_test
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/juju/collections/set"
 	"github.com/juju/loggo"
@@ -640,4 +642,24 @@ func (s *CharmSuite) TestNoVCSMaybeGenerateVersionString(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(versionString, gc.Equals, "")
 	c.Assert(vcsType, gc.Equals, "")
+}
+
+// We expect it to be successful because we set the timeout to be high and the executable "git" returns error code 0
+func (s *CharmSuite) TestCheckGitIsUsed(c *gc.C) {
+	charmDir := cloneDir(c, charmDirPath(c, "dummy"))
+	testing.PatchExecutableAsEchoArgs(c, s, "git")
+	cmdWaitTime := 100 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), cmdWaitTime)
+	isUsing := charm.UsesGit(charmDir, ctx, cancel)
+	c.Assert(isUsing, gc.Equals, true)
+}
+
+// We create the executable "git" and still expect it to "fail" because we set the timeout to be 0
+func (s *CharmSuite) TestCheckGitTimeout(c *gc.C) {
+	charmDir := cloneDir(c, charmDirPath(c, "dummy"))
+	testing.PatchExecutableAsEchoArgs(c, s, "git")
+	cmdWaitTime := 0 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), cmdWaitTime)
+	isUsing := charm.UsesGit(charmDir, ctx, cancel)
+	c.Assert(isUsing, gc.Equals, false)
 }

--- a/charmdir_test.go
+++ b/charmdir_test.go
@@ -251,17 +251,15 @@ func (s *CharmSuite) TestMaybeGenerateVersionStringHasAVersionFile(c *gc.C) {
 	charmDir := cloneDir(c, charmDirPath(c, "dummy"))
 	versionFile := filepath.Join(charmDir, "version")
 	f, err := os.Create(versionFile)
-	defer f.Close()
 	c.Assert(err, jc.ErrorIsNil)
+	defer f.Close()
 
 	expectedVersionNumber := "123456789abc"
 	_, err = f.WriteString(expectedVersionNumber)
 	c.Assert(err, jc.ErrorIsNil)
 
 	dir, err := charm.ReadCharmDir(charmDir)
-
 	c.Assert(err, gc.IsNil)
-	c.Assert(dir.Version(), gc.Equals, expectedVersionNumber)
 
 	version, vcsType, err := dir.MaybeGenerateVersionString(loggo.Logger{})
 	c.Assert(version, gc.Equals, expectedVersionNumber)


### PR DESCRIPTION
- logging fix -> old pr had a logger left
- ensure git timeout handle -> sometimes, rarely it seems that this command can hang
- only read version on charmdir archiving  -> this ensures same behaviour as before  
   -  thus removing charmdir version reading on reading the charmdir. This seem to have caused some unexpected behaviours in some juju/juju tests. As this was not used anyway there was no win.