### PR TITLE
Encode base into a URL

### DIFF
--- a/url.go
+++ b/url.go
@@ -81,15 +81,15 @@ type URL struct {
 	Name         string // "wordpress".
 	Revision     int    // -1 if unset, N otherwise.
 	Series       string // "precise" or "" if unset; "bundle" if it's a bundle.
-	Channel      string // "20.04:stable:branch" if channel is present, series is empty.
+	Base         string // "20.04:stable:branch" if base is present, series is empty.
 	Architecture string // "amd64" or "" if unset for charmstore (v1) URLs.
 }
 
 var (
-	validArch    = regexp.MustCompile("^[a-z]+([a-z0-9]+)?$")
-	validSeries  = regexp.MustCompile("^[a-z]+([a-z0-9]+)?$")
-	validChannel = regexp.MustCompile("^[a-zA-Z0-9.]+(:[a-zA-Z0-9]+(:[a-zA-Z0-9]+)?)?$")
-	validName    = regexp.MustCompile("^[a-z][a-z0-9]*(-[a-z0-9]*[a-z][a-z0-9]*)*$")
+	validArch   = regexp.MustCompile("^[a-z]+([a-z0-9]+)?$")
+	validSeries = regexp.MustCompile("^[a-z]+([a-z0-9]+)?$")
+	validBase   = regexp.MustCompile("^[a-zA-Z0-9]+:[a-zA-Z0-9.]+(:[a-zA-Z0-9]+(:[a-zA-Z0-9]+)?)?$")
+	validName   = regexp.MustCompile("^[a-z][a-z0-9]*(-[a-z0-9]*[a-z][a-z0-9]*)*$")
 )
 
 // ValidateSchema returns an error if the schema is invalid.
@@ -123,18 +123,18 @@ func ValidateSeries(series string) error {
 	return errors.NotValidf("series name %q", series)
 }
 
-// IsValidChannel reports whether series is a valid channel in charm or bundle
+// IsValidBase reports whether series is a valid base in charm or bundle
 // URLs.
