### PR TITLE
Ensure deployment block is correctly parsed with mode

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -983,9 +983,6 @@ func parseDeployment(deployment interface{}, charmSeries []string, storage map[s
 	if minVersion, ok := deploymentMap["min-version"].(string); ok {
 		result.MinVersion = minVersion
 	}
-	if result.DeploymentType == "" && result.ServiceType == "" {
-		return nil, errors.NotValidf("empty deployment metadata")
-	}
 	if result.ServiceType != "" {
 		osForSeries, err := series.GetOSFromSeries(charmSeries[0])
 		if err != nil {

--- a/meta_test.go
+++ b/meta_test.go
@@ -1077,6 +1077,10 @@ deployment:
 		yaml: "        type: foo",
 		err:  `metadata: deployment.type: unexpected value "foo"`,
 	}, {
+		desc: "invalid deployment mode",
+		yaml: "        mode: foo",
+		err:  `metadata: deployment.mode: unexpected value "foo"`,
+	}, {
 		desc: "invalid service type",
 		yaml: "        service: foo",
 		err:  `metadata: deployment.service: unexpected value "foo"`,


### PR DESCRIPTION
Remove a bogus check for empty deployment block. It will be picked up by the schema parser.
Also add a new test for deployment mode.