### PR TITLE
Block metadata v2 from being loaded in juju 2.8

### DIFF
--- a/meta_test.go
+++ b/meta_test.go
@@ -1572,6 +1572,18 @@ func (s *MetaSuite) TestParseResourceMetaNil(c *gc.C) {
 	})
 }
 
+func (s *MetaSuite) TestMetadataV2Fails(c *gc.C) {
+	_, err := charm.ReadMeta(strings.NewReader(`
+name: a
+summary: b
+description: c
+bases:
+  - name: ubuntu
+    channel: 18.04/stable
+`))
+	c.Assert(err, gc.ErrorMatches, `metadata format v2 not supported`)
+}
+
 type dummyCharm struct{}
 
 func (c *dummyCharm) Version() string {


### PR DESCRIPTION
Backported version detection logic to prevent v2 metadata being loaded when juju 2.8 only supports v1 charms.

This is due to min-juju-version being removed for v2.