### PR TITLE
Only allow expose-to-{spaces,CIDRs} fields to be present in overlays

### DIFF
--- a/bundledata.go
+++ b/bundledata.go
@@ -295,11 +295,11 @@ type ApplicationSpec struct {
 
 	// ExposeToSpaces contains a list of spaces that should be able to
 	// access the application ports if the application is exposed.
-	ExposeToSpaces []string `bson:"expose-to-spaces,omitempty" json:"expose-to-spaces,omitempty" yaml:"expose-to-spaces,omitempty"`
+	ExposeToSpaces []string `bson:"expose-to-spaces,omitempty" json:"expose-to-spaces,omitempty" yaml:"expose-to-spaces,omitempty" source:"overlay-only"`
 
 	// ExposeToCIDRs contains a list of CIDRs that should be able to
 	// access the application ports if the application is exposed.
-	ExposeToCIDRs []string `bson:"expose-to-cidrs,omitempty" json:"expose-to-cidrs,omitempty" yaml:"expose-to-cidrs,omitempty"`
+	ExposeToCIDRs []string `bson:"expose-to-cidrs,omitempty" json:"expose-to-cidrs,omitempty" yaml:"expose-to-cidrs,omitempty" source:"overlay-only"`
 
 	// Options holds the configuration values
 	// to apply to the new application. They should

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -30,6 +30,13 @@ func (*bundleDataOverlaySuite) TestExtractBaseAndOverlayParts(c *gc.C) {
 applications:
   apache2:
     charm: cs:apache2-26
+    expose: true
+    exposed-endpoints:
+      - www
+    expose-to-spaces:
+      - dmz
+    expose-to-cidrs:
+      - 13.37.0.016
     offers:
       my-offer:
         endpoints:
@@ -51,6 +58,9 @@ series: bionic
 applications:
   apache2:
     charm: cs:apache2-26
+    expose: true
+    exposed-endpoints:
+    - www
 saas:
   apache2:
     url: production:admin/info.apache
@@ -60,6 +70,10 @@ series: bionic
 	expOverlay := `
 applications:
   apache2:
+    expose-to-spaces:
+    - dmz
+    expose-to-cidrs:
+    - 13.37.0.016
     offers:
       my-offer:
         endpoints:


### PR DESCRIPTION
This is a followup to #315 to ensure that the `expose-to-spaces` and `expose-to-cidrs` fields can only be specified as part of an overlay whereas the `exposed-endpoints` field can be specified in either the base or the overlay part of a bundle.

The reasoning behind this change is both the space names and any CIDRs that you want to allow access to exposed applications are deployment-specific. As such, they should be provided via an overlay similar to the ACL bits for offers.