### PR TITLE
Allow charmhub url parsing

### DIFF
--- a/bundle_test.go
+++ b/bundle_test.go
@@ -68,21 +68,21 @@ func checkWordpressBundle(c *gc.C, b charm.Bundle, path string) {
 	mysqlCharm := readCharmDir(c, "mysql")
 
 	bd := b.Data()
-	c.Assert(bd.RequiredCharms(), jc.DeepEquals, []string{"mysql", "wordpress"})
+	c.Assert(bd.RequiredCharms(), jc.DeepEquals, []string{"cs:mysql", "cs:wordpress"})
 
 	charms := map[string]charm.Charm{
-		"wordpress": wordpressCharm,
-		"mysql":     mysqlCharm,
+		"cs:wordpress": wordpressCharm,
+		"cs:mysql":     mysqlCharm,
 	}
 	err := bd.VerifyWithCharms(verifyOk, nil, nil, charms)
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(bd.Applications, jc.DeepEquals, map[string]*charm.ApplicationSpec{
 		"wordpress": {
-			Charm: "wordpress",
+			Charm: "cs:wordpress",
 		},
 		"mysql": {
-			Charm:    "mysql",
+			Charm:    "cs:mysql",
 			NumUnits: 1,
 		},
 	})

--- a/bundledata.go
+++ b/bundledata.go
@@ -842,10 +842,21 @@ func (verifier *bundleDataVerifier) verifyRelations() {
 
 func (verifier *bundleDataVerifier) verifyEndpointBindings() {
 	for name, svc := range verifier.bd.Applications {
-		charm, ok := verifier.charms[name]
-		// Only test the ok path here because the !ok path is tested in verifyApplications
-		if !ok {
+		if svc == nil {
 			continue
+		}
+
+		// Verify the endpoint bindings from the fully qualified charm URL and
+		// not just the application name. Fallback to the charm name as the
+		// application name, but in reality this shouldn't be the case.
+		var (
+			charm Charm
+			ok    bool
+		)
+		if charm, ok = verifier.charms[svc.Charm]; !ok {
+			if charm, ok = verifier.charms[name]; !ok {
+				continue
+			}
 		}
 		for endpoint, space := range svc.EndpointBindings {
 			_, isInProvides := charm.Meta().Provides[endpoint]

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -657,11 +657,9 @@ func (*bundleDataSuite) TestVerifyCharmURL(c *gc.C) {
 	bd, err := charm.ReadBundleData(strings.NewReader(mediawikiBundle))
 	c.Assert(err, gc.IsNil)
 	for i, u := range []string{
-		"wordpress",
 		"cs:wordpress",
 		"cs:precise/wordpress",
-		"precise/wordpress",
-		"precise/wordpress-2",
+		"cs:precise/wordpress-2",
 		"local:foo",
 		"local:foo-45",
 	} {
@@ -680,11 +678,9 @@ func (*bundleDataSuite) TestVerifyLocalCharm(c *gc.C) {
 	err = os.MkdirAll(relativeCharmDir, 0700)
 	c.Assert(err, jc.ErrorIsNil)
 	for i, u := range []string{
-		"wordpress",
 		"cs:wordpress",
 		"cs:precise/wordpress",
-		"precise/wordpress",
-		"precise/wordpress-2",
+		"cs:precise/wordpress-2",
 		"local:foo",
 		"local:foo-45",
 		c.MkDir(),
@@ -707,9 +703,9 @@ func (s *bundleDataSuite) testPrepareAndMutateBeforeVerifyWithCharms(c *gc.C, mu
 	bd := b.Data()
 
 	charms := map[string]charm.Charm{
-		"wordpress": readCharmDir(c, "wordpress"),
-		"mysql":     readCharmDir(c, "mysql"),
-		"logging":   readCharmDir(c, "logging"),
+		"cs:wordpress": readCharmDir(c, "wordpress"),
+		"cs:mysql":     readCharmDir(c, "mysql"),
+		"cs:logging":   readCharmDir(c, "logging"),
 	}
 
 	if mutator != nil {
@@ -1456,13 +1452,13 @@ func (*bundleDataSuite) TestApplicationEmpty(c *gc.C) {
 applications:
     application1:
     application2:
-        charm: "test"
+        charm: "cs:test"
         plan: "testisv/test2"
 `,
 		`
 applications:
     application1:
-        charm: "test"
+        charm: "cs:test"
         plan: "testisv/test2"
     application2:
 `,
@@ -1481,13 +1477,13 @@ func (*bundleDataSuite) TestApplicationPlans(c *gc.C) {
 	data := `
 applications:
     application1:
-        charm: "test"
+        charm: "cs:test"
         plan: "testisv/test"
     application2:
-        charm: "test"
+        charm: "cs:test"
         plan: "testisv/test2"
     application3:
-        charm: "test"
+        charm: "cs:test"
         plan: "default"
 relations:
     - ["application1:prova", "application2:reqa"]
@@ -1500,15 +1496,15 @@ relations:
 
 	c.Assert(bd.Applications, jc.DeepEquals, map[string]*charm.ApplicationSpec{
 		"application1": &charm.ApplicationSpec{
-			Charm: "test",
+			Charm: "cs:test",
 			Plan:  "testisv/test",
 		},
 		"application2": &charm.ApplicationSpec{
-			Charm: "test",
+			Charm: "cs:test",
 			Plan:  "testisv/test2",
 		},
 		"application3": &charm.ApplicationSpec{
-			Charm: "test",
+			Charm: "cs:test",
 			Plan:  "default",
 		},
 	})

--- a/internal/test-charm-repo/bundle/bad/bundle.yaml
+++ b/internal/test-charm-repo/bundle/bad/bundle.yaml
@@ -2,10 +2,10 @@
 # its verification.
 applications:
     wordpress:
-        charm: wordpress
+        charm: cs:wordpress
         num_units: 1
     mysql:
-        charm: mysql
+        charm: cs:mysql
         num_units: 1
 relations:
     - ["foo:db", "mysql:server"]

--- a/internal/test-charm-repo/bundle/wordpress-legacy/bundle.yaml
+++ b/internal/test-charm-repo/bundle/wordpress-legacy/bundle.yaml
@@ -1,8 +1,8 @@
 services:
     wordpress:
-        charm: wordpress
+        charm: cs:wordpress
     mysql:
-        charm: mysql
+        charm: cs:mysql
         num_units: 1
 relations:
     - ["wordpress:db", "mysql:server"]

--- a/internal/test-charm-repo/bundle/wordpress-multidoc/bundle.yaml
+++ b/internal/test-charm-repo/bundle/wordpress-multidoc/bundle.yaml
@@ -1,8 +1,8 @@
 applications:
   wordpress:
-    charm: wordpress
+    charm: cs:wordpress
   mysql:
-    charm: mysql
+    charm: cs:mysql
     num_units: 1
 relations:
   - ["wordpress:db", "mysql:server"]

--- a/internal/test-charm-repo/bundle/wordpress-simple-multidoc/bundle.yaml
+++ b/internal/test-charm-repo/bundle/wordpress-simple-multidoc/bundle.yaml
@@ -1,8 +1,8 @@
 applications:
     wordpress:
-        charm: wordpress
+        charm: cs:wordpress
     mysql:
-        charm: mysql
+        charm: cs:mysql
         num_units: 1
 relations:
     - ["wordpress:db", "mysql:server"]

--- a/internal/test-charm-repo/bundle/wordpress-simple/bundle.yaml
+++ b/internal/test-charm-repo/bundle/wordpress-simple/bundle.yaml
@@ -1,8 +1,8 @@
 applications:
     wordpress:
-        charm: wordpress
+        charm: cs:wordpress
     mysql:
-        charm: mysql
+        charm: cs:mysql
         num_units: 1
 relations:
     - ["wordpress:db", "mysql:server"]

--- a/internal/test-charm-repo/bundle/wordpress-with-logging/bundle.yaml
+++ b/internal/test-charm-repo/bundle/wordpress-with-logging/bundle.yaml
@@ -1,6 +1,6 @@
 applications:
     wordpress:
-        charm: wordpress
+        charm: cs:wordpress
         num_units: 1
         bindings:
             db: db
@@ -8,12 +8,12 @@ applications:
             db-client: db
             admin-api: public
     mysql:
-        charm: mysql
+        charm: cs:mysql
         num_units: 1
         bindings:
             server: db
     logging:
-        charm: logging
+        charm: cs:logging
 relations:
     - ["wordpress:db", "mysql:server"]
     - ["wordpress:juju-info", "logging:info"]

--- a/url.go
+++ b/url.go
@@ -500,8 +500,10 @@ func EnsureSchema(url string) (string, error) {
 	switch Schema(u.Scheme) {
 	case CharmStore, CharmHub, Local, HTTP, HTTPS:
 		return url, nil
-	default:
+	case Schema(""):
 		// If the schema is empty, we fall back to the default schema.
 		return DefaultSchema.Prefix(url), nil
+	default:
+		return "", errors.NotValidf("schema %q", u.Scheme)
 	}
 }

--- a/url.go
+++ b/url.go
@@ -481,16 +481,21 @@ func parseHTTPURL(url *gourl.URL) (*URL, error) {
 
 func parseIdentifierURL(url *gourl.URL) (*URL, error) {
 	r := URL{
-		Schema: CharmHub.String(),
+		Schema:   CharmHub.String(),
+		Revision: -1,
 	}
 
-	parts := strings.Split(strings.Trim(url.Path, "/"), "/")
+	path := url.Path
+	if url.Opaque != "" {
+		path = url.Opaque
+	}
+
+	parts := strings.Split(strings.Trim(path, "/"), "/")
 	if len(parts) != 1 {
 		return nil, errors.Errorf(`charm or bundle URL %q malformed, expected "<name>"`, url)
 	}
 
 	r.Name = parts[0]
-
 	if err := ValidateName(r.Name); err != nil {
 		return nil, errors.Annotatef(err, "cannot parse URL %q", url)
 	}

--- a/url_test.go
+++ b/url_test.go
@@ -233,6 +233,27 @@ var urlTests = []struct {
 }, {
 	s:   "cs:foo/~blah",
 	err: `cannot parse URL $URL: name "~blah" not valid`,
+}, {
+	s:   "ch:name",
+	url: &charm.URL{"ch", "", "name", -1, ""},
+}, {
+	s:   "ch:name-suffix",
+	url: &charm.URL{"ch", "", "name-suffix", -1, ""},
+}, {
+	s:   "ch:name-1",
+	err: `cannot parse URL "ch:name-1": name "name-1" not valid`,
+}, {
+	s:   "ch:name/foo",
+	err: `charm or bundle URL $URL malformed, expected "<name>"`,
+}, {
+	s:   "ch:~user/name",
+	err: `charm or bundle URL $URL malformed, expected "<name>"`,
+}, {
+	s:   "ch:~user/series/name-0",
+	err: `charm or bundle URL $URL malformed, expected "<name>"`,
+}, {
+	s:   "ch:nam-!e",
+	err: `cannot parse URL "ch:nam-!e": name "nam-!e" not valid`,
 }}
 
 func (s *URLSuite) TestParseURL(c *gc.C) {

--- a/url_test.go
+++ b/url_test.go
@@ -241,7 +241,7 @@ var urlTests = []struct {
 	url: &charm.URL{"ch", "", "name-suffix", -1, ""},
 }, {
 	s:   "ch:name-1",
-	err: `cannot parse URL "ch:name-1": name "name-1" not valid`,
+	url: &charm.URL{"ch", "", "name", 1, ""},
 }, {
 	s:   "ch:name/foo",
 	err: `charm or bundle URL $URL malformed, expected "<name>"`,

--- a/url_test.go
+++ b/url_test.go
@@ -397,24 +397,33 @@ func (s *URLSuite) TestRewriteURL(c *gc.C) {
 }
 
 var ensureSchemaTests = []struct {
-	vague, exact string
+	input, expected, err string
 }{
-	{"foo", "ch:foo"},
-	{"foo-1", "ch:foo-1"},
-	{"~user/foo", "ch:~user/foo"},
-	{"series/foo", "ch:series/foo"},
-	{"cs:foo", "cs:foo"},
-	{"local:foo", "local:foo"},
-	{"http:foo", "http:foo"},
-	{"https:foo", "https:foo"},
+	{input: "foo", expected: "ch:foo"},
+	{input: "foo-1", expected: "ch:foo-1"},
+	{input: "~user/foo", expected: "ch:~user/foo"},
+	{input: "series/foo", expected: "ch:series/foo"},
+	{input: "cs:foo", expected: "cs:foo"},
+	{input: "local:foo", expected: "local:foo"},
+	{input: "http:foo", expected: "http:foo"},
+	{input: "https:foo", expected: "https:foo"},
+	{
+		input: "unknown:foo",
+		err:   `schema "unknown" not valid`,
+	},
 }
 
 func (s *URLSuite) TestInferURLNoDefaultSeries(c *gc.C) {
 	for i, t := range ensureSchemaTests {
-		c.Logf("%d: %s", i, t.vague)
-		inferred, err := charm.EnsureSchema(t.vague)
+		c.Logf("%d: %s", i, t.input)
+		inferred, err := charm.EnsureSchema(t.input)
+		if t.err != "" {
+			c.Assert(err, gc.ErrorMatches, t.err)
+			continue
+		}
+
 		c.Assert(err, gc.IsNil)
-		c.Assert(inferred, gc.Equals, t.exact)
+		c.Assert(inferred, gc.Equals, t.expected)
 	}
 }
 


### PR DESCRIPTION
The following updates the charm URL code to allow the parsing of
charmhub prefix schema. This is a breaking change and will require a v8
of the charm package!

Essentially all charm URLs will require a schema prefix in every case.
Juju or other consumers will have to lift the raw url into the right
schema so that you get the right url.

---

## Charmhub URLs:

## Without a revision

Charmhub URLs can be used without a revision, and will just contain the application name.

```
cs:wordpress
```

## With the revision

```
cs:wordpress-1
```

