### PR TITLE
Updating the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,93 @@ Juju charms
 
 This package parses juju charms.
 
-## Versions
+## Anatomy of a charm
 
-Stable versions of this API are available on gopkg.in at
-gopkg.in/juju/charm.vD where D is a version spec.  If you are viewing this
-readme on github.com you can click the 'branch:' button above to view tags
-and branches.  See http://labix.org/gopkg.in for more information.
+A bare minimum charm consists of a directory containing a series of files and
+directories that inform Juju how to correctly handle and execute a charm.
+
+The [charming docs](https://discourse.juju.is/c/docs/charming-docs) provide more
+advanced information and tutorials.
+The following is a very simple basic configuration guide.
+
+### `metadata.yaml`
+
+The `metadata.yaml` is a required charm configuration yaml. It is expected that
+every charm contains a `metadata.yaml`.
+
+An example of a very basic `metadata.yaml`:
+
+```yaml
+name: example
+summary: Example charm
+description: |
+    A contrived descriptive example of a charm
+    description that has multiple line.
+tags:
+    - example
+    - misc
+series:
+    - focal
+    - bionic
+```
+
+### `config.yaml`
+
+`config.yaml` is an optional configuration yaml for a charm. The configuration
+allows the author to express a series of options for the user to configure the 
+modelled charm software.
+
+An example of a `config.yaml`:
+
+```yaml
+options:
+    name:
+        default:
+        description: The name of the example software
+        type: string
+```
+
+It is expected that for every configuration option, there is a name and a type.
+All the other fields are optional.
+
+The type can be either a `string`, `int`, `float` or `boolean`. Everything else
+will cause Juju to error out when reading the charm.
+
+### `metrics.yaml`
+
+`metrics.yaml` represents an optional metrics gathering configuration yaml. For
+more information about metrics, read up on [Metric collecting charms](https://discourse.juju.is/t/metric-collecting-charms/1125)
+
+### `revision`
+
+The `revision` is used to indicate the revision of a charm. It expects that only
+an integer exists in that file.
+
+### `lxd-profile.yaml`
+
+The `lxd-profile.yaml` is an optional configuration yaml. It allows the author
+of the charm to configure a series of LXD containers directly from the charm.
+
+An example of a `lxd-profile.yaml`:
+
+```yaml
+config:
+  security.nesting: "true"
+  security.privileged: "true"
+  linux.kernel_modules: openvswitch,nbd,ip_tables,ip6_tables
+devices:
+  kvm:
+    path: /dev/kvm
+    type: unix-char
+  mem:
+    path: /dev/mem
+    type: unix-char
+  tun:
+    path: /dev/net/tun
+    type: unix-char
+```
+
+### `version`
+
+The `version` file is used to indicate the exact version of a charm. Useful for
+identifying the exact revision of a charm.


### PR DESCRIPTION
The README was way out of date, but also adding information about the
basics of a charm in terms of the configuration options. This doesn't go
into the differences between a bash charm, nor a reactive or operator
charm, just what a charm is in terms of configration.