### PR TITLE
Remove legacy services

### DIFF
--- a/bundle_test.go
+++ b/bundle_test.go
@@ -8,7 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v8"
+	"github.com/juju/charm/v9"
 )
 
 var _ = gc.Suite(&BundleSuite{})

--- a/bundle_test.go
+++ b/bundle_test.go
@@ -53,15 +53,6 @@ func (*BundleSuite) TestReadMultiDocBundleArchive(c *gc.C) {
 	checkWordpressBundle(c, b, path)
 }
 
-func (*BundleSuite) TestReadBundleArchiveWithLegacyServices(c *gc.C) {
-	path := bundleDirPath(c, "wordpress-legacy")
-	b, err := charm.ReadBundle(path)
-	c.Assert(err, gc.IsNil)
-	c.Assert(b.ContainsOverlays(), jc.IsFalse)
-	c.Assert(b, gc.FitsTypeOf, (*charm.BundleDir)(nil))
-	checkWordpressBundle(c, b, path)
-}
-
 func checkWordpressBundle(c *gc.C, b charm.Bundle, path string) {
 	// Load the charms required by the bundle.
 	wordpressCharm := readCharmDir(c, "wordpress")

--- a/bundlearchive_test.go
+++ b/bundlearchive_test.go
@@ -12,7 +12,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v8"
+	"github.com/juju/charm/v9"
 )
 
 var _ = gc.Suite(&BundleArchiveSuite{})

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -15,7 +15,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2/bson"
 
