### PR TITLE
Support per-endpoint expose params for space/CIDRs

### DIFF
--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -598,42 +598,39 @@ applications:
 		`invalid endpoint name "nope!" for offer "$bad-name" in application "aws-integrator"`,
 	},
 }, {
-	about: "expose parameters provided when the application is not exposed",
+	about: "expose parameters provided together with expose:true",
 	data: `
-applications:
-    aws-integrator:
-        charm: cs:~containers/aws-integrator
-        num_units: 1
-        expose: false
-        exposed-endpoints:
-          - admin
+applications: 
+  aws-integrator: 
+    charm: "cs:~containers/aws-integrator"
+    expose: true
+    exposed-endpoints:
+      admin:
         expose-to-spaces:
           - alpha
         expose-to-cidrs:
           - 13.37.0.0/16
+    num_units: 1
 `,
 	errors: []string{
-		`exposed endpoints parameter in application "aws-integrator" cannot be specified when the application is not exposed`,
-		`expose to spaces parameter in application "aws-integrator" cannot be specified when the application is not exposed`,
-		`expose to CIDRs parameter in application "aws-integrator" cannot be specified when the application is not exposed`,
+		`exposed-endpoints cannot be specified together with "exposed:true" in application "aws-integrator" as this poses a security risk when deploying bundles to older controllers`,
 	},
 }, {
 	about: "invalid CIDR in expose-to-cidrs parameter when the app is exposed",
 	data: `
-applications:
-    aws-integrator:
-        charm: cs:~containers/aws-integrator
-        num_units: 1
-        expose: true
-        exposed-endpoints:
-          - admin
+applications: 
+  aws-integrator: 
+    charm: "cs:~containers/aws-integrator"
+    exposed-endpoints:
+      admin:
         expose-to-spaces:
           - alpha
         expose-to-cidrs:
           - not-a-cidr
+    num_units: 1
 `,
 	errors: []string{
-		`invalid CIDR "not-a-cidr" for expose to CIDRs parameter in application "aws-integrator"`,
+		`invalid CIDR "not-a-cidr" for expose to CIDRs field for endpoint "admin" in application "aws-integrator"`,
 	},
 }}
 

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -30,13 +30,12 @@ func (*bundleDataOverlaySuite) TestExtractBaseAndOverlayParts(c *gc.C) {
 applications:
   apache2:
     charm: cs:apache2-26
-    expose: true
     exposed-endpoints:
-      - www
-    expose-to-spaces:
-      - dmz
-    expose-to-cidrs:
-      - 13.37.0.016
+      www:
+        expose-to-spaces:
+          - dmz
+        expose-to-cidrs:
+          - 13.37.0.0/16
     offers:
       my-offer:
         endpoints:
@@ -58,9 +57,6 @@ series: bionic
 applications:
   apache2:
     charm: cs:apache2-26
-    expose: true
-    exposed-endpoints:
-    - www
 saas:
   apache2:
     url: production:admin/info.apache
@@ -70,10 +66,12 @@ series: bionic
 	expOverlay := `
 applications:
   apache2:
-    expose-to-spaces:
-    - dmz
-    expose-to-cidrs:
-    - 13.37.0.016
+    exposed-endpoints:
+      www:
+        expose-to-spaces:
+        - dmz
+        expose-to-cidrs:
+        - 13.37.0.0/16
     offers:
       my-offer:
         endpoints:


### PR DESCRIPTION
This PR revises the work from #315 and #316 to  allow bundle authors 
to specify the list of spaces and/or CIDRs that can access the opened 
ports for exposed applications on a per-endpoint basis.

Given that the exposed-endpoint details are deployment specific, they
can only be specified as part of an overlay document. In addition, the
exposed-endpoint field is not allowed to be specified in tandem with the
'exposed: true' flag.

This is intentional: imagine a scenario where an operator exports a
bundle from a 2.9 controller where only a subset of an application's
endpoints have been exposed (e.g. to be accessed via a jumpbox) and
attempts to deploy the bundle to a 2.8 or older controller. If we
allowed both the "exposed: true" and the "exposed-endpoint" fields to be
present in the bundle, the 2.8 controller (which does not recognize the
"exposed-endpoint" field) would incorrectly assume that *all* endpoints
are to be exposed (due to "exposed: true"), thus opening a security
hole.

By making these two fields mutually exclusive, we mitigate this security
risk. In fact, as the export-bundle command will skip the "exposed: true"
flag and only emit the "exposed-endpoint" field, the bundle will not
cause the application to be exposed in older controllers and instead,
require the operator to audit the bundle and manually export the
application where needed.