### PR TITLE
Move channel from juju/core/charm into this package

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -1,0 +1,182 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charm
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/errors"
+)
+
+// Risk describes the type of risk in a current channel.
+type Risk string
+
+const (
+	Stable    Risk = "stable"
+	Candidate Risk = "candidate"
+	Beta      Risk = "beta"
+	Edge      Risk = "edge"
+)
+
+// Risks is a list of the available channel risks.
+var Risks = []Risk{
+	Stable,
+	Candidate,
+	Beta,
+	Edge,
+}
+
+func isRisk(potential string) bool {
+	for _, risk := range Risks {
+		if potential == string(risk) {
+			return true
+		}
+	}
+	return false
+}
+
+// Channel identifies and describes completely a store channel.
+//
+// A channel consists of, and is subdivided by, tracks, risk-levels and
+// branches:
+//  - Tracks enable snap developers to publish multiple supported releases of
+//    their application under the same snap name.
+//  - Risk-levels represent a progressive potential trade-off between stability
+//    and new features.
+//  - Branches are _optional_ and hold temporary releases intended to help with
+//    bug-fixing.
+//
+// The complete channel name can be structured as three distinct parts separated
+// by slashes:
+//
+//    <track>/<risk>/<branch>
+//
+type Channel struct {
+	Track  string
+	Risk   Risk
+	Branch string
+}
+
+// MakeChannel creates a core charm Channel from a set of component parts.
+func MakeChannel(track, risk, branch string) (Channel, error) {
+	if !isRisk(risk) {
+		return Channel{}, errors.NotValidf("risk %q", risk)
+	}
+	return Channel{
+		Track:  track,
+		Risk:   Risk(risk),
+		Branch: branch,
+	}, nil
+}
+
+// MakePermissiveChannel creates a normalized core charm channel which
+// never fails.  It assumes that the risk has been prechecked.
+func MakePermissiveChannel(track, risk, branch string) Channel {
+	ch := Channel{
+		Track:  track,
+		Risk:   Risk(risk),
+		Branch: branch,
+	}
+	return ch.Normalize()
+}
+
+// ParseChannel parses a string representing a store channel.
+func ParseChannel(s string) (Channel, error) {
+	if s == "" {
+		return Channel{}, errors.Errorf("channel cannot be empty")
+	}
+
+	p := strings.Split(s, "/")
+
+	var risk, track, branch *string
+	switch len(p) {
+	case 1:
+		if isRisk(p[0]) {
+			risk = &p[0]
+		} else {
+			track = &p[0]
+		}
+	case 2:
+		if isRisk(p[0]) {
+			risk, branch = &p[0], &p[1]
+		} else {
+			track, risk = &p[0], &p[1]
+		}
+	case 3:
+		track, risk, branch = &p[0], &p[1], &p[2]
+	default:
+		return Channel{}, errors.Errorf("channel is malformed and has too many components %q", s)
+	}
+
+	ch := Channel{}
+
+	if risk != nil {
+		if !isRisk(*risk) {
+			return Channel{}, errors.NotValidf("risk in channel %q", s)
+		}
+		// We can lift this into a risk, as we've validated prior to this to
+		// ensure it's a valid risk.
+		ch.Risk = Risk(*risk)
+	}
+	if track != nil {
+		if *track == "" {
+			return Channel{}, errors.NotValidf("track in channel %q", s)
+		}
+		ch.Track = *track
+	}
+	if branch != nil {
+		if *branch == "" {
+			return Channel{}, errors.NotValidf("branch in channel %q", s)
+		}
+		ch.Branch = *branch
+	}
+	return ch, nil
+}
+
+// ParseChannelNormalize parses a string representing a store channel.
+// The returned channel's track, risk and name are normalized.
+func ParseChannelNormalize(s string) (Channel, error) {
+	ch, err := ParseChannel(s)
+	if err != nil {
+		return Channel{}, errors.Trace(err)
+	}
+	return ch.Normalize(), nil
+}
+
+// Normalize the channel with normalized track, risk and names.
+func (ch Channel) Normalize() Channel {
+	track := ch.Track
+	if track == "latest" {
+		track = ""
+	}
+
+	risk := ch.Risk
+	if risk == "" {
+		risk = "stable"
+	}
+
+	return Channel{
+		Track:  track,
+		Risk:   risk,
+		Branch: ch.Branch,
+	}
+}
+
+// Empty returns true if all it's components are empty.
+func (ch Channel) Empty() bool {
+	return ch.Track == "" && ch.Risk == "" && ch.Branch == ""
+}
+
+func (ch Channel) String() string {
+	path := string(ch.Risk)
+	if track := ch.Track; track != "" {
+		path = fmt.Sprintf("%s/%s", track, path)
+	}
+	if branch := ch.Branch; branch != "" {
+		path = fmt.Sprintf("%s/%s", path, branch)
+	}
+
+	return path
+}

