### PR TITLE
Use absolute path when creating error messages for missing bundle includes

### DIFF
--- a/bundledatasrc.go
+++ b/bundledatasrc.go
@@ -80,19 +80,19 @@ func (s *resolvedBundleDataSource) ResolveInclude(path string) ([]byte, error) {
 	info, err := os.Stat(absPath)
 	if err != nil {
 		if isNotExistsError(err) {
-			return nil, errors.NotFoundf("include file %q", path)
+			return nil, errors.NotFoundf("include file %q", absPath)
 		}
 
-		return nil, errors.Annotatef(err, "stat failed for %q", path)
+		return nil, errors.Annotatef(err, "stat failed for %q", absPath)
 	}
 
 	if info.IsDir() {
-		return nil, errors.Errorf("include path %q resolves to a folder", path)
+		return nil, errors.Errorf("include path %q resolves to a folder", absPath)
 	}
 
 	data, err := ioutil.ReadFile(absPath)
 	if err != nil {
-		return nil, errors.Annotatef(err, "reading include file at %q", path)
+		return nil, errors.Annotatef(err, "reading include file at %q", absPath)
 	}
 
 	return data, nil

--- a/bundledatasrc_test.go
+++ b/bundledatasrc_test.go
@@ -131,6 +131,9 @@ func (s *BundleDataSourceSuite) TestResolveRelativeFileInclude(c *gc.C) {
 }
 
 func (s *BundleDataSourceSuite) TestResolveIncludeErrors(c *gc.C) {
+	cwd, err := os.Getwd()
+	c.Assert(err, gc.IsNil)
+
 	tmpDir := c.MkDir()
 	specs := []struct {
 		descr   string
@@ -145,7 +148,7 @@ func (s *BundleDataSourceSuite) TestResolveIncludeErrors(c *gc.C) {
 		{
 			descr:   "rel path does not exist",
 			incPath: "./missing",
-			exp:     `include file "./missing" not found`,
+			exp:     `include file "` + cwd + `/missing" not found`,
 		},
 		{
 			descr:   "path points to directory",


### PR DESCRIPTION
When resolving missing includes for a base bundle or an overlay, the
generated error messages used to specify the relative include path to
the missing resource.

The emitted error was of no use to the end-user as it omitted a critical
piece of information: the *base* path for the bundle/overlay that was
used to resolve the relative include path.

This PR attempts to address this issue by modifying the
aforementioned error messages to include the absolute path to the
missing resource.

These changes are required for improving error output as requested by https://bugs.launchpad.net/juju/+bug/1851817