### PR TITLE
Include ch schema in String().

### DIFF
--- a/url.go
+++ b/url.go
@@ -278,14 +278,7 @@ func (u *URL) Path() string {
 }
 
 // String returns the string representation of the URL.
-// To keep backwards compatibility with older schema versions (CharmStore), we
-// output the FullPath of the URL.
-// For new CharmHub integrations, we only want the Path.
-// That way we can hide the schema from the user.
 func (u *URL) String() string {
-	if CharmHub.Matches(u.Schema) {
-		return u.Path()
-	}
 	return u.FullPath()
 }
 

--- a/url_test.go
+++ b/url_test.go
@@ -204,15 +204,15 @@ var urlTests = []struct {
 	err: `charm or bundle URL $URL malformed, expected "<name>"`,
 }, {
 	s:     "foo",
-	exact: "foo",
+	exact: "ch:foo",
 	url:   &charm.URL{"ch", "", "foo", -1, ""},
 }, {
 	s:     "foo-1",
-	exact: "foo-1",
+	exact: "ch:foo-1",
 	url:   &charm.URL{"ch", "", "foo", 1, ""},
 }, {
 	s:     "n0-n0-n0",
-	exact: "n0-n0-n0",
+	exact: "ch:n0-n0-n0",
 	url:   &charm.URL{"ch", "", "n0-n0-n0", -1, ""},
 }, {
 	s:     "cs:foo",
@@ -229,17 +229,14 @@ var urlTests = []struct {
 	s:   "cs:foo/~blah",
 	err: `cannot parse URL $URL: name "~blah" not valid`,
 }, {
-	s:     "ch:name",
-	exact: "name",
-	url:   &charm.URL{"ch", "", "name", -1, ""},
+	s:   "ch:name",
+	url: &charm.URL{"ch", "", "name", -1, ""},
 }, {
-	s:     "ch:name-suffix",
-	exact: "name-suffix",
-	url:   &charm.URL{"ch", "", "name-suffix", -1, ""},
+	s:   "ch:name-suffix",
+	url: &charm.URL{"ch", "", "name-suffix", -1, ""},
 }, {
-	s:     "ch:name-1",
-	exact: "name-1",
-	url:   &charm.URL{"ch", "", "name", 1, ""},
+	s:   "ch:name-1",
+	url: &charm.URL{"ch", "", "name", 1, ""},
 }, {
 	s:   "ch:name/foo",
 	err: `charm or bundle URL $URL malformed, expected "<name>"`,


### PR DESCRIPTION
If we do not include the 'ch' schema in the String(), a *charm.URL is
not saved to the juju db with the ch schema.  It appears that mongo is
saving via the String().  This may create issues down the road when a
new charm schema is created.

User facing messages in juju have been cleaned up so that
charm.URL.String() is no longer directly printed.