--- a/channel_test.go
+++ b/channel_test.go
@@ -1,0 +1,194 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charm_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/charm/v8"
+)
+
+type channelSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&channelSuite{})
+
+func (s channelSuite) TestParseChannelNormalize(c *gc.C) {
+	// ParseChannelNoramlize tests ParseChannel as well.
+	tests := []struct {
+		Name        string
+		Value       string
+		Expected    charm.Channel
+		ExpectedErr string
+	}{{
+		Name:        "empty",
+		Value:       "",
+		ExpectedErr: "channel cannot be empty",
+	}, {
+		Name:        "empty components",
+		Value:       "//",
+		ExpectedErr: `risk in channel "//" not valid`,
+	}, {
+		Name:        "too many components",
+		Value:       "////",
+		ExpectedErr: `channel is malformed and has too many components "////"`,
+	}, {
+		Name:        "invalid risk",
+		Value:       "track/meshuggah",
+		ExpectedErr: `risk in channel "track/meshuggah" not valid`,
+	}, {
+		Name:  "risk",
+		Value: "stable",
+		Expected: charm.Channel{
+			Risk: "stable",
+		},
+	}, {
+		Name:  "track",
+		Value: "meshuggah",
+		Expected: charm.Channel{
+			Track: "meshuggah",
+			Risk:  "stable",
+		},
+	}, {
+		Name:  "risk and branch",
+		Value: "stable/foo",
+		Expected: charm.Channel{
+			Risk:   "stable",
+			Branch: "foo",
+		},
+	}, {
+		Name:  "track and risk",
+		Value: "foo/stable",
+		Expected: charm.Channel{
+			Track: "foo",
+			Risk:  "stable",
+		},
+	}, {
+		Name:  "track, risk and branch",
+		Value: "foo/stable/bar",
+		Expected: charm.Channel{
+			Track:  "foo",
+			Risk:   "stable",
+			Branch: "bar",
+		},
+	}}
+	for k, test := range tests {
+		c.Logf("test %q at %d", test.Name, k)
+		ch, err := charm.ParseChannelNormalize(test.Value)
+		if test.ExpectedErr != "" {
+			c.Assert(err, gc.ErrorMatches, test.ExpectedErr)
+		} else {
+			c.Assert(ch, gc.DeepEquals, test.Expected)
+			c.Assert(err, gc.IsNil)
+		}
+	}
+}
+
+func (s channelSuite) TestString(c *gc.C) {
+	tests := []struct {
+		Name     string
+		Value    string
+		Expected string
+	}{{
+		Name:     "risk",
+		Value:    "stable",
+		Expected: "stable",
+	}, {
+		Name:     "latest track",
+		Value:    "latest/stable",
+		Expected: "stable",
+	}, {
+		Name:     "track",
+		Value:    "1.0",
+		Expected: "1.0/stable",
+	}, {
+		Name:     "track and risk",
+		Value:    "1.0/edge",
+		Expected: "1.0/edge",
+	}, {
+		Name:     "track, risk and branch",
+		Value:    "1.0/edge/foo",
+		Expected: "1.0/edge/foo",
+	}, {
+		Name:     "latest, risk and branch",
+		Value:    "latest/edge/foo",
+		Expected: "edge/foo",
+	}}
+	for k, test := range tests {
+		c.Logf("test %q at %d", test.Name, k)
+		ch, err := charm.ParseChannelNormalize(test.Value)
+		c.Assert(err, gc.IsNil)
+		c.Assert(ch.String(), gc.DeepEquals, test.Expected)
+	}
+}
+
+func (s channelSuite) TestMakeChannel(c *gc.C) {
+	tests := []struct {
+		Name      string
+		Track     string
+		Risk      string
+		Branch    string
+		Expected  string
+		ErrorType func(err error) bool
+	}{{
+		Name:      "track, risk, branch not normalized",
+		Track:     "latest",
+		Risk:      "beta",
+		Branch:    "bar",
+		Expected:  "latest/beta/bar",
+		ErrorType: nil,
+	}, {
+		Name:      "",
+		Track:     "",
+		Risk:      "testme",
+		Branch:    "",
+		ErrorType: errors.IsNotValid,
+	}}
+	for k, test := range tests {
+		c.Logf("test %q at %d", test.Name, k)
+		ch, err := charm.MakeChannel(test.Track, test.Risk, test.Branch)
+		if test.ErrorType == nil {
+			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(ch, gc.DeepEquals, charm.Channel{
+				Track:  test.Track,
+				Risk:   charm.Risk(test.Risk),
+				Branch: test.Branch,
+			})
+		} else {
+			c.Assert(err, jc.Satisfies, errors.IsNotValid)
+		}
+	}
+}
+
+func (s channelSuite) TestMakePermissiveChannelAndEmpty(c *gc.C) {
+	tests := []struct {
+		Name     string
+		Track    string
+		Risk     string
+		Expected string
+	}{{
+		Name:     "latest track, risk",
+		Track:    "latest",
+		Risk:     "beta",
+		Expected: "beta",
+	}, {
+		Name:     "risk not valid",
+		Track:    "",
+		Risk:     "testme",
+		Expected: "testme",
+	}}
+	for k, test := range tests {
+		c.Logf("test %q at %d", test.Name, k)
+		ch := charm.MakePermissiveChannel(test.Track, test.Risk, "")
+		c.Assert(ch.String(), gc.Equals, test.Expected)
+	}
+}
+
+func (s channelSuite) TestEmpty(c *gc.C) {
+	c.Assert(charm.Channel{}.Empty(), jc.IsTrue)
+}


### PR DESCRIPTION
Moves most of the channel logic from _juju/core/charm/_ into this package.

Following this, we will merge the _channel_ and _base_ logic from _systems_ into this package as well. Then all such logic will be used in Juju by importing _charm_.

The _systems_ repository will then be archived.