### PR TITLE
Application short syntax

### DIFF
--- a/bundle_test.go
+++ b/bundle_test.go
@@ -65,16 +65,18 @@ func checkWordpressBundle(c *gc.C, b charm.Bundle, path string) {
 		"cs:wordpress": wordpressCharm,
 		"cs:mysql":     mysqlCharm,
 	}
-	err := bd.VerifyWithCharms(verifyOk, nil, nil, charms)
+	warnings, err := bd.VerifyWithCharms(verifyOk, nil, nil, charms)
 	c.Assert(err, gc.IsNil)
+	c.Assert(len(warnings), gc.Equals, 0)
 
 	c.Assert(bd.Applications, jc.DeepEquals, map[string]*charm.ApplicationSpec{
 		"wordpress": {
-			Charm: "cs:wordpress",
+			Charm:    "cs:wordpress",
+			NumUnits: newInt(1),
 		},
 		"mysql": {
 			Charm:    "cs:mysql",
-			NumUnits: 1,
+			NumUnits: newInt(1),
 		},
 	})
 	c.Assert(bd.Relations, jc.DeepEquals, [][]string{

--- a/bundle_test.go
+++ b/bundle_test.go
@@ -65,9 +65,8 @@ func checkWordpressBundle(c *gc.C, b charm.Bundle, path string) {
 		"cs:wordpress": wordpressCharm,
 		"cs:mysql":     mysqlCharm,
 	}
-	warnings, err := bd.VerifyWithCharms(verifyOk, nil, nil, charms)
+	err := bd.VerifyWithCharms(verifyOk, nil, nil, charms)
 	c.Assert(err, gc.IsNil)
-	c.Assert(len(warnings), gc.Equals, 0)
 
 	c.Assert(bd.Applications, jc.DeepEquals, map[string]*charm.ApplicationSpec{
 		"wordpress": {

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -57,6 +57,7 @@ series: bionic
 applications:
   apache2:
     charm: cs:apache2-26
+    num_units: 1
 saas:
   apache2:
     url: production:admin/info.apache
@@ -367,6 +368,7 @@ applications:
     resources:
       res1: bar
       res2: new
+    num_units: 1
     storage:
       dsk0: vol0
       dsk1: new
@@ -402,6 +404,7 @@ applications:
 applications:
   apache2:
     charm: cs:apache2-26
+    num_units: 1
     options:
       opt1: foo
       opt2: ""
@@ -465,8 +468,10 @@ relations:
 applications:
   apache2:
     charm: cs:apache2-42
+    num_units: 1
   dummy:
     charm: cs:dummy
+    num_units: 1
 relations:
 - - dummy:www
   - apache2:www
@@ -494,6 +499,7 @@ saas:
 applications:
   wordpress:
     charm: cs:wordpress-2
+    num_units: 1
 saas:
   cockroachdb:
     url: jaas:admin/default.cockroachdb
@@ -529,6 +535,7 @@ applications:
 applications:
   apache2:
     charm: cs:apache2-26
+    num_units: 1
     offers:
       my-offer:
         endpoints:
@@ -556,6 +563,7 @@ machines:
 applications:
   apache2:
     charm: cs:apache2-26
+    num_units: 1
 machines:
   "2": {}
 `,
@@ -686,6 +694,7 @@ machines:
 	exp := `
 applications:
   apache2:
+    num_units: 1
     options:
       opt-b64: bG9yZW0kaXBzdW0k
       opt-other:
@@ -751,6 +760,7 @@ applications:
 applications:
   django:
     charm: cs:django
+    num_units: 1
     options:
       opt1: lorem ipsum
       opt2: dolor
@@ -790,6 +800,7 @@ applications:
 applications:
   django:
     charm: cs:django
+    num_units: 1
 `
 
 	c.Assert("\n"+string(merged), gc.Equals, exp)
@@ -824,12 +835,16 @@ applications:
 applications:
   apache2:
     charm: /tmp/base/apache
+    num_units: 1
   mysql:
     charm: cs:mysql
+    num_units: 1
   varnish:
     charm: /some/absolute/path
+    num_units: 1
   wordpress:
     charm: /overlay/wordpress
+    num_units: 1
 `[1:]
 
 	c.Assert(string(merged), gc.Equals, exp)


### PR DESCRIPTION
The following implements application short syntax as the following:

    applications:
        mysql: {}

There are valid reasons for doing this. Initially, it was thought that ~
could be used to indicate the short syntax, but ~ already indicates
null. This is fine but causes all sorts of hell when integrating with
overlays. ~ becomes a way to delete charms and that makes it confusing
and very hard to work out if we should use the short syntax or delete a
charm.

The best way forward is to just sidestep this completely and use the
empty object type. It's not as short, but it's very clear from the code
how to move forward with it.

Additionally, this also adds the default number of units to 1, which also
handles the Scale and NumUnits conversion. Essentially Scale can just be
ignored once it's been normalized.
