### PR TITLE
Allow architecture and series in identifier URLs

### DIFF
--- a/url.go
+++ b/url.go
@@ -76,14 +76,16 @@ type Location interface {
 //     ch:wordpress
 //
 type URL struct {
-	Schema   string // "cs", "ch" or "local".
-	User     string // "joe".
-	Name     string // "wordpress".
-	Revision int    // -1 if unset, N otherwise.
-	Series   string // "precise" or "" if unset; "bundle" if it's a bundle.
+	Schema       string // "cs", "ch" or "local".
+	User         string // "joe".
+	Name         string // "wordpress".
+	Revision     int    // -1 if unset, N otherwise.
+	Series       string // "precise" or "" if unset; "bundle" if it's a bundle.
+	Architecture string // "amd64" or "" if unset for charmstore (v1) URLs.
 }
 
 var (
+	validArch   = regexp.MustCompile("^[a-z]+([a-z0-9]+)?$")
 	validSeries = regexp.MustCompile("^[a-z]+([a-z0-9]+)?$")
 	validName   = regexp.MustCompile("^[a-z][a-z0-9]*(-[a-z0-9]*[a-z][a-z0-9]*)*$")
 )
@@ -113,10 +115,24 @@ func IsValidSeries(series string) bool {
 
 // ValidateSeries returns an error if the given series is invalid.
 func ValidateSeries(series string) error {
-	if IsValidSeries(series) == false {
-		return errors.NotValidf("series name %q", series)
+	if IsValidSeries(series) {
+		return nil
 	}
-	return nil
+	return errors.NotValidf("series name %q", series)
+}
+
+// IsValidArchitecture reports whether the architecture is a valid architecture
+// in charm or bundle URLs.
+func IsValidArchitecture(arch string) bool {
+	return validArch.MatchString(arch)
+}
+
+// ValidateArchitecture returns an error if the given architecture is invalid.
+func ValidateArchitecture(arch string) error {
+	if IsValidArchitecture(arch) {
+		return nil
+	}
+	return errors.NotValidf("architecture name %q", arch)
 }
 
 // IsValidName reports whether name is a valid charm or bundle name.
@@ -126,10 +142,10 @@ func IsValidName(name string) bool {
 
 // ValidateName returns an error if the given name is invalid.
 func ValidateName(name string) error {
-	if IsValidName(name) == false {
-		return errors.NotValidf("name %q", name)
+	if IsValidName(name) {
+		return nil
 	}
-	return nil
+	return errors.NotValidf("name %q", name)
 }
 
 // WithRevision returns a URL equivalent to url but with Revision set
@@ -255,6 +271,9 @@ func (u *URL) path() string {
 	var parts []string
 	if u.User != "" {
 		parts = append(parts, fmt.Sprintf("~%s", u.User))
+	}
+	if u.Architecture != "" {
+		parts = append(parts, u.Architecture)
 	}
 	if u.Series != "" {
 		parts = append(parts, u.Series)
@@ -461,6 +480,23 @@ func parseHTTPURL(url *gourl.URL) (*URL, error) {
 	return &r, nil
 }
 
+// parseIdentifierURL will attempt to parse an identifier URL. The identifier
+// URL is split up into 3 parts, some of which are optional and some are
+// mandatory.
+//
+//  - architecture (optional)
+//  - series (optional)
+//  - name
+//  - revision (optional)
+//
+// Examples are as follows:
+//
+//  - ch:amd64/foo-1
+//  - ch:amd64/focal/foo-1
+//  - ch:foo-1
+//  - ch:foo
+//  - ch:amd64/focal/foo
+//
 func parseIdentifierURL(url *gourl.URL) (*URL, error) {
 	r := URL{
 		Schema:   CharmHub.String(),
@@ -473,14 +509,37 @@ func parseIdentifierURL(url *gourl.URL) (*URL, error) {
 	}
 
 	parts := strings.Split(strings.Trim(path, "/"), "/")
-	if len(parts) != 1 {
-		return nil, errors.Errorf(`charm or bundle URL %q malformed, expected "<name>"`, url)
+	if len(parts) == 0 || len(parts) > 3 {
+		return nil, errors.Errorf(`charm or bundle URL %q malformed`, url)
 	}
 
-	r.Name, r.Revision = extractRevision(parts[0])
-	if err := ValidateName(r.Name); err != nil {
-		return nil, errors.Annotatef(err, "cannot parse URL %q", url)
+	var nameRev string
+	if num := len(parts); num == 3 {
+		r.Architecture, r.Series, nameRev = parts[0], parts[1], parts[2]
+	} else if num == 2 {
+		r.Architecture, nameRev = parts[0], parts[1]
+	} else {
+		nameRev = parts[0]
 	}
+
+	// Mandatory
+	r.Name, r.Revision = extractRevision(nameRev)
+	if err := ValidateName(r.Name); err != nil {
+		return nil, errors.Annotatef(err, "cannot parse name and/or revision in URL %q", url)
+	}
+
+	// Optional
+	if r.Architecture != "" {
+		if err := ValidateArchitecture(r.Architecture); err != nil {
+			return nil, errors.Annotatef(err, "cannot parse architecture in URL %q", url)
+		}
+	}
+	if r.Series != "" {
+		if err := ValidateSeries(r.Series); err != nil {
+			return nil, errors.Annotatef(err, "cannot parse series in URL %q", url)
+		}
+	}
+
 	return &r, nil
 }
 

--- a/url_test.go
+++ b/url_test.go
@@ -26,109 +26,109 @@ var urlTests = []struct {
 	url    *charm.URL
 }{{
 	s:   "cs:~user/series/name",
-	url: &charm.URL{"cs", "user", "name", -1, "series"},
+	url: &charm.URL{"cs", "user", "name", -1, "series", ""},
 }, {
 	s:   "cs:~user/series/name-0",
-	url: &charm.URL{"cs", "user", "name", 0, "series"},
+	url: &charm.URL{"cs", "user", "name", 0, "series", ""},
 }, {
 	s:   "cs:series/name",
-	url: &charm.URL{"cs", "", "name", -1, "series"},
+	url: &charm.URL{"cs", "", "name", -1, "series", ""},
 }, {
 	s:   "cs:series/name-42",
-	url: &charm.URL{"cs", "", "name", 42, "series"},
+	url: &charm.URL{"cs", "", "name", 42, "series", ""},
 }, {
 	s:   "local:series/name-1",
-	url: &charm.URL{"local", "", "name", 1, "series"},
+	url: &charm.URL{"local", "", "name", 1, "series", ""},
 }, {
 	s:   "local:series/name",
-	url: &charm.URL{"local", "", "name", -1, "series"},
+	url: &charm.URL{"local", "", "name", -1, "series", ""},
 }, {
 	s:   "local:series/n0-0n-n0",
-	url: &charm.URL{"local", "", "n0-0n-n0", -1, "series"},
+	url: &charm.URL{"local", "", "n0-0n-n0", -1, "series", ""},
 }, {
 	s:   "cs:~user/name",
-	url: &charm.URL{"cs", "user", "name", -1, ""},
+	url: &charm.URL{"cs", "user", "name", -1, "", ""},
 }, {
 	s:   "cs:name",
-	url: &charm.URL{"cs", "", "name", -1, ""},
+	url: &charm.URL{"cs", "", "name", -1, "", ""},
 }, {
 	s:   "local:name",
-	url: &charm.URL{"local", "", "name", -1, ""},
+	url: &charm.URL{"local", "", "name", -1, "", ""},
 }, {
 	s:     "http://jujucharms.com/u/user/name/series/1",
-	url:   &charm.URL{"cs", "user", "name", 1, "series"},
+	url:   &charm.URL{"cs", "user", "name", 1, "series", ""},
 	exact: "cs:~user/series/name-1",
 }, {
 	s:     "http://www.jujucharms.com/u/user/name/series/1",
-	url:   &charm.URL{"cs", "user", "name", 1, "series"},
+	url:   &charm.URL{"cs", "user", "name", 1, "series", ""},
 	exact: "cs:~user/series/name-1",
 }, {
 	s:     "https://www.jujucharms.com/u/user/name/series/1",
-	url:   &charm.URL{"cs", "user", "name", 1, "series"},
+	url:   &charm.URL{"cs", "user", "name", 1, "series", ""},
 	exact: "cs:~user/series/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name/series/1",
-	url:   &charm.URL{"cs", "user", "name", 1, "series"},
+	url:   &charm.URL{"cs", "user", "name", 1, "series", ""},
 	exact: "cs:~user/series/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name/series",
-	url:   &charm.URL{"cs", "user", "name", -1, "series"},
+	url:   &charm.URL{"cs", "user", "name", -1, "series", ""},
 	exact: "cs:~user/series/name",
 }, {
 	s:     "https://jujucharms.com/u/user/name/1",
-	url:   &charm.URL{"cs", "user", "name", 1, ""},
+	url:   &charm.URL{"cs", "user", "name", 1, "", ""},
 	exact: "cs:~user/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name",
-	url:   &charm.URL{"cs", "user", "name", -1, ""},
+	url:   &charm.URL{"cs", "user", "name", -1, "", ""},
 	exact: "cs:~user/name",
 }, {
 	s:     "https://jujucharms.com/name",
-	url:   &charm.URL{"cs", "", "name", -1, ""},
+	url:   &charm.URL{"cs", "", "name", -1, "", ""},
 	exact: "cs:name",
 }, {
 	s:     "https://jujucharms.com/name/series",
-	url:   &charm.URL{"cs", "", "name", -1, "series"},
+	url:   &charm.URL{"cs", "", "name", -1, "series", ""},
 	exact: "cs:series/name",
 }, {
 	s:     "https://jujucharms.com/name/1",
-	url:   &charm.URL{"cs", "", "name", 1, ""},
+	url:   &charm.URL{"cs", "", "name", 1, "", ""},
 	exact: "cs:name-1",
 }, {
 	s:     "https://jujucharms.com/name/series/1",
-	url:   &charm.URL{"cs", "", "name", 1, "series"},
+	url:   &charm.URL{"cs", "", "name", 1, "series", ""},
 	exact: "cs:series/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name/series/1/",
-	url:   &charm.URL{"cs", "user", "name", 1, "series"},
+	url:   &charm.URL{"cs", "user", "name", 1, "series", ""},
 	exact: "cs:~user/series/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name/series/",
-	url:   &charm.URL{"cs", "user", "name", -1, "series"},
+	url:   &charm.URL{"cs", "user", "name", -1, "series", ""},
 	exact: "cs:~user/series/name",
 }, {
 	s:     "https://jujucharms.com/u/user/name/1/",
-	url:   &charm.URL{"cs", "user", "name", 1, ""},
+	url:   &charm.URL{"cs", "user", "name", 1, "", ""},
 	exact: "cs:~user/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name/",
-	url:   &charm.URL{"cs", "user", "name", -1, ""},
+	url:   &charm.URL{"cs", "user", "name", -1, "", ""},
 	exact: "cs:~user/name",
 }, {
 	s:     "https://jujucharms.com/name/",
-	url:   &charm.URL{"cs", "", "name", -1, ""},
+	url:   &charm.URL{"cs", "", "name", -1, "", ""},
 	exact: "cs:name",
 }, {
 	s:     "https://jujucharms.com/name/series/",
-	url:   &charm.URL{"cs", "", "name", -1, "series"},
+	url:   &charm.URL{"cs", "", "name", -1, "series", ""},
 	exact: "cs:series/name",
 }, {
 	s:     "https://jujucharms.com/name/1/",
-	url:   &charm.URL{"cs", "", "name", 1, ""},
+	url:   &charm.URL{"cs", "", "name", 1, "", ""},
 	exact: "cs:name-1",
 }, {
 	s:     "https://jujucharms.com/name/series/1/",
-	url:   &charm.URL{"cs", "", "name", 1, "series"},
+	url:   &charm.URL{"cs", "", "name", 1, "series", ""},
 	exact: "cs:series/name-1",
 }, {
 	s:   "https://jujucharms.com/",
@@ -200,55 +200,58 @@ var urlTests = []struct {
 	s:   "local:~user/name",
 	err: `local charm or bundle URL with user name: $URL`,
 }, {
-	s:   "precise/wordpress",
-	err: `charm or bundle URL $URL malformed, expected "<name>"`,
+	s:     "amd64/name",
+	url:   &charm.URL{"ch", "", "name", -1, "", "amd64"},
+	exact: "ch:amd64/name",
 }, {
 	s:     "foo",
+	url:   &charm.URL{"ch", "", "foo", -1, "", ""},
 	exact: "ch:foo",
-	url:   &charm.URL{"ch", "", "foo", -1, ""},
 }, {
 	s:     "foo-1",
 	exact: "ch:foo-1",
-	url:   &charm.URL{"ch", "", "foo", 1, ""},
+	url:   &charm.URL{"ch", "", "foo", 1, "", ""},
 }, {
 	s:     "n0-n0-n0",
 	exact: "ch:n0-n0-n0",
-	url:   &charm.URL{"ch", "", "n0-n0-n0", -1, ""},
+	url:   &charm.URL{"ch", "", "n0-n0-n0", -1, "", ""},
 }, {
 	s:     "cs:foo",
 	exact: "cs:foo",
-	url:   &charm.URL{"cs", "", "foo", -1, ""},
+	url:   &charm.URL{"cs", "", "foo", -1, "", ""},
 }, {
 	s:     "local:foo",
 	exact: "local:foo",
-	url:   &charm.URL{"local", "", "foo", -1, ""},
+	url:   &charm.URL{"local", "", "foo", -1, "", ""},
 }, {
-	s:   "series/foo/bar",
-	err: `charm or bundle URL $URL malformed, expected "<name>"`,
+	s:     "arch/series/bar",
+	url:   &charm.URL{"ch", "", "bar", -1, "series", "arch"},
+	exact: "ch:arch/series/bar",
 }, {
 	s:   "cs:foo/~blah",
 	err: `cannot parse URL $URL: name "~blah" not valid`,
 }, {
 	s:   "ch:name",
-	url: &charm.URL{"ch", "", "name", -1, ""},
+	url: &charm.URL{"ch", "", "name", -1, "", ""},
 }, {
 	s:   "ch:name-suffix",
-	url: &charm.URL{"ch", "", "name-suffix", -1, ""},
+	url: &charm.URL{"ch", "", "name-suffix", -1, "", ""},
 }, {
 	s:   "ch:name-1",
-	url: &charm.URL{"ch", "", "name", 1, ""},
+	url: &charm.URL{"ch", "", "name", 1, "", ""},
 }, {
-	s:   "ch:name/foo",
-	err: `charm or bundle URL $URL malformed, expected "<name>"`,
+	s:     "ch:arch/name",
+	url:   &charm.URL{"ch", "", "name", -1, "", "arch"},
+	exact: "ch:arch/name",
 }, {
 	s:   "ch:~user/name",
-	err: `charm or bundle URL $URL malformed, expected "<name>"`,
+	err: `cannot parse architecture in URL "ch:~user/name": architecture name "~user" not valid`,
 }, {
 	s:   "ch:~user/series/name-0",
-	err: `charm or bundle URL $URL malformed, expected "<name>"`,
+	err: `cannot parse architecture in URL "ch:~user/series/name-0": architecture name "~user" not valid`,
 }, {
 	s:   "ch:nam-!e",
-	err: `cannot parse URL "ch:nam-!e": name "nam-!e" not valid`,
+	err: `cannot parse name and/or revision in URL "ch:nam-!e": name "nam-!e" not valid`,
 }}
 
 func (s *URLSuite) TestParseURL(c *gc.C) {
@@ -463,7 +466,7 @@ func (s *URLSuite) TestValidCheckers(c *gc.C) {
 
 func (s *URLSuite) TestMustParseURL(c *gc.C) {
 	url := charm.MustParseURL("cs:series/name")
-	c.Assert(url, gc.DeepEquals, &charm.URL{"cs", "", "name", -1, "series"})
+	c.Assert(url, gc.DeepEquals, &charm.URL{"cs", "", "name", -1, "series", ""})
 	f := func() { charm.MustParseURL("local:@@/name") }
 	c.Assert(f, gc.PanicMatches, "cannot parse URL \"local:@@/name\": series name \"@@\" not valid")
 	f = func() { charm.MustParseURL("cs:~user") }
@@ -475,8 +478,8 @@ func (s *URLSuite) TestMustParseURL(c *gc.C) {
 func (s *URLSuite) TestWithRevision(c *gc.C) {
 	url := charm.MustParseURL("cs:series/name")
 	other := url.WithRevision(1)
-	c.Assert(url, gc.DeepEquals, &charm.URL{"cs", "", "name", -1, "series"})
-	c.Assert(other, gc.DeepEquals, &charm.URL{"cs", "", "name", 1, "series"})
+	c.Assert(url, gc.DeepEquals, &charm.URL{"cs", "", "name", -1, "series", ""})
+	c.Assert(other, gc.DeepEquals, &charm.URL{"cs", "", "name", 1, "series", ""})
 
 	// Should always copy. The opposite behavior is error prone.
 	c.Assert(other.WithRevision(1), gc.Not(gc.Equals), other)


### PR DESCRIPTION
Identifier URLs (charmhub URLs) are required to now identify themselves
with ability to adorn themselves with architectures and series. This is
so the uniquness of a URL within Juju is more than just the name and
revision. It allows more fine grained constraints about what a charm URL
is.

It does have the consequence that any other repsonsibilities outside of
the constrainted URL domain is now lost. If you want to use the charm
URL for a differing architecture becomes unwise or even impossible.