### PR TITLE
Add manifest details

### DIFF
--- a/charm.go
+++ b/charm.go
@@ -17,10 +17,13 @@ var logger = loggo.GetLogger("juju.charm")
 // may be handled as a charm.
 type Charm interface {
 	Meta() *Meta
+	BasesManifest() *Manifest
 	Config() *Config
 	Metrics() *Metrics
 	Actions() *Actions
 	Revision() int
+	Format() Format
+	ComputedSeries() []string
 }
 
 // ReadCharm reads a Charm from path, which can point to either a charm archive or a
@@ -99,3 +102,13 @@ func IsUnsupportedSeriesError(err error) bool {
 	_, ok := err.(*unsupportedSeriesError)
 	return ok
 }
+
+// Format of the parsed charm.
+type Format int
+
+// Formats are the different versions of charm metadata supported.
+const (
+	FormatUnknown Format = iota
+	FormatV1      Format = iota
+	FormatV2      Format = iota
+)

--- a/computedseries_test.go
+++ b/computedseries_test.go
@@ -4,17 +4,15 @@
 package charm
 
 import (
-	"strings"
-	stdtesting "testing"
-
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"strings"
 )
 
-func Test(t *stdtesting.T) {
-	gc.TestingT(t)
-}
+//func Test(t *stdtesting.T) {
+//	gc.TestingT(t)
+//}
 
 type computedSeriesSuite struct {
 	testing.CleanupSuite
@@ -49,14 +47,16 @@ description: c
 	manifest, err := ReadManifest(strings.NewReader(`
 bases:
   - name: ubuntu
-    channel: 18.04/stable
+    channel: "18.04"
+  - name: ubuntu
+    channel: "20.04"
 `))
 	c.Assert(err, gc.IsNil)
 	dir := CharmDir{
 		meta: meta,
 		manifest:manifest,
 	}
-	c.Assert(dir.ComputedSeries(), jc.DeepEquals, []string{"bionic"})
+	c.Assert(dir.ComputedSeries(), jc.DeepEquals, []string{"bionic", "focal"})
 }
 
 func (s *computedSeriesSuite) TestArchiveComputedSeriesLegacy(c *gc.C) {

--- a/computedseries_test.go
+++ b/computedseries_test.go
@@ -1,0 +1,96 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charm
+
+import (
+	"strings"
+	stdtesting "testing"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *stdtesting.T) {
+	gc.TestingT(t)
+}
+
+type computedSeriesSuite struct {
+	testing.CleanupSuite
+}
+
+var _ = gc.Suite(&computedSeriesSuite{})
+
+func (s *computedSeriesSuite) TestDirComputedSeriesLegacy(c *gc.C) {
+	meta, err := ReadMeta(strings.NewReader(`
+name: a
+summary: b
+description: c
+series:
+  - bionic
+`))
+	c.Assert(err, gc.IsNil)
+	dir := CharmDir{
+		meta: meta,
+		manifest: &Manifest{},
+	}
+	c.Assert(err, gc.IsNil)
+	c.Assert(dir.ComputedSeries(), jc.DeepEquals, []string{"bionic"})
+}
+
+func (s *computedSeriesSuite) TestDirComputedSeries(c *gc.C) {
+	meta, err := ReadMeta(strings.NewReader(`
+name: a
+summary: b
+description: c
+`))
+	c.Assert(err, gc.IsNil)
+	manifest, err := ReadManifest(strings.NewReader(`
+bases:
+  - name: ubuntu
+    channel: 18.04/stable
+`))
+	c.Assert(err, gc.IsNil)
+	dir := CharmDir{
+		meta: meta,
+		manifest:manifest,
+	}
+	c.Assert(dir.ComputedSeries(), jc.DeepEquals, []string{"bionic"})
+}
+
+func (s *computedSeriesSuite) TestArchiveComputedSeriesLegacy(c *gc.C) {
+	meta, err := ReadMeta(strings.NewReader(`
+name: a
+summary: b
+description: c
+series:
+  - bionic
+`))
+	c.Assert(err, gc.IsNil)
+	arc := CharmArchive{
+		meta: meta,
+		manifest: &Manifest{},
+	}
+	c.Assert(arc.ComputedSeries(), jc.DeepEquals, []string{"bionic"})
+}
+
+func (s *computedSeriesSuite) TestArchiveComputedSeries(c *gc.C) {
+	meta, err := ReadMeta(strings.NewReader(`
+name: a
+summary: b
+description: c
+`))
+	c.Assert(err, gc.IsNil)
+	manifest, err := ReadManifest(strings.NewReader(`
+bases:
+  - name: ubuntu
+    channel: 18.04/stable
+`))
+	c.Assert(err, gc.IsNil)
+	arc := CharmArchive{
+		meta: meta,
+		manifest:manifest,
+	}
+	c.Assert(arc.ComputedSeries(), jc.DeepEquals, []string{"bionic"})
+}

--- a/manifest.go
+++ b/manifest.go
@@ -3,18 +3,72 @@
 
 package charm
 
-import "io"
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/juju/errors"
+	"github.com/juju/schema"
+	"github.com/juju/systems"
+	"gopkg.in/yaml.v2"
+)
 
 // Manifest represents the recording of the building of the charm or bundle.
 // The manifest file should represent the metadata.yaml, but a lot more
 // information.
 type Manifest struct {
-	// TODO (stickupkid): Represent architectures in the future.
+	Bases []systems.Base `yaml:"bases"`
+}
+
+// Validate checks the manifest to ensure there are no empty names, nor channels,
+// and that architectures are supported.
+func (m *Manifest) Validate() error {
+	for _, b := range m.Bases {
+		if err := b.Validate(); err != nil {
+			return fmt.Errorf("invalid base: empty file")
+		}
+	}
+	return nil
 }
 
 // ReadManifest reads in a Manifest from a charm's manifest.yaml.
 // It is not validated at this point so that the caller can choose to override
 // any validation.
 func ReadManifest(r io.Reader) (*Manifest, error) {
-	return &Manifest{}, nil
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	var manifest *Manifest
+	if err := yaml.Unmarshal(data, &manifest); err != nil {
+		return nil, err
+	}
+	if manifest == nil {
+		return nil, errors.Annotatef(err, "invalid base in manifest")
+	}
+	formatSchema := baseSchema
+	for _, base := range manifest.Bases {
+		_, err := formatSchema.Coerce(base, nil)
+		if err != nil {
+			return nil, errors.Annotatef(err, "manifest")
+		}
+	}
+	return manifest, nil
 }
