### PR TITLE
Remove injected default limit of 1 for peer/requirer relations

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -610,11 +610,7 @@ type marshaledRelation Relation
 
 func (r marshaledRelation) MarshalYAML() (interface{}, error) {
 	// See calls to ifaceExpander in charmSchema.
-	noLimit := 1
-	if r.Role == RoleProvider {
-		noLimit = 0
-	}
-
+	var noLimit int
 	if !r.Optional && r.Limit == noLimit && r.Scope == ScopeGlobal {
 		// All attributes are default, so use the simple string form of the relation.
 		return r.Interface, nil
@@ -1143,9 +1139,9 @@ var charmSchema = schema.FieldMap(
 		"name":             schema.String(),
 		"summary":          schema.String(),
 		"description":      schema.String(),
-		"peers":            schema.StringMap(ifaceExpander(int64(1))),
+		"peers":            schema.StringMap(ifaceExpander(nil)),
 		"provides":         schema.StringMap(ifaceExpander(nil)),
-		"requires":         schema.StringMap(ifaceExpander(int64(1))),
+		"requires":         schema.StringMap(ifaceExpander(nil)),
 		"extra-bindings":   extraBindingsSchema,
 		"revision":         schema.Int(), // Obsolete
 		"format":           schema.Int(), // Obsolete

--- a/meta_test.go
+++ b/meta_test.go
@@ -357,7 +357,6 @@ func (s *MetaSuite) TestParseMetaRelations(c *gc.C) {
 		Name:      "ring",
 		Role:      charm.RolePeer,
 		Interface: "riak",
-		Limit:     1,
 		Scope:     charm.ScopeGlobal,
 	})
 	c.Assert(meta.Requires, gc.IsNil)
@@ -375,7 +374,6 @@ func (s *MetaSuite) TestParseMetaRelations(c *gc.C) {
 		Name:      "server-array",
 		Role:      charm.RolePeer,
 		Interface: "terracotta-server",
-		Limit:     1,
 		Scope:     charm.ScopeGlobal,
 	})
 	c.Assert(meta.Requires, gc.IsNil)
@@ -404,6 +402,29 @@ func (s *MetaSuite) TestParseMetaRelations(c *gc.C) {
 		Scope:     charm.ScopeGlobal,
 	})
 	c.Assert(meta.Peers, gc.IsNil)
+
+	meta, err = charm.ReadMeta(repoMeta(c, "monitoring"))
+	c.Assert(err, gc.IsNil)
+	c.Assert(meta.Provides["monitoring-client"], gc.Equals, charm.Relation{
+		Name:      "monitoring-client",
+		Role:      charm.RoleProvider,
+		Interface: "monitoring",
+		Scope:     charm.ScopeGlobal,
+	})
+	c.Assert(meta.Requires["monitoring-port"], gc.Equals, charm.Relation{
+		Name:      "monitoring-port",
+		Role:      charm.RoleRequirer,
+		Interface: "monitoring",
+		Scope:     charm.ScopeContainer,
+	})
+	c.Assert(meta.Requires["info"], gc.Equals, charm.Relation{
+		Name:      "info",
+		Role:      charm.RoleRequirer,
+		Interface: "juju-info",
+		Scope:     charm.ScopeContainer,
+	})
+
+	c.Assert(meta.Peers, gc.IsNil)
 }
 
 func (s *MetaSuite) TestCombinedRelations(c *gc.C) {
@@ -429,7 +450,6 @@ func (s *MetaSuite) TestCombinedRelations(c *gc.C) {
 			Name:      "ring",
 			Role:      charm.RolePeer,
 			Interface: "riak",
-			Limit:     1,
 			Scope:     charm.ScopeGlobal,
 		},
 	})
@@ -580,7 +600,6 @@ func (s *MetaSuite) TestCheckMismatchedRelationName(c *gc.C) {
 				Name:      "foo",
 				Role:      charm.RolePeer,
 				Interface: "x",
-				Limit:     1,
 				Scope:     charm.ScopeGlobal,
 			},
 		},
@@ -598,7 +617,6 @@ func (s *MetaSuite) TestCheckMismatchedRole(c *gc.C) {
 			"foo": {
 				Role:      charm.RolePeer,
 				Interface: "foo",
-				Limit:     1,
 				Scope:     charm.ScopeGlobal,
 			},
 		},


### PR DESCRIPTION
While working on a fix for https://bugs.launchpad.net/juju/+bug/1869840, I realized that the charm.v6 package is using an odd schema-coercion mechanism that ends up injecting a default limit of **1** for `peer` and `requires` relations (provides is subject to no limit).

These defaults cause problems when attempting to actually enforce the limit as there are several valid use cases where forcing such a default is wrong. For example, a metrics collector charm defines a required relation and should be relate-able to multiple applications as a subordinate.

To this end, this PR removes the above limits and aligns our implementation with the [docs](https://discourse.juju.is/t/implementing-relations/1051):

```
limit is ignored by Juju, but if present should be a positive integer N indicating that the charm is not designed to use this interface in more than N relations at once.
```