-	"github.com/juju/charm/v8"
+	"github.com/juju/charm/v9"
 )
 
 type bundleDataSuite struct {

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -81,11 +81,10 @@ description: |
 `
 
 var parseTests = []struct {
-	about                         string
-	data                          string
-	expectedBD                    *charm.BundleData
-	expectedErr                   string
-	expectUnmarshaledWithServices bool
+	about       string
+	data        string
+	expectedBD  *charm.BundleData
+	expectedErr string
 }{{
 	about: "mediawiki",
 	data:  mediawikiBundle,
@@ -171,49 +170,6 @@ relations:
 			{"mysql:foo", "mediawiki:bar"},
 		},
 	},
-}, {
-	about: "legacy bundle with services instead of applications",
-	data: `
-services:
-    wordpress:
-        charm: wordpress
-    mysql:
-        charm: mysql
-        num_units: 1
-relations:
-    - ["wordpress:db", "mysql:db"]
-`,
-	expectedBD: &charm.BundleData{
-		Applications: map[string]*charm.ApplicationSpec{
-			"wordpress": {
-				Charm: "wordpress",
-			},
-			"mysql": {
-				Charm:    "mysql",
-				NumUnits: 1,
-			},
-		},
-		Relations: [][]string{
-			{"wordpress:db", "mysql:db"},
-		},
-	},
-	expectUnmarshaledWithServices: true,
-}, {
-	about: "bundle with services and applications",
-	data: `
-applications:
-    wordpress:
-        charm: wordpress
-services:
-    wordpress:
-        charm: wordpress
-    mysql:
-        charm: mysql
-        num_units: 1
-relations:
-    - ["wordpress:db", "mysql:db"]
-`,
-	expectedErr: ".*cannot specify both applications and services",
 }, {
 	about: "scale alias for num_units",
 	data: `
@@ -375,20 +331,21 @@ func (*bundleDataSuite) TestParse(c *gc.C) {
 			continue
 		}
 		c.Assert(err, gc.IsNil)
-		c.Assert(bd.UnmarshaledWithServices(), gc.Equals, test.expectUnmarshaledWithServices)
-		bd.ClearUnmarshaledWithServices()
 		c.Assert(bd, jc.DeepEquals, test.expectedBD)
 	}
 }
 
 func (*bundleDataSuite) TestCodecRoundTrip(c *gc.C) {
-	for _, test := range parseTests {
+	for i, test := range parseTests {
 		if test.expectedErr != "" {
 			continue
 		}
 		// Check that for all the known codecs, we can
 		// round-trip the bundle data through them.
 		for _, codec := range codecs {
+
+			c.Logf("Code Test %s for test %d: %s", codec.Name, i, test.about)
+
 			data, err := codec.Marshal(test.expectedBD)
 			c.Assert(err, gc.IsNil)
 			var bd charm.BundleData
@@ -427,29 +384,6 @@ func (*bundleDataSuite) TestParseLocalWithSeries(c *gc.C) {
 				NumUnits: 1,
 			},
 		}})
-}
-
-func (s *bundleDataSuite) TestUnmarshalWithServices(c *gc.C) {
-	obj := map[string]interface{}{
-		"services": map[string]interface{}{
-			"wordpress": map[string]interface{}{
-				"charm": "wordpress",
-			},
-		},
-	}
-	for i, codec := range codecs {
-		c.Logf("codec %d: %v", i, codec.Name)
-		data, err := codec.Marshal(obj)
-		c.Assert(err, gc.IsNil)
-		var bd charm.BundleData
-		err = codec.Unmarshal(data, &bd)
-		c.Assert(err, gc.IsNil)
-		c.Assert(bd.UnmarshaledWithServices(), gc.Equals, true)
-		bd.ClearUnmarshaledWithServices()
-		c.Assert(bd, jc.DeepEquals, charm.BundleData{
-			Applications: map[string]*charm.ApplicationSpec{"wordpress": {Charm: "wordpress"}}},
-		)
-	}
 }
 
 func (s *bundleDataSuite) TestBSONNilData(c *gc.C) {

--- a/bundledir_test.go
+++ b/bundledir_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v8"
+	"github.com/juju/charm/v9"
 )
 
 type BundleDirSuite struct {

--- a/charm_test.go
+++ b/charm_test.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 	stdtesting "testing"
 
-	"github.com/juju/charm/v8"
+	"github.com/juju/charm/v9"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2/fs"

--- a/charmarchive_test.go
+++ b/charmarchive_test.go
@@ -21,7 +21,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 
-	"github.com/juju/charm/v8"
+	"github.com/juju/charm/v9"
 )
 
 type CharmArchiveSuite struct {

--- a/charmdir_test.go
+++ b/charmdir_test.go
@@ -15,7 +15,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/juju/charm/v8"
+	"github.com/juju/charm/v9"
 	"github.com/juju/collections/set"
 	"github.com/juju/loggo"
 	"github.com/juju/testing"

--- a/config_test.go
+++ b/config_test.go
@@ -12,7 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 
-	"github.com/juju/charm/v8"
+	"github.com/juju/charm/v9"
 )
 
 type ConfigSuite struct {

--- a/export_test.go
+++ b/export_test.go
@@ -19,7 +19,3 @@ var (
 func MissingSeriesError() error {
 	return missingSeriesError
 }
-
-func (bd *BundleData) ClearUnmarshaledWithServices() {
-	bd.unmarshaledWithServices = false
-}

--- a/extra_bindings_test.go
+++ b/extra_bindings_test.go
@@ -7,7 +7,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v8"
+	"github.com/juju/charm/v9"
 )
 
 var _ = gc.Suite(&extraBindingsSuite{})

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/juju/charm/v8
+module github.com/juju/charm/v9
 
 require (
 	github.com/gobwas/glob v0.2.3 // indirect

--- a/internal/test-charm-repo/bundle/wordpress-legacy/README.md
+++ b/internal/test-charm-repo/bundle/wordpress-legacy/README.md
@@ -1,1 +1,0 @@
-A dummy bundle

--- a/internal/test-charm-repo/bundle/wordpress-legacy/bundle.yaml
+++ b/internal/test-charm-repo/bundle/wordpress-legacy/bundle.yaml
@@ -1,8 +1,0 @@
-services:
-    wordpress:
-        charm: cs:wordpress
-    mysql:
-        charm: cs:mysql
-        num_units: 1
-relations:
-    - ["wordpress:db", "mysql:server"]

--- a/lxdprofile_test.go
+++ b/lxdprofile_test.go
@@ -9,7 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v8"
+	"github.com/juju/charm/v9"
 )
 
 type ProfileSuite struct{}

--- a/meta.go
+++ b/meta.go
@@ -23,8 +23,8 @@ import (
 	"github.com/juju/version"
 	"gopkg.in/yaml.v2"
 
-	"github.com/juju/charm/v8/hooks"
-	"github.com/juju/charm/v8/resource"
+	"github.com/juju/charm/v9/hooks"
+	"github.com/juju/charm/v9/resource"
 )
 
 // RelationScope describes the scope of a relation.

--- a/meta_test.go
+++ b/meta_test.go
@@ -20,8 +20,8 @@ import (
 	"gopkg.in/yaml.v2"
 	yamlv2 "gopkg.in/yaml.v2"
 
-	"github.com/juju/charm/v8"
-	"github.com/juju/charm/v8/resource"
+	"github.com/juju/charm/v9"
+	"github.com/juju/charm/v9/resource"
 )
 
 func repoMeta(c *gc.C, name string) io.Reader {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -9,7 +9,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v8"
+	"github.com/juju/charm/v9"
 )
 
 // Keys returns a list of all defined metrics keys.

--- a/offerurl_test.go
+++ b/offerurl_test.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"strings"
 
-	charm "github.com/juju/charm/v8"
+	charm "github.com/juju/charm/v9"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 )