-func IsValidChannel(channel string) bool {
-	return validChannel.MatchString(channel)
+func IsValidBase(base string) bool {
+	return validBase.MatchString(base)
 }
 
-// ValidateChannel returns an error if the given channel is invalid.
-func ValidateChannel(channel string) error {
-	if IsValidChannel(channel) {
+// ValidateBase returns an error if the given base is invalid.
+func ValidateBase(base string) error {
+	if IsValidBase(base) {
 		return nil
 	}
-	return errors.NotValidf("channel %q", channel)
+	return errors.NotValidf("base %q", base)
 }
 
 // IsValidArchitecture reports whether the architecture is a valid architecture
@@ -180,11 +180,11 @@ func (u *URL) WithArchitecture(arch string) *URL {
 	return &urlCopy
 }
 
-// WithChannel returns a URL equivalent to url but with Channel set
-// to channel.
-func (u *URL) WithChannel(channel string) *URL {
+// WithBase returns a URL equivalent to url but with Base set
+// to base.
+func (u *URL) WithBase(base string) *URL {
 	urlCopy := *u
-	urlCopy.Channel = channel
+	urlCopy.Base = base
 	return &urlCopy
 }
 
@@ -315,11 +315,11 @@ func (u *URL) path() string {
 	if u.Architecture != "" {
 		parts = append(parts, u.Architecture)
 	}
-	if u.Channel == "" && u.Series != "" {
+	if u.Base == "" && u.Series != "" {
 		parts = append(parts, u.Series)
 	}
-	if u.Channel != "" && u.Series == "" {
-		parts = append(parts, u.Channel)
+	if u.Base != "" && u.Series == "" {
+		parts = append(parts, u.Base)
 	}
 	if u.Revision >= 0 {
 		parts = append(parts, fmt.Sprintf("%s-%d", u.Name, u.Revision))
@@ -561,7 +561,7 @@ func parseIdentifierURL(url *gourl.URL) (*URL, error) {
 	var nameRev string
 	switch len(parts) {
 	case 3:
-		r.Architecture, r.Channel, nameRev = parts[0], parts[1], parts[2]
+		r.Architecture, r.Base, nameRev = parts[0], parts[1], parts[2]
 	case 2:
 		r.Architecture, nameRev = parts[0], parts[1]
 	default:
@@ -580,9 +580,9 @@ func parseIdentifierURL(url *gourl.URL) (*URL, error) {
 			return nil, errors.Annotatef(err, "cannot parse architecture in URL %q", url)
 		}
 	}
-	if r.Channel != "" {
-		if err := ValidateChannel(r.Channel); err != nil {
-			return nil, errors.Annotatef(err, "cannot parse channel in URL %q", url)
+	if r.Base != "" {
+		if err := ValidateBase(r.Base); err != nil {
+			return nil, errors.Annotatef(err, "cannot parse base in URL %q", url)
 		}
 	}
 

--- a/url.go
+++ b/url.go
@@ -81,7 +81,7 @@ type URL struct {
 	Name         string // "wordpress".
 	Revision     int    // -1 if unset, N otherwise.
 	Series       string // "precise" or "" if unset; "bundle" if it's a bundle.
-	Base         string // "20.04:stable:branch" if base is present, series is empty.
+	Base         string // "ubuntu:20.04:stable:branch" if base is present, series is empty.
 	Architecture string // "amd64" or "" if unset for charmstore (v1) URLs.
 }
 

--- a/url.go
+++ b/url.go
@@ -535,12 +535,12 @@ func parseHTTPURL(url *gourl.URL) (*URL, error) {
 // Examples are as follows:
 //
 //  - ch:amd64/foo-1
-//  - ch:amd64/20.04/foo-1
-//  - ch:amd64/20.04:stable/foo-1
-//  - ch:amd64/20.04:stable:branch/foo-1
+//  - ch:amd64/ubuntu:20.04/foo-1
+//  - ch:amd64/ubuntu:20.04:stable/foo-1
+//  - ch:amd64/ubuntu:20.04:stable:branch/foo-1
 //  - ch:foo-1
 //  - ch:foo
-//  - ch:amd64/20.04/foo
+//  - ch:amd64/ubuntu:20.04/foo
 //
 func parseIdentifierURL(url *gourl.URL) (*URL, error) {
 	r := URL{

--- a/url_test.go
+++ b/url_test.go
@@ -224,32 +224,36 @@ var urlTests = []struct {
 	exact: "local:foo",
 	url:   makeURL("local", "", "foo", -1, "", ""),
 }, {
-	s:     "arch/channel/bar",
-	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Channel: "channel", Architecture: "arch"},
-	exact: "ch:arch/channel/bar",
+	s:     "arch/base:version/bar",
+	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Base: "base:version", Architecture: "arch"},
+	exact: "ch:arch/base:version/bar",
 }, {
-	s:     "arch/20.04:stable:branch/bar",
-	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Channel: "20.04:stable:branch", Architecture: "arch"},
-	exact: "ch:arch/20.04:stable:branch/bar",
+	s:     "arch/ubuntu:20.04:stable:branch/bar",
+	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Base: "ubuntu:20.04:stable:branch", Architecture: "arch"},
+	exact: "ch:arch/ubuntu:20.04:stable:branch/bar",
 }, {
-	s:     "arch/20.04:stable/bar",
-	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Channel: "20.04:stable", Architecture: "arch"},
-	exact: "ch:arch/20.04:stable/bar",
+	s:     "arch/ubuntu:20.04:stable/bar",
+	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Base: "ubuntu:20.04:stable", Architecture: "arch"},
+	exact: "ch:arch/ubuntu:20.04:stable/bar",
 }, {
-	s:     "arch/20.04/bar",
-	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Channel: "20.04", Architecture: "arch"},
-	exact: "ch:arch/20.04/bar",
+	s:     "arch/ubuntu:20.04/bar",
+	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Base: "ubuntu:20.04", Architecture: "arch"},
+	exact: "ch:arch/ubuntu:20.04/bar",
+}, {
+	s:   "arch/ubuntu/bar",
+	url: &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Base: "ubuntu", Architecture: "arch"},
+	err: `cannot parse base in URL "arch/ubuntu/bar": base "ubuntu" not valid`,
 }, {
 	s:     "arch/windows:stable/bar",
-	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Channel: "windows:stable", Architecture: "arch"},
+	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Base: "windows:stable", Architecture: "arch"},
 	exact: "ch:arch/windows:stable/bar",
 }, {
 	s:     "arch/windows:10/bar",
-	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Channel: "windows:10", Architecture: "arch"},
+	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Base: "windows:10", Architecture: "arch"},
 	exact: "ch:arch/windows:10/bar",
 }, {
 	s:     "arch/centos:7/bar",
-	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Channel: "centos:7", Architecture: "arch"},
+	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Base: "centos:7", Architecture: "arch"},
 	exact: "ch:arch/centos:7/bar",
 }, {
 	s:   "cs:foo/~blah",

--- a/url_test.go
+++ b/url_test.go
@@ -26,109 +26,109 @@ var urlTests = []struct {
 	url    *charm.URL
 }{{
 	s:   "cs:~user/series/name",
-	url: makeURL("cs", "user", "name", -1, "series", ""),
+	url: makeV1URL("cs", "user", "name", -1, "series", ""),
 }, {
 	s:   "cs:~user/series/name-0",
-	url: makeURL("cs", "user", "name", 0, "series", ""),
+	url: makeV1URL("cs", "user", "name", 0, "series", ""),
 }, {
 	s:   "cs:series/name",
-	url: makeURL("cs", "", "name", -1, "series", ""),
+	url: makeV1URL("cs", "", "name", -1, "series", ""),
 }, {
 	s:   "cs:series/name-42",
-	url: makeURL("cs", "", "name", 42, "series", ""),
+	url: makeV1URL("cs", "", "name", 42, "series", ""),
 }, {
 	s:   "local:series/name-1",
-	url: makeURL("local", "", "name", 1, "series", ""),
+	url: makeV1URL("local", "", "name", 1, "series", ""),
 }, {
 	s:   "local:series/name",
-	url: makeURL("local", "", "name", -1, "series", ""),
+	url: makeV1URL("local", "", "name", -1, "series", ""),
 }, {
 	s:   "local:series/n0-0n-n0",
-	url: makeURL("local", "", "n0-0n-n0", -1, "series", ""),
+	url: makeV1URL("local", "", "n0-0n-n0", -1, "series", ""),
 }, {
 	s:   "cs:~user/name",
-	url: makeURL("cs", "user", "name", -1, "", ""),
+	url: makeV1URL("cs", "user", "name", -1, "", ""),
 }, {
 	s:   "cs:name",
-	url: makeURL("cs", "", "name", -1, "", ""),
+	url: makeV1URL("cs", "", "name", -1, "", ""),
 }, {
 	s:   "local:name",
-	url: makeURL("local", "", "name", -1, "", ""),
+	url: makeV1URL("local", "", "name", -1, "", ""),
 }, {
 	s:     "http://jujucharms.com/u/user/name/series/1",
-	url:   makeURL("cs", "user", "name", 1, "series", ""),
+	url:   makeV1URL("cs", "user", "name", 1, "series", ""),
 	exact: "cs:~user/series/name-1",
 }, {
 	s:     "http://www.jujucharms.com/u/user/name/series/1",
-	url:   makeURL("cs", "user", "name", 1, "series", ""),
+	url:   makeV1URL("cs", "user", "name", 1, "series", ""),
 	exact: "cs:~user/series/name-1",
 }, {
 	s:     "https://www.jujucharms.com/u/user/name/series/1",
-	url:   makeURL("cs", "user", "name", 1, "series", ""),
+	url:   makeV1URL("cs", "user", "name", 1, "series", ""),
 	exact: "cs:~user/series/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name/series/1",
-	url:   makeURL("cs", "user", "name", 1, "series", ""),
+	url:   makeV1URL("cs", "user", "name", 1, "series", ""),
 	exact: "cs:~user/series/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name/series",
-	url:   makeURL("cs", "user", "name", -1, "series", ""),
+	url:   makeV1URL("cs", "user", "name", -1, "series", ""),
 	exact: "cs:~user/series/name",
 }, {
 	s:     "https://jujucharms.com/u/user/name/1",
-	url:   makeURL("cs", "user", "name", 1, "", ""),
+	url:   makeV1URL("cs", "user", "name", 1, "", ""),
 	exact: "cs:~user/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name",
-	url:   makeURL("cs", "user", "name", -1, "", ""),
+	url:   makeV1URL("cs", "user", "name", -1, "", ""),
 	exact: "cs:~user/name",
 }, {
 	s:     "https://jujucharms.com/name",
-	url:   makeURL("cs", "", "name", -1, "", ""),
+	url:   makeV1URL("cs", "", "name", -1, "", ""),
 	exact: "cs:name",
 }, {
 	s:     "https://jujucharms.com/name/series",
-	url:   makeURL("cs", "", "name", -1, "series", ""),
+	url:   makeV1URL("cs", "", "name", -1, "series", ""),
 	exact: "cs:series/name",
 }, {
 	s:     "https://jujucharms.com/name/1",
-	url:   makeURL("cs", "", "name", 1, "", ""),
+	url:   makeV1URL("cs", "", "name", 1, "", ""),
 	exact: "cs:name-1",
 }, {
 	s:     "https://jujucharms.com/name/series/1",
-	url:   makeURL("cs", "", "name", 1, "series", ""),
+	url:   makeV1URL("cs", "", "name", 1, "series", ""),
 	exact: "cs:series/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name/series/1/",
-	url:   makeURL("cs", "user", "name", 1, "series", ""),
+	url:   makeV1URL("cs", "user", "name", 1, "series", ""),
 	exact: "cs:~user/series/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name/series/",
-	url:   makeURL("cs", "user", "name", -1, "series", ""),
+	url:   makeV1URL("cs", "user", "name", -1, "series", ""),
 	exact: "cs:~user/series/name",
 }, {
 	s:     "https://jujucharms.com/u/user/name/1/",
-	url:   makeURL("cs", "user", "name", 1, "", ""),
+	url:   makeV1URL("cs", "user", "name", 1, "", ""),
 	exact: "cs:~user/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name/",
-	url:   makeURL("cs", "user", "name", -1, "", ""),
+	url:   makeV1URL("cs", "user", "name", -1, "", ""),
 	exact: "cs:~user/name",
 }, {
 	s:     "https://jujucharms.com/name/",
-	url:   makeURL("cs", "", "name", -1, "", ""),
+	url:   makeV1URL("cs", "", "name", -1, "", ""),
 	exact: "cs:name",
 }, {
 	s:     "https://jujucharms.com/name/series/",
-	url:   makeURL("cs", "", "name", -1, "series", ""),
+	url:   makeV1URL("cs", "", "name", -1, "series", ""),
 	exact: "cs:series/name",
 }, {
 	s:     "https://jujucharms.com/name/1/",
-	url:   makeURL("cs", "", "name", 1, "", ""),
+	url:   makeV1URL("cs", "", "name", 1, "", ""),
 	exact: "cs:name-1",
 }, {
 	s:     "https://jujucharms.com/name/series/1/",
-	url:   makeURL("cs", "", "name", 1, "series", ""),
+	url:   makeV1URL("cs", "", "name", 1, "series", ""),
 	exact: "cs:series/name-1",
 }, {
 	s:   "https://jujucharms.com/",
@@ -201,28 +201,28 @@ var urlTests = []struct {
 	err: `local charm or bundle URL with user name: $URL`,
 }, {
 	s:     "amd64/name",
-	url:   makeURL("ch", "", "name", -1, "", "amd64"),
+	url:   makeV1URL("ch", "", "name", -1, "", "amd64"),
 	exact: "ch:amd64/name",
 }, {
 	s:     "foo",
-	url:   makeURL("ch", "", "foo", -1, "", ""),
+	url:   makeV1URL("ch", "", "foo", -1, "", ""),
 	exact: "ch:foo",
 }, {
 	s:     "foo-1",
 	exact: "ch:foo-1",
-	url:   makeURL("ch", "", "foo", 1, "", ""),
+	url:   makeV1URL("ch", "", "foo", 1, "", ""),
 }, {
 	s:     "n0-n0-n0",
 	exact: "ch:n0-n0-n0",
-	url:   makeURL("ch", "", "n0-n0-n0", -1, "", ""),
+	url:   makeV1URL("ch", "", "n0-n0-n0", -1, "", ""),
 }, {
 	s:     "cs:foo",
 	exact: "cs:foo",
-	url:   makeURL("cs", "", "foo", -1, "", ""),
+	url:   makeV1URL("cs", "", "foo", -1, "", ""),
 }, {
 	s:     "local:foo",
 	exact: "local:foo",
-	url:   makeURL("local", "", "foo", -1, "", ""),
+	url:   makeV1URL("local", "", "foo", -1, "", ""),
 }, {
 	s:     "arch/base:version/bar",
 	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Base: "base:version", Architecture: "arch"},
@@ -260,16 +260,16 @@ var urlTests = []struct {
 	err: `cannot parse URL $URL: name "~blah" not valid`,
 }, {
 	s:   "ch:name",
-	url: makeURL("ch", "", "name", -1, "", ""),
+	url: makeV1URL("ch", "", "name", -1, "", ""),
 }, {
 	s:   "ch:name-suffix",
-	url: makeURL("ch", "", "name-suffix", -1, "", ""),
+	url: makeV1URL("ch", "", "name-suffix", -1, "", ""),
 }, {
 	s:   "ch:name-1",
-	url: makeURL("ch", "", "name", 1, "", ""),
+	url: makeV1URL("ch", "", "name", 1, "", ""),
 }, {
 	s:     "ch:arch/name",
-	url:   makeURL("ch", "", "name", -1, "", "arch"),
+	url:   makeV1URL("ch", "", "name", -1, "", "arch"),
 	exact: "ch:arch/name",
 }, {
 	s:   "ch:~user/name",
@@ -494,7 +494,7 @@ func (s *URLSuite) TestValidCheckers(c *gc.C) {
 
 func (s *URLSuite) TestMustParseURL(c *gc.C) {
 	url := charm.MustParseURL("cs:series/name")
-	c.Assert(url, gc.DeepEquals, makeURL("cs", "", "name", -1, "series", ""))
+	c.Assert(url, gc.DeepEquals, makeV1URL("cs", "", "name", -1, "series", ""))
 	f := func() { charm.MustParseURL("local:@@/name") }
 	c.Assert(f, gc.PanicMatches, "cannot parse URL \"local:@@/name\": series name \"@@\" not valid")
 	f = func() { charm.MustParseURL("cs:~user") }
@@ -506,15 +506,15 @@ func (s *URLSuite) TestMustParseURL(c *gc.C) {
 func (s *URLSuite) TestWithRevision(c *gc.C) {
 	url := charm.MustParseURL("cs:series/name")
 	other := url.WithRevision(1)
-	c.Assert(url, gc.DeepEquals, makeURL("cs", "", "name", -1, "series", ""))
-	c.Assert(other, gc.DeepEquals, makeURL("cs", "", "name", 1, "series", ""))
+	c.Assert(url, gc.DeepEquals, makeV1URL("cs", "", "name", -1, "series", ""))
+	c.Assert(other, gc.DeepEquals, makeV1URL("cs", "", "name", 1, "series", ""))
 
 	// Should always copy. The opposite behavior is error prone.
 	c.Assert(other.WithRevision(1), gc.Not(gc.Equals), other)
 	c.Assert(other.WithRevision(1), gc.DeepEquals, other)
 }
 
-func makeURL(schema, user, name string, revision int, series, arch string) *charm.URL {
+func makeV1URL(schema, user, name string, revision int, series, arch string) *charm.URL {
 	return &charm.URL{
 		Schema:       schema,
 		User:         user,

--- a/url_test.go
+++ b/url_test.go
@@ -26,109 +26,109 @@ var urlTests = []struct {
 	url    *charm.URL
 }{{
 	s:   "cs:~user/series/name",
-	url: &charm.URL{"cs", "user", "name", -1, "series", ""},
+	url: makeURL("cs", "user", "name", -1, "series", ""),
 }, {
 	s:   "cs:~user/series/name-0",
-	url: &charm.URL{"cs", "user", "name", 0, "series", ""},
+	url: makeURL("cs", "user", "name", 0, "series", ""),
 }, {
 	s:   "cs:series/name",
-	url: &charm.URL{"cs", "", "name", -1, "series", ""},
+	url: makeURL("cs", "", "name", -1, "series", ""),
 }, {
 	s:   "cs:series/name-42",
-	url: &charm.URL{"cs", "", "name", 42, "series", ""},
+	url: makeURL("cs", "", "name", 42, "series", ""),
 }, {
 	s:   "local:series/name-1",
-	url: &charm.URL{"local", "", "name", 1, "series", ""},
+	url: makeURL("local", "", "name", 1, "series", ""),
 }, {
 	s:   "local:series/name",
-	url: &charm.URL{"local", "", "name", -1, "series", ""},
+	url: makeURL("local", "", "name", -1, "series", ""),
 }, {
 	s:   "local:series/n0-0n-n0",
-	url: &charm.URL{"local", "", "n0-0n-n0", -1, "series", ""},
+	url: makeURL("local", "", "n0-0n-n0", -1, "series", ""),
 }, {
 	s:   "cs:~user/name",
-	url: &charm.URL{"cs", "user", "name", -1, "", ""},
+	url: makeURL("cs", "user", "name", -1, "", ""),
 }, {
 	s:   "cs:name",
-	url: &charm.URL{"cs", "", "name", -1, "", ""},
+	url: makeURL("cs", "", "name", -1, "", ""),
 }, {
 	s:   "local:name",
-	url: &charm.URL{"local", "", "name", -1, "", ""},
+	url: makeURL("local", "", "name", -1, "", ""),
 }, {
 	s:     "http://jujucharms.com/u/user/name/series/1",
-	url:   &charm.URL{"cs", "user", "name", 1, "series", ""},
+	url:   makeURL("cs", "user", "name", 1, "series", ""),
 	exact: "cs:~user/series/name-1",
 }, {
 	s:     "http://www.jujucharms.com/u/user/name/series/1",
-	url:   &charm.URL{"cs", "user", "name", 1, "series", ""},
+	url:   makeURL("cs", "user", "name", 1, "series", ""),
 	exact: "cs:~user/series/name-1",
 }, {
 	s:     "https://www.jujucharms.com/u/user/name/series/1",
-	url:   &charm.URL{"cs", "user", "name", 1, "series", ""},
+	url:   makeURL("cs", "user", "name", 1, "series", ""),
 	exact: "cs:~user/series/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name/series/1",
-	url:   &charm.URL{"cs", "user", "name", 1, "series", ""},
+	url:   makeURL("cs", "user", "name", 1, "series", ""),
 	exact: "cs:~user/series/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name/series",
-	url:   &charm.URL{"cs", "user", "name", -1, "series", ""},
+	url:   makeURL("cs", "user", "name", -1, "series", ""),
 	exact: "cs:~user/series/name",
 }, {
 	s:     "https://jujucharms.com/u/user/name/1",
-	url:   &charm.URL{"cs", "user", "name", 1, "", ""},
+	url:   makeURL("cs", "user", "name", 1, "", ""),
 	exact: "cs:~user/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name",
-	url:   &charm.URL{"cs", "user", "name", -1, "", ""},
+	url:   makeURL("cs", "user", "name", -1, "", ""),
 	exact: "cs:~user/name",
 }, {
 	s:     "https://jujucharms.com/name",
-	url:   &charm.URL{"cs", "", "name", -1, "", ""},
+	url:   makeURL("cs", "", "name", -1, "", ""),
 	exact: "cs:name",
 }, {
 	s:     "https://jujucharms.com/name/series",
-	url:   &charm.URL{"cs", "", "name", -1, "series", ""},
+	url:   makeURL("cs", "", "name", -1, "series", ""),
 	exact: "cs:series/name",
 }, {
 	s:     "https://jujucharms.com/name/1",
-	url:   &charm.URL{"cs", "", "name", 1, "", ""},
+	url:   makeURL("cs", "", "name", 1, "", ""),
 	exact: "cs:name-1",
 }, {
 	s:     "https://jujucharms.com/name/series/1",
-	url:   &charm.URL{"cs", "", "name", 1, "series", ""},
+	url:   makeURL("cs", "", "name", 1, "series", ""),
 	exact: "cs:series/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name/series/1/",
-	url:   &charm.URL{"cs", "user", "name", 1, "series", ""},
+	url:   makeURL("cs", "user", "name", 1, "series", ""),
 	exact: "cs:~user/series/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name/series/",
-	url:   &charm.URL{"cs", "user", "name", -1, "series", ""},
+	url:   makeURL("cs", "user", "name", -1, "series", ""),
 	exact: "cs:~user/series/name",
 }, {
 	s:     "https://jujucharms.com/u/user/name/1/",
-	url:   &charm.URL{"cs", "user", "name", 1, "", ""},
+	url:   makeURL("cs", "user", "name", 1, "", ""),
 	exact: "cs:~user/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name/",
-	url:   &charm.URL{"cs", "user", "name", -1, "", ""},
+	url:   makeURL("cs", "user", "name", -1, "", ""),
 	exact: "cs:~user/name",
 }, {
 	s:     "https://jujucharms.com/name/",
-	url:   &charm.URL{"cs", "", "name", -1, "", ""},
+	url:   makeURL("cs", "", "name", -1, "", ""),
 	exact: "cs:name",
 }, {
 	s:     "https://jujucharms.com/name/series/",
-	url:   &charm.URL{"cs", "", "name", -1, "series", ""},
+	url:   makeURL("cs", "", "name", -1, "series", ""),
 	exact: "cs:series/name",
 }, {
 	s:     "https://jujucharms.com/name/1/",
-	url:   &charm.URL{"cs", "", "name", 1, "", ""},
+	url:   makeURL("cs", "", "name", 1, "", ""),
 	exact: "cs:name-1",
 }, {
 	s:     "https://jujucharms.com/name/series/1/",
-	url:   &charm.URL{"cs", "", "name", 1, "series", ""},
+	url:   makeURL("cs", "", "name", 1, "series", ""),
 	exact: "cs:series/name-1",
 }, {
 	s:   "https://jujucharms.com/",
@@ -201,47 +201,71 @@ var urlTests = []struct {
 	err: `local charm or bundle URL with user name: $URL`,
 }, {
 	s:     "amd64/name",
-	url:   &charm.URL{"ch", "", "name", -1, "", "amd64"},
+	url:   makeURL("ch", "", "name", -1, "", "amd64"),
 	exact: "ch:amd64/name",
 }, {
 	s:     "foo",
-	url:   &charm.URL{"ch", "", "foo", -1, "", ""},
+	url:   makeURL("ch", "", "foo", -1, "", ""),
 	exact: "ch:foo",
 }, {
 	s:     "foo-1",
 	exact: "ch:foo-1",
-	url:   &charm.URL{"ch", "", "foo", 1, "", ""},
+	url:   makeURL("ch", "", "foo", 1, "", ""),
 }, {
 	s:     "n0-n0-n0",
 	exact: "ch:n0-n0-n0",
-	url:   &charm.URL{"ch", "", "n0-n0-n0", -1, "", ""},
+	url:   makeURL("ch", "", "n0-n0-n0", -1, "", ""),
 }, {
 	s:     "cs:foo",
 	exact: "cs:foo",
-	url:   &charm.URL{"cs", "", "foo", -1, "", ""},
+	url:   makeURL("cs", "", "foo", -1, "", ""),
 }, {
 	s:     "local:foo",
 	exact: "local:foo",
-	url:   &charm.URL{"local", "", "foo", -1, "", ""},
+	url:   makeURL("local", "", "foo", -1, "", ""),
 }, {
-	s:     "arch/series/bar",
-	url:   &charm.URL{"ch", "", "bar", -1, "series", "arch"},
-	exact: "ch:arch/series/bar",
+	s:     "arch/channel/bar",
+	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Channel: "channel", Architecture: "arch"},
+	exact: "ch:arch/channel/bar",
+}, {
+	s:     "arch/20.04:stable:branch/bar",
+	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Channel: "20.04:stable:branch", Architecture: "arch"},
+	exact: "ch:arch/20.04:stable:branch/bar",
+}, {
+	s:     "arch/20.04:stable/bar",
+	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Channel: "20.04:stable", Architecture: "arch"},
+	exact: "ch:arch/20.04:stable/bar",
+}, {
+	s:     "arch/20.04/bar",
+	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Channel: "20.04", Architecture: "arch"},
+	exact: "ch:arch/20.04/bar",
+}, {
+	s:     "arch/windows:stable/bar",
+	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Channel: "windows:stable", Architecture: "arch"},
+	exact: "ch:arch/windows:stable/bar",
+}, {
+	s:     "arch/windows:10/bar",
+	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Channel: "windows:10", Architecture: "arch"},
+	exact: "ch:arch/windows:10/bar",
+}, {
+	s:     "arch/centos:7/bar",
+	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Channel: "centos:7", Architecture: "arch"},
+	exact: "ch:arch/centos:7/bar",
 }, {
 	s:   "cs:foo/~blah",
 	err: `cannot parse URL $URL: name "~blah" not valid`,
 }, {
 	s:   "ch:name",
-	url: &charm.URL{"ch", "", "name", -1, "", ""},
+	url: makeURL("ch", "", "name", -1, "", ""),
 }, {
 	s:   "ch:name-suffix",
-	url: &charm.URL{"ch", "", "name-suffix", -1, "", ""},
+	url: makeURL("ch", "", "name-suffix", -1, "", ""),
 }, {
 	s:   "ch:name-1",
-	url: &charm.URL{"ch", "", "name", 1, "", ""},
+	url: makeURL("ch", "", "name", 1, "", ""),
 }, {
 	s:     "ch:arch/name",
-	url:   &charm.URL{"ch", "", "name", -1, "", "arch"},
+	url:   makeURL("ch", "", "name", -1, "", "arch"),
 	exact: "ch:arch/name",
 }, {
 	s:   "ch:~user/name",
@@ -466,7 +490,7 @@ func (s *URLSuite) TestValidCheckers(c *gc.C) {
 
 func (s *URLSuite) TestMustParseURL(c *gc.C) {
 	url := charm.MustParseURL("cs:series/name")
-	c.Assert(url, gc.DeepEquals, &charm.URL{"cs", "", "name", -1, "series", ""})
+	c.Assert(url, gc.DeepEquals, makeURL("cs", "", "name", -1, "series", ""))
 	f := func() { charm.MustParseURL("local:@@/name") }
 	c.Assert(f, gc.PanicMatches, "cannot parse URL \"local:@@/name\": series name \"@@\" not valid")
 	f = func() { charm.MustParseURL("cs:~user") }
@@ -478,12 +502,23 @@ func (s *URLSuite) TestMustParseURL(c *gc.C) {
 func (s *URLSuite) TestWithRevision(c *gc.C) {
 	url := charm.MustParseURL("cs:series/name")
 	other := url.WithRevision(1)
-	c.Assert(url, gc.DeepEquals, &charm.URL{"cs", "", "name", -1, "series", ""})
-	c.Assert(other, gc.DeepEquals, &charm.URL{"cs", "", "name", 1, "series", ""})
+	c.Assert(url, gc.DeepEquals, makeURL("cs", "", "name", -1, "series", ""))
+	c.Assert(other, gc.DeepEquals, makeURL("cs", "", "name", 1, "series", ""))
 
 	// Should always copy. The opposite behavior is error prone.
 	c.Assert(other.WithRevision(1), gc.Not(gc.Equals), other)
 	c.Assert(other.WithRevision(1), gc.DeepEquals, other)
+}
+
+func makeURL(schema, user, name string, revision int, series, arch string) *charm.URL {
+	return &charm.URL{
+		Schema:       schema,
+		User:         user,
+		Name:         name,
+		Revision:     revision,
+		Series:       series,
+		Architecture: arch,
+	}
 }
 
 var codecs = []struct {
@@ -516,6 +551,7 @@ func (s *URLSuite) TestURLCodecs(c *gc.C) {
 		c.Assert(err, gc.IsNil)
 		var v doc
 		err = codec.Unmarshal(data, &v)
+		c.Assert(err, gc.IsNil)
 		c.Assert(v, gc.DeepEquals, v0)
 
 		// Check that the underlying representation


### PR DESCRIPTION
The following encodes a channel into a URL. A channel is comprised of
the following parts; track, risk, and branch. Track in this scenario is
always required and the other parts are optional.

To keep backwards compatibility with version 1 and HTTP version of the
charm URL, I have elected to keep the series. Series and channel are
exclusive and the String() method defines that. I believe we should
implement a validate for the URL to ensure that all components are
correct at the time of manual construction, but during parsing, it will
be impossible to have series and channel at the same time.

One last thing, I'm not sure about the split on the channel. As this is
intended to be a URL, I would like to keep it as close to a URL in terms
of semantics. So the URL should be parsable via url.Parse from the std
package, hence why we're not using #.