### PR TITLE
[v8] Missing application body causes panic

### DIFF
--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -1497,6 +1497,13 @@ applications:
         plan: "testisv/test2"
     application2:
 `,
+		`
+applications:
+    application1:
+        charm: "test"
+        plan: "testisv/test2"
+    application2: ~
+`,
 	}
 
 	for _, d := range tstDatas {

--- a/overlay.go
+++ b/overlay.go
@@ -440,6 +440,9 @@ func ReadAndMergeBundleData(sources ...BundleDataSource) (*BundleData, error) {
 		incResolver := sources[srcIndex].ResolveInclude
 		basePath := sources[srcIndex].BasePath()
 		for app, appData := range base.Data.Applications {
+			if appData == nil {
+				return nil, errors.Errorf("base application %q has no body", app)
+			}
 			resolvedCharm, err := resolveRelativeCharmPath(basePath, appData.Charm)
 			if err != nil {
 				return nil, errors.Annotatef(err, "resolving relative charm path %q for application %q", appData.Charm, app)

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -25,6 +25,22 @@ type bundleDataOverlaySuite struct {
 
 var _ = gc.Suite(&bundleDataOverlaySuite{})
 
+func (*bundleDataOverlaySuite) TestEmptyBaseApplication(c *gc.C) {
+	data := `
+applications:
+  apache2:
+---
+series: trusty
+applications:
+  apache2:
+    charm: cs:apache2-42
+    series: bionic
+`[1:]
+
+	_, err := charm.ReadAndMergeBundleData(mustCreateStringDataSource(c, data))
+	c.Assert(err, gc.ErrorMatches, `base application "apache2" has no body`)
+}
+
 func (*bundleDataOverlaySuite) TestExtractBaseAndOverlayParts(c *gc.C) {
 	data := `
 applications:


### PR DESCRIPTION
The following ensures that the base body is required when dealing with
overlays. The fix is really easy, but additionally I've added a test to
the bundle data to also check for empty bodies with ~ symbol.

Fixes: https://bugs.launchpad.net/juju/+bug/1918742
