### PR TITLE
Add k8s deployment mode for workload vs operator

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -158,6 +158,14 @@ const (
 	DeploymentDaemon    DeploymentType = "daemon"
 )
 
+// DeploymentMode defines a deployment mode.
+type DeploymentMode string
+
+const (
+	ModeOperator DeploymentMode = "operator"
+	ModeWorkload DeploymentMode = "workload"
+)
+
 // ServiceType defines a service type.
 type ServiceType string
 
@@ -181,6 +189,7 @@ var validServiceTypes = map[os.OSType][]ServiceType{
 // metadata.yaml file.
 type Deployment struct {
 	DeploymentType DeploymentType `bson:"type"`
+	DeploymentMode DeploymentMode `bson:"mode"`
 	ServiceType    ServiceType    `bson:"service"`
 	MinVersion     string         `bson:"min-version"`
 }
@@ -965,6 +974,9 @@ func parseDeployment(deployment interface{}, charmSeries []string, storage map[s
 	if deploymentType, ok := deploymentMap["type"].(string); ok {
 		result.DeploymentType = DeploymentType(deploymentType)
 	}
+	if deploymentMode, ok := deploymentMap["mode"].(string); ok {
+		result.DeploymentMode = DeploymentMode(deploymentMode)
+	}
 	if serviceType, ok := deploymentMap["service"].(string); ok {
 		result.ServiceType = ServiceType(serviceType)
 	}
@@ -1113,6 +1125,10 @@ var deploymentSchema = schema.FieldMap(
 			schema.Const(string(DeploymentStateless)),
 			schema.Const(string(DeploymentDaemon)),
 		),
+		"mode": schema.OneOf(
+			schema.Const(string(ModeOperator)),
+			schema.Const(string(ModeWorkload)),
+		),
 		"service": schema.OneOf(
 			schema.Const(string(ServiceCluster)),
 			schema.Const(string(ServiceLoadBalancer)),
@@ -1122,6 +1138,7 @@ var deploymentSchema = schema.FieldMap(
 		"min-version": schema.String(),
 	}, schema.Defaults{
 		"type":        schema.Omit,
+		"mode":        string(ModeWorkload),
 		"service":     schema.Omit,
 		"min-version": schema.Omit,
 	},

--- a/meta_test.go
+++ b/meta_test.go
@@ -1051,12 +1051,14 @@ series:
     - kubernetes
 deployment:
     type: stateless
+    mode: operator
     service: loadbalancer
     min-version: "1.15"
 `))
 	c.Assert(err, gc.IsNil)
 	c.Assert(meta.Deployment, gc.DeepEquals, &charm.Deployment{
 		DeploymentType: "stateless",
+		DeploymentMode: "operator",
 		ServiceType:    "loadbalancer",
 		MinVersion:     "1.15",
 	}, gc.Commentf("meta: %+v", meta))


### PR DESCRIPTION
k8s charms can act as operators - they do not ask Juju to deploy something like a database workload, but instead directly create resources in the cluster.

This PR adds "mode" the deployment metadata to enable a k8s charm to say that it is acting as an "operator" (vs a "workload").
Juju will manage such charms differently to workload charms.