+
+var baseSchema = schema.FieldMap(
+	schema.Fields{
+		"name": schema.OneOf(
+			schema.Const(systems.Ubuntu),
+			schema.Const(systems.Windows),
+			schema.Const(systems.CentOS),
+			schema.Const(systems.OpenSUSE),
+			schema.Const(systems.GenericLinux),
+			schema.Const(systems.OSX),
+		),
+		"channel": schema.String(),
+	}, schema.Defaults{
+		"name":    schema.Omit,
+		"channel": schema.Omit,
+	})

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -2,3 +2,47 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package charm
+
+import (
+	"strings"
+
+	"github.com/juju/systems"
+	"github.com/juju/systems/channel"
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+)
+
+type manifestSuite struct {
+	testing.CleanupSuite
+}
+
+var _ = gc.Suite(&manifestSuite{})
+
+func (s *manifestSuite) TestReadManifest(c *gc.C) {
+	manifest, err := ReadManifest(strings.NewReader(`
+bases:
+  - name: ubuntu
+    channel: "18.04"
+  - name: ubuntu
+    channel: "20.04/stable"
+`))
+	c.Assert(err, gc.IsNil)
+	c.Assert(manifest, gc.DeepEquals, &Manifest{[]systems.Base{{
+		Name: "ubuntu",
+		Channel: channel.Channel{
+			Name:   "18.04/stable",
+			Track:  "18.04",
+			Risk:   "stable",
+			Branch: "",
+		},
+	}, {
+		Name: "ubuntu",
+		Channel: channel.Channel{
+			Name:   "20.04/stable",
+			Track:  "20.04",
+			Risk:   "stable",
+			Branch: "",
+		},
+	},
+	}})
+}

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -1,0 +1,4 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charm

--- a/meta_test.go
+++ b/meta_test.go
@@ -12,8 +12,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/juju/systems"
-	"github.com/juju/systems/channel"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
@@ -806,10 +804,6 @@ func (s *MetaSuite) TestCodecRoundTrip(c *gc.C) {
 		Categories: []string{"quxxxx", "quxxxxx"},
 		Tags:       []string{"openstack", "storage"},
 		Terms:      []string{"test-term/1", "test-term/2"},
-		Bases: []systems.Base{{
-			Name:    "ubuntu",
-			Channel: channel.MustParse("18.04/stable"),
-		}},
 	}
 	for _, codec := range codecs {
 		c.Logf("codec %s", codec.Name)
@@ -874,10 +868,6 @@ func (s *MetaSuite) TestCodecRoundTripKubernetes(c *gc.C) {
 				Resource: "test",
 			},
 		},
-		Bases: []systems.Base{{
-			Name:    "ubuntu",
-			Channel: channel.MustParse("18.04/stable"),
-		}},
 		Resources: map[string]resource.Meta{
 			"test": resource.Meta{
 				Name: "test",
@@ -1664,30 +1654,7 @@ func (s *MetaSuite) TestParseResourceMetaNil(c *gc.C) {
 	})
 }
 
-func (s *MetaSuite) TestComputedSeriesLegacy(c *gc.C) {
-	meta, err := charm.ReadMeta(strings.NewReader(`
-name: a
-summary: b
-description: c
-series:
-  - bionic
-`))
-	c.Assert(err, gc.IsNil)
-	c.Assert(meta.ComputedSeries(), jc.DeepEquals, []string{"bionic"})
-}
 
-func (s *MetaSuite) TestComputedSeries(c *gc.C) {
-	meta, err := charm.ReadMeta(strings.NewReader(`
-name: a
-summary: b
-description: c
-bases:
-  - name: ubuntu
-    channel: 18.04/stable
-`))
-	c.Assert(err, gc.IsNil)
-	c.Assert(meta.ComputedSeries(), jc.DeepEquals, []string{"bionic"})
-}
 
 func (s *MetaSuite) TestContainers(c *gc.C) {
 	meta, err := charm.ReadMeta(strings.NewReader(`
@@ -1887,6 +1854,18 @@ func (c *dummyCharm) LXDProfile() *charm.LXDProfile {
 }
 
 func (c *dummyCharm) Revision() int {
+	panic("unused")
+}
+
+func (c *dummyCharm) BasesManifest() *charm.Manifest {
+	panic("unused")
+}
+
+func (c *dummyCharm) ComputedSeries() []string {
+	panic("unused")
+}
+
+func (c *dummyCharm) Format() charm.Format {
 	panic("unused")
 }
 


### PR DESCRIPTION
New BasesManifest method for CharmArchive and CharmDir, Manifest is
already used by CharmArchive.

Move Format and ComputedSeries from to CharmArchive and CharmDir,
both require manifest and metadata to compute.

Implementing ReadManifest and manifest Validate.