--- a/overlay.go
+++ b/overlay.go
@@ -87,9 +87,7 @@ func ExtractBaseAndOverlayParts(bd *BundleData) (base, overlay *BundleData, err 
 
 // cloneBundleData uses the gob package to perform a deep copy of bd.
 func cloneBundleData(bd *BundleData) *BundleData {
-	clone := deepcopy.Copy(bd).(*BundleData)
-	clone.unmarshaledWithServices = bd.unmarshaledWithServices
-	return clone
+	return deepcopy.Copy(bd).(*BundleData)
 }
 
 // VerifyNoOverlayFieldsPresent scans the contents of bd and returns an error

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -16,7 +16,7 @@ import (
 	gc "gopkg.in/check.v1"
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/juju/charm/v8"
+	"github.com/juju/charm/v9"
 )
 
 type bundleDataOverlaySuite struct {

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -7,7 +7,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v8"
+	"github.com/juju/charm/v9"
 )
 
 var _ = gc.Suite(&payloadClassSuite{})

--- a/resource/fingerprint_test.go
+++ b/resource/fingerprint_test.go
@@ -12,7 +12,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v8/resource"
+	"github.com/juju/charm/v9/resource"
 )
 
 func newFingerprint(c *gc.C, data string) ([]byte, string) {

--- a/resource/meta_test.go
+++ b/resource/meta_test.go
@@ -8,7 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v8/resource"
+	"github.com/juju/charm/v9/resource"
 )
 
 var _ = gc.Suite(&MetaSuite{})

--- a/resource/origin_test.go
+++ b/resource/origin_test.go
@@ -9,7 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v8/resource"
+	"github.com/juju/charm/v9/resource"
 )
 
 type OriginSuite struct {

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -8,7 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v8/resource"
+	"github.com/juju/charm/v9/resource"
 )
 
 var fingerprint = []byte("123456789012345678901234567890123456789012345678")

--- a/resource/type_test.go
+++ b/resource/type_test.go
@@ -8,7 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v8/resource"
+	"github.com/juju/charm/v9/resource"
 )
 
 var _ = gc.Suite(&TypeSuite{})

--- a/resources.go
+++ b/resources.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/schema"
 
-	"github.com/juju/charm/v8/resource"
+	"github.com/juju/charm/v9/resource"
 )
 
 var resourceSchema = schema.FieldMap(

--- a/resources_test.go
+++ b/resources_test.go
@@ -7,7 +7,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v8"
+	"github.com/juju/charm/v9"
 )
 
 var _ = gc.Suite(&resourceSuite{})

--- a/url_test.go
+++ b/url_test.go
@@ -13,7 +13,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/yaml.v2"
 
-	"github.com/juju/charm/v8"
+	"github.com/juju/charm/v9"
 )
 
 type URLSuite struct{}

--- a/version_test.go
+++ b/version_test.go
@@ -6,7 +6,7 @@ package charm_test
 import (
 	"strings"
 
-	"github.com/juju/charm/v8"
+	"github.com/juju/charm/v9"
 	gc "gopkg.in/check.v1"
 )
 


### PR DESCRIPTION
Services have been time and memorial, unfortunately, they were
deprecated in version 2.x (2016 timeframe). I think authors of charms
have had enough time to move over to applications.

This removes services, yet we have to keep the horrid hack of
normalizing the data when we unmarshal. It's wrong and shouldn't be in
this code, it should be a two-step process and remove the magic that
causes us issues in the long run.

---

This is a breaking change and we'll bump the version appropriately. 