### PR TITLE
Expose rewriting of charmhub URLs

### DIFF
--- a/url.go
+++ b/url.go
@@ -116,14 +116,6 @@ func MustParseURL(url string) *URL {
 //    https://jujucharms.com/u/user/name/series
 //    https://jujucharms.com/u/user/name/revision
 //    https://jujucharms.com/u/user/name/series/revision
-//    https://jujucharms.com/channel/name
-//    https://jujucharms.com/channel/name/series
-//    https://jujucharms.com/channel/name/revision
-//    https://jujucharms.com/channel/name/series/revision
-//    https://jujucharms.com/u/user/channel/name
-//    https://jujucharms.com/u/user/channel/name/series
-//    https://jujucharms.com/u/user/channel/name/revision
-//    https://jujucharms.com/u/user/channel/name/series/revision
 //
 // A missing schema is assumed to be 'cs'.
 func ParseURL(url string) (*URL, error) {
@@ -370,14 +362,6 @@ func Quote(unsafe string) string {
 //    https://jujucharms.com/u/user/name/series -> cs:~user/series/name
 //    https://jujucharms.com/u/user/name/revision -> cs:~user/name-revision
 //    https://jujucharms.com/u/user/name/series/revision -> cs:~user/series/name-revision
-//    https://jujucharms.com/channel/name
-//    https://jujucharms.com/channel/name/series
-//    https://jujucharms.com/channel/name/revision
-//    https://jujucharms.com/channel/name/series/revision
-//    https://jujucharms.com/u/user/channel/name
-//    https://jujucharms.com/u/user/channel/name/series
-//    https://jujucharms.com/u/user/channel/name/revision
-//    https://jujucharms.com/u/user/channel/name/series/revision
 //
 // A missing schema is assumed to be 'cs'.
 func RewriteURL(url string) (string, error) {

--- a/url.go
+++ b/url.go
@@ -104,6 +104,27 @@ func MustParseURL(url string) *URL {
 // ParseURL parses the provided charm URL string into its respective
 // structure.
 //
+// Additionally, fully-qualified charmstore URLs are supported; note that this
+// currently assumes that they will map to jujucharms.com (that is,
+// fully-qualified URLs currently map to the 'cs' schema):
+//
+//    https://jujucharms.com/name
+//    https://jujucharms.com/name/series
+//    https://jujucharms.com/name/revision
+//    https://jujucharms.com/name/series/revision
+//    https://jujucharms.com/u/user/name
+//    https://jujucharms.com/u/user/name/series
+//    https://jujucharms.com/u/user/name/revision
+//    https://jujucharms.com/u/user/name/series/revision
+//    https://jujucharms.com/channel/name
+//    https://jujucharms.com/channel/name/series
+//    https://jujucharms.com/channel/name/revision
+//    https://jujucharms.com/channel/name/series/revision
+//    https://jujucharms.com/u/user/channel/name
+//    https://jujucharms.com/u/user/channel/name/series
+//    https://jujucharms.com/u/user/channel/name/revision
+//    https://jujucharms.com/u/user/channel/name/series/revision
+//
 // A missing schema is assumed to be 'cs'.
 func ParseURL(url string) (*URL, error) {
 	// Check if we're dealing with a v1 or v2 URL.
@@ -337,7 +358,7 @@ func Quote(unsafe string) string {
 
 // RewriteURL turns a HTTP(s) URL into a charm URL.
 //
-// Additionally, fully-qualified charmstore URLs are supported; note that this
+// Fully-qualified charmstore URLs are supported; note that this
 // currently assumes that they will map to jujucharms.com (that is,
 // fully-qualified URLs currently map to the 'cs' schema):
 //


### PR DESCRIPTION
In theory charmhub URLs should never be written into the database as the
version 2 of the charmhub URL. Yet, we should do our utmost to ensure
that is the case. By exposing the re-write capabilities of our charm URL
function, we can re-use that with in Juju directly and ensure that all
charm URLs are of the correct fashion.

----

Essentially the v2 charm URL re-writes from a URL that has a schema (not
RFC3986 URL Schema) and re-arranges it into a v1 charm URL.

Example:
 - `http://<domain>/<name>` becomes `cs:<name>`

So if any "store" implements this schema, it can be re-written into the v1 charm
URL.

> `https://<domain>/u/<user>/<name>/<series>/<revision>`

Whilst clever, it conflates the charm URL parsing code and causes issues when
migrating away from the charm store.

I guess the idea was to allow people to copy URLs directly from a browser into
Juju CLI directly. Unsure how much this is supported, considering most if not
all tutorials/documentation refers to v1 charm URL extensively.