### PR TITLE
Ignore contents of empty overlay files when merging overlays and bundles

### DIFF
--- a/overlay.go
+++ b/overlay.go
@@ -488,6 +488,9 @@ func ReadAndMergeBundleData(sources ...BundleDataSource) (*BundleData, error) {
 }
 
 func applyOverlay(base, overlay *BundleDataPart) error {
+	if overlay == nil || len(overlay.PresenceMap) == 0 {
+		return nil
+	}
 	if !overlay.PresenceMap.fieldPresent("applications") && len(overlay.Data.Applications) > 0 {
 		return errors.Errorf("bundle overlay file used deprecated 'services' key, this is not valid for bundle overlay files")
 	}

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -760,6 +760,41 @@ applications:
 	c.Assert("\n"+string(merged), gc.Equals, exp)
 }
 
+func (*bundleDataOverlaySuite) TestBundleDataSourceWithEmptyOverlay(c *gc.C) {
+	base := `
+applications:
+  django:
+    charm: cs:django
+`
+
+	overlays := `
+---
+`
+
+	baseDir := c.MkDir()
+	mustWriteFile(c, filepath.Join(baseDir, "bundle.yaml"), base)
+
+	ovlDir := c.MkDir()
+	mustWriteFile(c, filepath.Join(ovlDir, "overlays.yaml"), overlays)
+
+	bd, err := charm.ReadAndMergeBundleData(
+		mustCreateLocalDataSource(c, filepath.Join(baseDir, "bundle.yaml")),
+		mustCreateLocalDataSource(c, filepath.Join(ovlDir, "overlays.yaml")),
+	)
+	c.Assert(err, gc.IsNil)
+
+	merged, err := yaml.Marshal(bd)
+	c.Assert(err, gc.IsNil)
+
+	exp := `
+applications:
+  django:
+    charm: cs:django
+`
+
+	c.Assert("\n"+string(merged), gc.Equals, exp)
+}
+
 func (*bundleDataOverlaySuite) TestReadAndMergeBundleDataWithRelativeCharmPaths(c *gc.C) {
 	base := `
 applications:


### PR DESCRIPTION
This PR adds extra checks in the overlay merging code to skip empty overlays when merging them into bundles. Otherwise, a NPE will occur.