### PR TITLE
Encode base into charm URL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/juju/charm/v8
 
 require (
 	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/juju/charm/v9 v9.0.0-20210324234318-1204b46e47ee
 	github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271
 	github.com/juju/errors v0.0.0-20200330140219-3fe23663418f
 	github.com/juju/gojsonpointer v0.0.0-20150204194629-afe8b77aa08f // indirect
@@ -13,7 +14,7 @@ require (
 	github.com/juju/os/v2 v2.0.0
 	github.com/juju/schema v0.0.0-20160301111646-1e25943f8c6f
 	github.com/juju/systems v0.0.0-20210311041303-bc6b2f9677ca
-	github.com/juju/testing v0.0.0-20200923013621-75df6121fbb0
+	github.com/juju/testing v0.0.0-20210302031854-2c7ee8570c07
 	github.com/juju/utils/v2 v2.0.0-20200923005554-4646bfea2ef1
 	github.com/juju/version v0.0.0-20191219164919-81c1be00b9a6
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJA
 github.com/golang/mock v1.4.3 h1:GV+pQPG/EUUbkh47niozDcADz6go/dUwhVzdUQHIVRw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
+github.com/juju/charm/v9 v9.0.0-20210324234318-1204b46e47ee h1:Sa+juB94sYHtCPAaEQRrckf8xZfLzE+Mhn+dSv4wrxs=
+github.com/juju/charm/v9 v9.0.0-20210324234318-1204b46e47ee/go.mod h1:iMgXKAsiVw2Qd5LvT7GHzJiPpC7V4PacaD3LdAjTmuE=
 github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c h1:3UvYABOQRhJAApj9MdCN+Ydv841ETSoy6xLzdmmr/9A=
 github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c/go.mod h1:nD0vlnrUjcjJhqN5WuCWZyzfd5AHZAC9/ajvbSx69xA=
 github.com/juju/cmd v0.0.0-20171107070456-e74f39857ca0/go.mod h1:yWJQHl73rdSX4DHVKGqkAip+huBslxRwS8m9CrOLq18=
@@ -45,6 +47,7 @@ github.com/juju/testing v0.0.0-20180402130637-44801989f0f7/go.mod h1:63prj8cnj0t
 github.com/juju/testing v0.0.0-20190723135506-ce30eb24acd2/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20200923013621-75df6121fbb0 h1:ZNHhUeJYnc98o0ZpU7/c2TBuQokG5TBiDx8UvhDTIt0=
 github.com/juju/testing v0.0.0-20200923013621-75df6121fbb0/go.mod h1:Ky6DwobyXXeXSqRJCCuHpAtVEGRPOT8gUsFpJhDoXZ8=
+github.com/juju/testing v0.0.0-20210302031854-2c7ee8570c07/go.mod h1:7lxZW0B50+xdGFkvhAb8bwAGt6IU87JB1H9w4t8MNVM=
 github.com/juju/utils v0.0.0-20180424094159-2000ea4ff043/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/utils v0.0.0-20180517015153-d2ddf8edc7dc/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/utils v0.0.0-20200116185830-d40c2fe10647 h1:wQpkHVbIIpz1PCcLYku9KFWsJ7aEMQXHBBmLy3tRBTk=
@@ -55,6 +58,8 @@ github.com/juju/version v0.0.0-20161031051906-1f41e27e54f2/go.mod h1:kE8gK5X0CIm
 github.com/juju/version v0.0.0-20180108022336-b64dbd566305/go.mod h1:kE8gK5X0CImdr7qpSKl3xB2PmpySSmfj7zVbkZFs81U=
 github.com/juju/version v0.0.0-20191219164919-81c1be00b9a6 h1:nrqc9b4YKpKV4lPI3GPPFbo5FUuxkWxgZE2Z8O4lgaw=
 github.com/juju/version v0.0.0-20191219164919-81c1be00b9a6/go.mod h1:kE8gK5X0CImdr7qpSKl3xB2PmpySSmfj7zVbkZFs81U=
+github.com/juju/version/v2 v2.0.0-20210319015800-dcfac8f4f057 h1:BT3bXGYas64ISk/NRmGcHWe2n9OLLmEfAM7LUrlDnww=
+github.com/juju/version/v2 v2.0.0-20210319015800-dcfac8f4f057/go.mod h1:Ljlbryh9sYaUSGXucslAEDf0A2XUSGvDbHJgW8ps6nc=
 github.com/julienschmidt/httprouter v1.1.1-0.20151013225520-77a895ad01eb/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/url.go
+++ b/url.go
@@ -561,7 +561,17 @@ func parseIdentifierURL(url *gourl.URL) (*URL, error) {
 	var nameRev string
 	switch len(parts) {
 	case 3:
-		r.Architecture, r.Base, nameRev = parts[0], parts[1], parts[2]
+		var base string
+		r.Architecture, base, nameRev = parts[0], parts[1], parts[2]
+		// This handles the fact that we may have a V2 url with a series as the
+		// second part and not an actual base. In this case, we check for the
+		// existence of a seperator and if it has one, we know for a fact it's
+		// a base, otherwise it's a series.
+		if strings.Contains(base, ":") {
+			r.Base = base
+		} else {
+			r.Series = base
+		}
 	case 2:
 		r.Architecture, nameRev = parts[0], parts[1]
 	default:
@@ -583,6 +593,11 @@ func parseIdentifierURL(url *gourl.URL) (*URL, error) {
 	if r.Base != "" {
 		if err := ValidateBase(r.Base); err != nil {
 			return nil, errors.Annotatef(err, "cannot parse base in URL %q", url)
+		}
+	}
+	if r.Series != "" {
+		if err := ValidateSeries(r.Series); err != nil {
+			return nil, errors.Annotatef(err, "cannot parse series in URL %q", url)
 		}
 	}
 

--- a/url_test.go
+++ b/url_test.go
@@ -26,109 +26,109 @@ var urlTests = []struct {
 	url    *charm.URL
 }{{
 	s:   "cs:~user/series/name",
-	url: &charm.URL{"cs", "user", "name", -1, "series", ""},
+	url: makeV1URL("cs", "user", "name", -1, "series", ""),
 }, {
 	s:   "cs:~user/series/name-0",
-	url: &charm.URL{"cs", "user", "name", 0, "series", ""},
+	url: makeV1URL("cs", "user", "name", 0, "series", ""),
 }, {
 	s:   "cs:series/name",
-	url: &charm.URL{"cs", "", "name", -1, "series", ""},
+	url: makeV1URL("cs", "", "name", -1, "series", ""),
 }, {
 	s:   "cs:series/name-42",
-	url: &charm.URL{"cs", "", "name", 42, "series", ""},
+	url: makeV1URL("cs", "", "name", 42, "series", ""),
 }, {
 	s:   "local:series/name-1",
-	url: &charm.URL{"local", "", "name", 1, "series", ""},
+	url: makeV1URL("local", "", "name", 1, "series", ""),
 }, {
 	s:   "local:series/name",
-	url: &charm.URL{"local", "", "name", -1, "series", ""},
+	url: makeV1URL("local", "", "name", -1, "series", ""),
 }, {
 	s:   "local:series/n0-0n-n0",
-	url: &charm.URL{"local", "", "n0-0n-n0", -1, "series", ""},
+	url: makeV1URL("local", "", "n0-0n-n0", -1, "series", ""),
 }, {
 	s:   "cs:~user/name",
-	url: &charm.URL{"cs", "user", "name", -1, "", ""},
+	url: makeV1URL("cs", "user", "name", -1, "", ""),
 }, {
 	s:   "cs:name",
-	url: &charm.URL{"cs", "", "name", -1, "", ""},
+	url: makeV1URL("cs", "", "name", -1, "", ""),
 }, {
 	s:   "local:name",
-	url: &charm.URL{"local", "", "name", -1, "", ""},
+	url: makeV1URL("local", "", "name", -1, "", ""),
 }, {
 	s:     "http://jujucharms.com/u/user/name/series/1",
-	url:   &charm.URL{"cs", "user", "name", 1, "series", ""},
+	url:   makeV1URL("cs", "user", "name", 1, "series", ""),
 	exact: "cs:~user/series/name-1",
 }, {
 	s:     "http://www.jujucharms.com/u/user/name/series/1",
-	url:   &charm.URL{"cs", "user", "name", 1, "series", ""},
+	url:   makeV1URL("cs", "user", "name", 1, "series", ""),
 	exact: "cs:~user/series/name-1",
 }, {
 	s:     "https://www.jujucharms.com/u/user/name/series/1",
-	url:   &charm.URL{"cs", "user", "name", 1, "series", ""},
+	url:   makeV1URL("cs", "user", "name", 1, "series", ""),
 	exact: "cs:~user/series/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name/series/1",
-	url:   &charm.URL{"cs", "user", "name", 1, "series", ""},
+	url:   makeV1URL("cs", "user", "name", 1, "series", ""),
 	exact: "cs:~user/series/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name/series",
-	url:   &charm.URL{"cs", "user", "name", -1, "series", ""},
+	url:   makeV1URL("cs", "user", "name", -1, "series", ""),
 	exact: "cs:~user/series/name",
 }, {
 	s:     "https://jujucharms.com/u/user/name/1",
-	url:   &charm.URL{"cs", "user", "name", 1, "", ""},
+	url:   makeV1URL("cs", "user", "name", 1, "", ""),
 	exact: "cs:~user/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name",
-	url:   &charm.URL{"cs", "user", "name", -1, "", ""},
+	url:   makeV1URL("cs", "user", "name", -1, "", ""),
 	exact: "cs:~user/name",
 }, {
 	s:     "https://jujucharms.com/name",
-	url:   &charm.URL{"cs", "", "name", -1, "", ""},
+	url:   makeV1URL("cs", "", "name", -1, "", ""),
 	exact: "cs:name",
 }, {
 	s:     "https://jujucharms.com/name/series",
-	url:   &charm.URL{"cs", "", "name", -1, "series", ""},
+	url:   makeV1URL("cs", "", "name", -1, "series", ""),
 	exact: "cs:series/name",
 }, {
 	s:     "https://jujucharms.com/name/1",
-	url:   &charm.URL{"cs", "", "name", 1, "", ""},
+	url:   makeV1URL("cs", "", "name", 1, "", ""),
 	exact: "cs:name-1",
 }, {
 	s:     "https://jujucharms.com/name/series/1",
-	url:   &charm.URL{"cs", "", "name", 1, "series", ""},
+	url:   makeV1URL("cs", "", "name", 1, "series", ""),
 	exact: "cs:series/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name/series/1/",
-	url:   &charm.URL{"cs", "user", "name", 1, "series", ""},
+	url:   makeV1URL("cs", "user", "name", 1, "series", ""),
 	exact: "cs:~user/series/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name/series/",
-	url:   &charm.URL{"cs", "user", "name", -1, "series", ""},
+	url:   makeV1URL("cs", "user", "name", -1, "series", ""),
 	exact: "cs:~user/series/name",
 }, {
 	s:     "https://jujucharms.com/u/user/name/1/",
-	url:   &charm.URL{"cs", "user", "name", 1, "", ""},
+	url:   makeV1URL("cs", "user", "name", 1, "", ""),
 	exact: "cs:~user/name-1",
 }, {
 	s:     "https://jujucharms.com/u/user/name/",
-	url:   &charm.URL{"cs", "user", "name", -1, "", ""},
+	url:   makeV1URL("cs", "user", "name", -1, "", ""),
 	exact: "cs:~user/name",
 }, {
 	s:     "https://jujucharms.com/name/",
-	url:   &charm.URL{"cs", "", "name", -1, "", ""},
+	url:   makeV1URL("cs", "", "name", -1, "", ""),
 	exact: "cs:name",
 }, {
 	s:     "https://jujucharms.com/name/series/",
-	url:   &charm.URL{"cs", "", "name", -1, "series", ""},
+	url:   makeV1URL("cs", "", "name", -1, "series", ""),
 	exact: "cs:series/name",
 }, {
 	s:     "https://jujucharms.com/name/1/",
-	url:   &charm.URL{"cs", "", "name", 1, "", ""},
+	url:   makeV1URL("cs", "", "name", 1, "", ""),
 	exact: "cs:name-1",
 }, {
 	s:     "https://jujucharms.com/name/series/1/",
-	url:   &charm.URL{"cs", "", "name", 1, "series", ""},
+	url:   makeV1URL("cs", "", "name", 1, "series", ""),
 	exact: "cs:series/name-1",
 }, {
 	s:   "https://jujucharms.com/",
@@ -201,47 +201,75 @@ var urlTests = []struct {
 	err: `local charm or bundle URL with user name: $URL`,
 }, {
 	s:     "amd64/name",
-	url:   &charm.URL{"ch", "", "name", -1, "", "amd64"},
+	url:   makeV1URL("ch", "", "name", -1, "", "amd64"),
 	exact: "ch:amd64/name",
 }, {
 	s:     "foo",
-	url:   &charm.URL{"ch", "", "foo", -1, "", ""},
+	url:   makeV1URL("ch", "", "foo", -1, "", ""),
 	exact: "ch:foo",
 }, {
 	s:     "foo-1",
 	exact: "ch:foo-1",
-	url:   &charm.URL{"ch", "", "foo", 1, "", ""},
+	url:   makeV1URL("ch", "", "foo", 1, "", ""),
 }, {
 	s:     "n0-n0-n0",
 	exact: "ch:n0-n0-n0",
-	url:   &charm.URL{"ch", "", "n0-n0-n0", -1, "", ""},
+	url:   makeV1URL("ch", "", "n0-n0-n0", -1, "", ""),
 }, {
 	s:     "cs:foo",
 	exact: "cs:foo",
-	url:   &charm.URL{"cs", "", "foo", -1, "", ""},
+	url:   makeV1URL("cs", "", "foo", -1, "", ""),
 }, {
 	s:     "local:foo",
 	exact: "local:foo",
-	url:   &charm.URL{"local", "", "foo", -1, "", ""},
+	url:   makeV1URL("local", "", "foo", -1, "", ""),
 }, {
-	s:     "arch/series/bar",
-	url:   &charm.URL{"ch", "", "bar", -1, "series", "arch"},
-	exact: "ch:arch/series/bar",
+	s:     "arch/base:version/bar",
+	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Base: "base:version", Architecture: "arch"},
+	exact: "ch:arch/base:version/bar",
+}, {
+	s:     "arch/ubuntu:20.04:stable:branch/bar",
+	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Base: "ubuntu:20.04:stable:branch", Architecture: "arch"},
+	exact: "ch:arch/ubuntu:20.04:stable:branch/bar",
+}, {
+	s:     "arch/ubuntu:20.04:stable/bar",
+	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Base: "ubuntu:20.04:stable", Architecture: "arch"},
+	exact: "ch:arch/ubuntu:20.04:stable/bar",
+}, {
+	s:     "arch/ubuntu:20.04/bar",
+	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Base: "ubuntu:20.04", Architecture: "arch"},
+	exact: "ch:arch/ubuntu:20.04/bar",
+}, {
+	s:   "arch/ubuntu/bar",
+	url: &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Base: "ubuntu", Architecture: "arch"},
+	err: `cannot parse base in URL "arch/ubuntu/bar": base "ubuntu" not valid`,
+}, {
+	s:     "arch/windows:stable/bar",
+	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Base: "windows:stable", Architecture: "arch"},
+	exact: "ch:arch/windows:stable/bar",
+}, {
+	s:     "arch/windows:10/bar",
+	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Base: "windows:10", Architecture: "arch"},
+	exact: "ch:arch/windows:10/bar",
+}, {
+	s:     "arch/centos:7/bar",
+	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Base: "centos:7", Architecture: "arch"},
+	exact: "ch:arch/centos:7/bar",
 }, {
 	s:   "cs:foo/~blah",
 	err: `cannot parse URL $URL: name "~blah" not valid`,
 }, {
 	s:   "ch:name",
-	url: &charm.URL{"ch", "", "name", -1, "", ""},
+	url: makeV1URL("ch", "", "name", -1, "", ""),
 }, {
 	s:   "ch:name-suffix",
-	url: &charm.URL{"ch", "", "name-suffix", -1, "", ""},
+	url: makeV1URL("ch", "", "name-suffix", -1, "", ""),
 }, {
 	s:   "ch:name-1",
-	url: &charm.URL{"ch", "", "name", 1, "", ""},
+	url: makeV1URL("ch", "", "name", 1, "", ""),
 }, {
 	s:     "ch:arch/name",
-	url:   &charm.URL{"ch", "", "name", -1, "", "arch"},
+	url:   makeV1URL("ch", "", "name", -1, "", "arch"),
 	exact: "ch:arch/name",
 }, {
 	s:   "ch:~user/name",
@@ -466,7 +494,7 @@ func (s *URLSuite) TestValidCheckers(c *gc.C) {
 
 func (s *URLSuite) TestMustParseURL(c *gc.C) {
 	url := charm.MustParseURL("cs:series/name")
-	c.Assert(url, gc.DeepEquals, &charm.URL{"cs", "", "name", -1, "series", ""})
+	c.Assert(url, gc.DeepEquals, makeV1URL("cs", "", "name", -1, "series", ""))
 	f := func() { charm.MustParseURL("local:@@/name") }
 	c.Assert(f, gc.PanicMatches, "cannot parse URL \"local:@@/name\": series name \"@@\" not valid")
 	f = func() { charm.MustParseURL("cs:~user") }
@@ -478,12 +506,23 @@ func (s *URLSuite) TestMustParseURL(c *gc.C) {
 func (s *URLSuite) TestWithRevision(c *gc.C) {
 	url := charm.MustParseURL("cs:series/name")
 	other := url.WithRevision(1)
-	c.Assert(url, gc.DeepEquals, &charm.URL{"cs", "", "name", -1, "series", ""})
-	c.Assert(other, gc.DeepEquals, &charm.URL{"cs", "", "name", 1, "series", ""})
+	c.Assert(url, gc.DeepEquals, makeV1URL("cs", "", "name", -1, "series", ""))
+	c.Assert(other, gc.DeepEquals, makeV1URL("cs", "", "name", 1, "series", ""))
 
 	// Should always copy. The opposite behavior is error prone.
 	c.Assert(other.WithRevision(1), gc.Not(gc.Equals), other)
 	c.Assert(other.WithRevision(1), gc.DeepEquals, other)
+}
+
+func makeV1URL(schema, user, name string, revision int, series, arch string) *charm.URL {
+	return &charm.URL{
+		Schema:       schema,
+		User:         user,
+		Name:         name,
+		Revision:     revision,
+		Series:       series,
+		Architecture: arch,
+	}
 }
 
 var codecs = []struct {
@@ -516,6 +555,7 @@ func (s *URLSuite) TestURLCodecs(c *gc.C) {
 		c.Assert(err, gc.IsNil)
 		var v doc
 		err = codec.Unmarshal(data, &v)
+		c.Assert(err, gc.IsNil)
 		c.Assert(v, gc.DeepEquals, v0)
 
 		// Check that the underlying representation

--- a/url_test.go
+++ b/url_test.go
@@ -240,9 +240,9 @@ var urlTests = []struct {
 	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Base: "ubuntu:20.04", Architecture: "arch"},
 	exact: "ch:arch/ubuntu:20.04/bar",
 }, {
-	s:   "arch/ubuntu/bar",
-	url: &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Base: "ubuntu", Architecture: "arch"},
-	err: `cannot parse base in URL "arch/ubuntu/bar": base "ubuntu" not valid`,
+	s:     "arch/ubuntu/bar",
+	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Series: "ubuntu", Architecture: "arch"},
+	exact: "ch:arch/ubuntu/bar",
 }, {
 	s:     "arch/windows:stable/bar",
 	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Base: "windows:stable", Architecture: "arch"},


### PR DESCRIPTION
The following encodes a base into a URL. A base is comprised of
the following parts; track, risk, and branch. Track in this scenario is
always required and the other parts are optional.

To keep backwards compatibility with version 1 and HTTP version of the
charm URL, I have elected to keep the series. Series and base are
exclusive and the String() method defines that. I believe we should
implement a validate for the URL to ensure that all components are
correct at the time of manual construction, but during parsing, it will
be impossible to have series and base at the same time.

One last thing, I'm not sure about the split on the base. As this is
intended to be a URL, I would like to keep it as close to a URL in terms
of semantics. So the URL should be parsable via url.Parse from the std
package, hence why we're not using #.