### PR TITLE
Added container hook *-container-ready

### DIFF
--- a/hooks/hooks.go
+++ b/hooks/hooks.go
@@ -46,6 +46,12 @@ const (
 	// "shared-fs-storage-attached".
 	StorageAttached  Kind = "storage-attached"
 	StorageDetaching Kind = "storage-detaching"
+
+	// These hooks require an associated container, and the name of the container
+	// whose change triggered the hook. The hook file names that these
+	// kinds represent will be prefixed by the container name; for example,
+	// "myapp-container-ready".
+	ContainerReady Kind = "container-ready"
 )
 
 var unitHooks = []Kind{
@@ -99,6 +105,17 @@ func StorageHooks() []Kind {
 	return hooks
 }
 
+var containerHooks = []Kind{
+	ContainerReady,
+}
+
+// ContainerHooks returns all known container hook kinds.
+func ContainerHooks() []Kind {
+	hooks := make([]Kind, len(containerHooks))
+	copy(hooks, containerHooks)
+	return hooks
+}
+
 // IsRelation returns whether the Kind represents a relation hook.
 func (kind Kind) IsRelation() bool {
 	switch kind {
@@ -112,6 +129,15 @@ func (kind Kind) IsRelation() bool {
 func (kind Kind) IsStorage() bool {
 	switch kind {
 	case StorageAttached, StorageDetaching:
+		return true
+	}
+	return false
+}
+
+// IsContainer returns whether the Kind represents a storage hook.
+func (kind Kind) IsContainer() bool {
+	switch kind {
+	case ContainerReady:
 		return true
 	}
 	return false

--- a/meta.go
+++ b/meta.go
@@ -332,6 +332,18 @@ func generateRelationHooks(relName string, allHooks map[string]bool) {
 	}
 }
 
+func generateContainerHooks(containerName string, allHooks map[string]bool) {
+	for _, hookName := range hooks.ContainerHooks() {
+		allHooks[fmt.Sprintf("%s-%s", containerName, hookName)] = true
+	}
+}
+
+func generateStorageHooks(storageName string, allHooks map[string]bool) {
+	for _, hookName := range hooks.StorageHooks() {
+		allHooks[fmt.Sprintf("%s-%s", storageName, hookName)] = true
+	}
+}
+
 // Hooks returns a map of all possible valid hooks, taking relations
 // into account. It's a map to enable fast lookups, and the value is
 // always true.
@@ -350,6 +362,12 @@ func (m Meta) Hooks() map[string]bool {
 	}
 	for hookName := range m.Peers {
 		generateRelationHooks(hookName, allHooks)
+	}
+	for storageName := range m.Storage {
+		generateStorageHooks(storageName, allHooks)
+	}
+	for containerName := range m.Containers {
+		generateContainerHooks(containerName, allHooks)
 	}
 	return allHooks
 }


### PR DESCRIPTION
Charms with containers will receive a hook invocation to -container-ready when the container has started.

This PR adds this new hook to the list of hooks supported.