### PR TITLE
Force the charmhub naming for URLs

### DIFF
--- a/url.go
+++ b/url.go
@@ -134,8 +134,8 @@ func ValidateName(name string) error {
 
 // WithRevision returns a URL equivalent to url but with Revision set
 // to revision.
-func (url *URL) WithRevision(revision int) *URL {
-	urlCopy := *url
+func (u *URL) WithRevision(revision int) *URL {
+	urlCopy := *u
 	urlCopy.Revision = revision
 	return &urlCopy
 }
@@ -181,16 +181,16 @@ func ParseURL(url string) (*URL, error) {
 		// Handle talking to the new style of the schema.
 		curl, err = parseIdentifierURL(u)
 	case u.Opaque != "":
-		// Shortcut old-style URLs.
 		u.Path = u.Opaque
 		curl, err = parseV1URL(u, url)
+	case CharmStore.Matches(u.Scheme):
+		curl, err = parseV1URL(u, url)
 	case HTTP.Matches(u.Scheme) || HTTPS.Matches(u.Scheme):
-		// Shortcut new-style URLs.
 		curl, err = parseHTTPURL(u)
 	default:
-		// TODO: for now, fall through to parsing v1 references; this will be
-		// expanded to be more robust in the future.
-		curl, err = parseV1URL(u, url)
+		// Handle the fact that anything without a prefix is now a CharmHub
+		// charm URL.
+		curl, err = parseIdentifierURL(u)
 	}
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -251,28 +251,41 @@ func parseV1URL(url *gourl.URL, originalURL string) (*URL, error) {
 	return &r, nil
 }
 
-func (r *URL) path() string {
+func (u *URL) path() string {
 	var parts []string
-	if r.User != "" {
-		parts = append(parts, fmt.Sprintf("~%s", r.User))
+	if u.User != "" {
+		parts = append(parts, fmt.Sprintf("~%s", u.User))
 	}
-	if r.Series != "" {
-		parts = append(parts, r.Series)
+	if u.Series != "" {
+		parts = append(parts, u.Series)
 	}
-	if r.Revision >= 0 {
-		parts = append(parts, fmt.Sprintf("%s-%d", r.Name, r.Revision))
+	if u.Revision >= 0 {
+		parts = append(parts, fmt.Sprintf("%s-%d", u.Name, u.Revision))
 	} else {
-		parts = append(parts, r.Name)
+		parts = append(parts, u.Name)
 	}
 	return strings.Join(parts, "/")
 }
 
-func (r URL) Path() string {
-	return r.path()
+// FullPath returns the full path of a URL path including the schema.
+func (u *URL) FullPath() string {
+	return fmt.Sprintf("%s:%s", u.Schema, u.Path())
 }
 
-func (u URL) String() string {
-	return fmt.Sprintf("%s:%s", u.Schema, u.Path())
+// Path returns the path of the URL without the schema.
+func (u *URL) Path() string {
+	return u.path()
+}
+
+// String returns the string representation of the URL.
+// To keep backwards with older schema versions (CharmStore), we output the
+// FullPath of the URL. For new CharmHub integrations, we only want the Path.
+// That way we can hide the schema to the user.
+func (u *URL) String() string {
+	if CharmHub.Matches(u.Schema) {
+		return u.Path()
+	}
+	return u.FullPath()
 }
 
 // GetBSON turns u into a bson.Getter so it can be saved directly
@@ -311,13 +324,16 @@ func (u *URL) SetBSON(raw bson.Raw) error {
 	return nil
 }
 
+// MarshalJSON will marshal the URL into a slice of bytes in a JSON
+// representation.
 func (u *URL) MarshalJSON() ([]byte, error) {
 	if u == nil {
 		panic("cannot marshal nil *charm.URL")
 	}
-	return json.Marshal(u.String())
+	return json.Marshal(u.FullPath())
 }
 
+// UnmarshalJSON will unmarshal the URL from a JSON representation.
 func (u *URL) UnmarshalJSON(b []byte) error {
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {
@@ -332,12 +348,12 @@ func (u *URL) UnmarshalJSON(b []byte) error {
 }
 
 // MarshalText implements encoding.TextMarshaler by
-// returning u.String()
+// returning u.FullPath()
 func (u *URL) MarshalText() ([]byte, error) {
 	if u == nil {
 		return nil, nil
 	}
-	return []byte(u.String()), nil
+	return []byte(u.FullPath()), nil
 }
 
 // UnmarshalText implements encoding.TestUnmarshaler by

--- a/url.go
+++ b/url.go
@@ -278,9 +278,10 @@ func (u *URL) Path() string {
 }
 
 // String returns the string representation of the URL.
-// To keep backwards with older schema versions (CharmStore), we output the
-// FullPath of the URL. For new CharmHub integrations, we only want the Path.
-// That way we can hide the schema to the user.
+// To keep backwards compatibility with older schema versions (CharmStore), we
+// output the FullPath of the URL.
+// For new CharmHub integrations, we only want the Path.
+// That way we can hide the schema from the user.
 func (u *URL) String() string {
 	if CharmHub.Matches(u.Schema) {
 		return u.Path()

--- a/url_test.go
+++ b/url_test.go
@@ -200,21 +200,20 @@ var urlTests = []struct {
 	s:   "local:~user/name",
 	err: `local charm or bundle URL with user name: $URL`,
 }, {
-	s:     "precise/wordpress",
-	exact: "cs:precise/wordpress",
-	url:   &charm.URL{"cs", "", "wordpress", -1, "precise"},
+	s:   "precise/wordpress",
+	err: `charm or bundle URL $URL malformed, expected "<name>"`,
 }, {
 	s:     "foo",
-	exact: "cs:foo",
-	url:   &charm.URL{"cs", "", "foo", -1, ""},
+	exact: "foo",
+	url:   &charm.URL{"ch", "", "foo", -1, ""},
 }, {
 	s:     "foo-1",
-	exact: "cs:foo-1",
-	url:   &charm.URL{"cs", "", "foo", 1, ""},
+	exact: "foo-1",
+	url:   &charm.URL{"ch", "", "foo", 1, ""},
 }, {
 	s:     "n0-n0-n0",
-	exact: "cs:n0-n0-n0",
-	url:   &charm.URL{"cs", "", "n0-n0-n0", -1, ""},
+	exact: "n0-n0-n0",
+	url:   &charm.URL{"ch", "", "n0-n0-n0", -1, ""},
 }, {
 	s:     "cs:foo",
 	exact: "cs:foo",
@@ -224,24 +223,23 @@ var urlTests = []struct {
 	exact: "local:foo",
 	url:   &charm.URL{"local", "", "foo", -1, ""},
 }, {
-	s:     "series/foo",
-	exact: "cs:series/foo",
-	url:   &charm.URL{"cs", "", "foo", -1, "series"},
-}, {
 	s:   "series/foo/bar",
-	err: `charm or bundle URL has invalid form: "series/foo/bar"`,
+	err: `charm or bundle URL $URL malformed, expected "<name>"`,
 }, {
 	s:   "cs:foo/~blah",
 	err: `cannot parse URL $URL: name "~blah" not valid`,
 }, {
-	s:   "ch:name",
-	url: &charm.URL{"ch", "", "name", -1, ""},
+	s:     "ch:name",
+	exact: "name",
+	url:   &charm.URL{"ch", "", "name", -1, ""},
 }, {
-	s:   "ch:name-suffix",
-	url: &charm.URL{"ch", "", "name-suffix", -1, ""},
+	s:     "ch:name-suffix",
+	exact: "name-suffix",
+	url:   &charm.URL{"ch", "", "name-suffix", -1, ""},
 }, {
-	s:   "ch:name-1",
-	url: &charm.URL{"ch", "", "name", 1, ""},
+	s:     "ch:name-1",
+	exact: "name-1",
+	url:   &charm.URL{"ch", "", "name", 1, ""},
 }, {
 	s:   "ch:name/foo",
 	err: `charm or bundle URL $URL malformed, expected "<name>"`,


### PR DESCRIPTION
The following forces non-prefix charm URLs to fallback to charmhub
schemas. This is a much bigger breaking change than the previous
changes. This states that anything withouth a prefix is a charmhub,
where previously that was stated as a charmstore charm URL.

Additionally we drop the prefix of a charm URL during the string
representation of a URL. To get the previous same logic, calling the
following, URL#FullPath() will do it.

This has been tricky as we want to preserve as much of the old way as
possible, but we also don't want to keep things around for no reason.