### PR TITLE
Charm origin

### DIFF
--- a/charmarchive.go
+++ b/charmarchive.go
@@ -29,6 +29,7 @@ type CharmArchive struct {
 	metrics    *Metrics
 	actions    *Actions
 	lxdProfile *LXDProfile
+	origin     *Origin
 	revision   int
 	version    string
 }
@@ -224,8 +225,8 @@ func (a *CharmArchive) Metrics() *Metrics {
 	return a.metrics
 }
 
-// Actions returns the Actions map for the actions.yaml/functions.yaml  file for the charm
-// archive.
+// Actions returns the Actions map for the actions.yaml/functions.yaml
+// file for the charm archive.
 func (a *CharmArchive) Actions() *Actions {
 	return a.actions
 }
@@ -234,6 +235,17 @@ func (a *CharmArchive) Actions() *Actions {
 // for the charm expanded in dir.
 func (a *CharmArchive) LXDProfile() *LXDProfile {
 	return a.lxdProfile
+}
+
+// Origin returns the Origin of the charm. This is optional and doesn't require
+// a charm change on the operator or writer side.
+func (a *CharmArchive) Origin() *Origin {
+	return a.origin
+}
+
+// SetOrigin allows the modification of the Charms origin.
+func (a *CharmArchive) SetOrigin(origin *Origin) {
+	a.origin = origin
 }
 
 type zipReadCloser struct {

--- a/charmdir.go
+++ b/charmdir.go
@@ -50,6 +50,7 @@ type CharmDir struct {
 	metrics    *Metrics
 	actions    *Actions
 	lxdProfile *LXDProfile
+	origin     *Origin
 	revision   int
 	version    string
 }
@@ -227,6 +228,17 @@ func (dir *CharmDir) Actions() *Actions {
 // for the charm expanded in dir.
 func (dir *CharmDir) LXDProfile() *LXDProfile {
 	return dir.lxdProfile
+}
+
+// Origin returns the Origin of the charm. This is optional and doesn't require
+// a charm change on the operator or writer side.
+func (dir *CharmDir) Origin() *Origin {
+	return dir.origin
+}
+
+// SetOrigin allows the modification of the Charms origin.
+func (dir *CharmDir) SetOrigin(origin *Origin) {
+	dir.origin = origin
 }
 
 // SetRevision changes the charm revision number. This affects

--- a/lxdprofile_test.go
+++ b/lxdprofile_test.go
@@ -104,7 +104,6 @@ func (s *ProfileSuite) TestValidate(c *gc.C) {
 		if err != nil {
 			c.Assert(err.Error(), gc.Equals, test.expectedError)
 		} else {
-
 			c.Assert(err, jc.ErrorIsNil)
 		}
 	}

--- a/meta_test.go
+++ b/meta_test.go
@@ -1594,6 +1594,10 @@ func (c *dummyCharm) LXDProfile() *charm.LXDProfile {
 	panic("unused")
 }
 
+func (c *dummyCharm) Origin() *charm.Origin {
+	panic("unused")
+}
+
 func (c *dummyCharm) Revision() int {
 	panic("unused")
 }

--- a/origin.go
+++ b/origin.go
@@ -1,0 +1,44 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package charm
+
+import "fmt"
+
+// Source represents the source of the charm.
+type Source string
+
+const (
+	// Local represents a local charm.
+	Local Source = "local"
+	// CharmStore represents a charm from the now old charmstore.
+	CharmStore Source = "charm-store"
+	// Charmhub represents a charm from the new charmhub.
+	Charmhub Source = "charmhub"
+	// Unknown represents that we don't know where this charm came from. Either
+	// the charm was migrated up from an older version of Juju or we didn't
+	// have enough information when we set the charm.
+	Unknown Source = "unknown"
+)
+
+// Originator represents the source of a charm.
+type Originator interface {
+	// Origin returns the source of the charm.
+	Origin() *Origin
+}
+
+// Origin holds the information about where the charm originally came from.
+type Origin struct {
+	Source Source
+}
+
+// Validate the origin of a charm to ensure it's valid.
+func (o *Origin) Validate() error {
+	switch o.Source {
+	case Local, CharmStore, Charmhub, Unknown:
+	default:
+		return fmt.Errorf("invalid source: %q", o.Source)
+	}
+
+	return nil
+}

--- a/origin_test.go
+++ b/origin_test.go
@@ -1,0 +1,60 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package charm_test
+
+import (
+	"fmt"
+
+	"github.com/juju/charm/v7"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type OriginSuite struct{}
+
+var _ = gc.Suite(&OriginSuite{})
+
+func (s *OriginSuite) TestValidate(c *gc.C) {
+	var originTests = []struct {
+		description   string
+		origin        *charm.Origin
+		expectedError error
+	}{
+		{
+			description: "local",
+			origin:      &charm.Origin{Source: charm.Local},
+		},
+		{
+			description: "charmstore",
+			origin:      &charm.Origin{Source: charm.CharmStore},
+		},
+		{
+			description: "charmhub",
+			origin:      &charm.Origin{Source: charm.Charmhub},
+		},
+		{
+			description: "unknown",
+			origin:      &charm.Origin{Source: charm.Unknown},
+		},
+		{
+			description:   "empty",
+			origin:        &charm.Origin{Source: charm.Source("")},
+			expectedError: fmt.Errorf(`invalid source: ""`),
+		},
+		{
+			description:   "boom",
+			origin:        &charm.Origin{Source: charm.Source("boom")},
+			expectedError: fmt.Errorf(`invalid source: "boom"`),
+		},
+	}
+	for i, test := range originTests {
+		c.Logf("test %d: %s", i, test.description)
+		err := test.origin.Validate()
+		if err != nil {
+			c.Assert(err.Error(), gc.Equals, test.expectedError.Error())
+		} else {
+			c.Assert(err, jc.ErrorIsNil)
+		}
+	}
+}


### PR DESCRIPTION
With the addition of different stores from which you can install a charm
from, we need to correctly model where a charm originates from. The
changes here allow just the origin source for now, I can see in the
future that more fields will want to be added.

The possible sources that we need to model are charmhub and everything
else. With this change though we can give feedback to the operator about
where a charm originates from to help them understand why a charm might
not be updated without switching or updating the path.

Without correctly modelling this we have to inspect the URL of a charm
and that's just more tricky. If we know when we deploy a charm what the
source was, we should store that.

---

The code is really simple, it's an optional addition to a charm, so
libraries using this won't have to do anything.