### PR TITLE
Move bases from metadata to manifest

### DIFF
--- a/charm.go
+++ b/charm.go
@@ -18,6 +18,7 @@ var logger = loggo.GetLogger("juju.charm")
 type Charm interface {
 	Meta() *Meta
 	Config() *Config
+	Manifest() *Manifest
 	Metrics() *Metrics
 	Actions() *Actions
 	Revision() int

--- a/charm.go
+++ b/charm.go
@@ -22,6 +22,7 @@ type Charm interface {
 	Metrics() *Metrics
 	Actions() *Actions
 	Revision() int
+	ComputedSeries() []string
 }
 
 // ReadCharm reads a Charm from path, which can point to either a charm archive or a

--- a/charm.go
+++ b/charm.go
@@ -40,7 +40,15 @@ func ReadCharm(path string) (charm Charm, err error) {
 	if err != nil {
 		return nil, err
 	}
-	return charm, nil
+
+	// Find out the charm format, to Check the metadata.  It should
+	// be one format or the other.
+	format := FormatV2
+	if len(charm.Manifest().Bases) == 0 {
+		format = FormatV1
+	}
+
+	return charm, charm.Meta().Check(format)
 }
 
 // SeriesForCharm takes a requested series and a list of series supported by a

--- a/charm.go
+++ b/charm.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/juju/loggo"
 	"github.com/juju/collections/set"
+	"github.com/juju/loggo"
 )
 
 var logger = loggo.GetLogger("juju.charm")
@@ -76,8 +76,8 @@ func SeriesForCharm(requestedSeries string, supportedSeries []string) (string, e
 }
 
 // ComputedSeries of a charm. This is to support legacy logic on new
-// charms that use Systems.
-func  ComputedSeries(c Charm) []string {
+// charms that use Bases.
+func ComputedSeries(c Charm) []string {
 	if len(c.Manifest().Bases) == 0 {
 		return c.Meta().Series
 	}

--- a/charmarchive.go
+++ b/charmarchive.go
@@ -24,14 +24,7 @@ type CharmArchive struct {
 	zopen zipOpener
 
 	Path       string // May be empty if CharmArchive wasn't read from a file
-	meta       *Meta
-	config     *Config
-	metrics    *Metrics
-	actions    *Actions
-	lxdProfile *LXDProfile
-	manifest   *Manifest
-	revision   int
-	version    string
+	*charmBase
 }
 
 // Trick to ensure *CharmArchive implements the Charm interface.
@@ -67,6 +60,7 @@ func ReadCharmArchiveFromReader(r io.ReaderAt, size int64) (archive *CharmArchiv
 func readCharmArchive(zopen zipOpener) (archive *CharmArchive, err error) {
 	b := &CharmArchive{
 		zopen: zopen,
+		charmBase: &charmBase{},
 	}
 	zipr, err := zopen.openZip()
 	if err != nil {
@@ -203,59 +197,6 @@ type noCharmArchiveFile struct {
 
 func (err noCharmArchiveFile) Error() string {
 	return fmt.Sprintf("archive file %q not found", err.path)
-}
-
-// Version returns the VCS version representing the version file from archive.
-func (a *CharmArchive) Version() string {
-	return a.version
-}
-
-// Revision returns the revision number for the charm
-// expanded in dir.
-func (a *CharmArchive) Revision() int {
-	return a.revision
-}
-
-// SetRevision changes the charm revision number. This affects the
-// revision reported by Revision and the revision of the charm
-// directory created by ExpandTo.
-func (a *CharmArchive) SetRevision(revision int) {
-	a.revision = revision
-}
-
-// Meta returns the Meta representing the metadata.yaml file from archive.
-func (a *CharmArchive) Meta() *Meta {
-	return a.meta
-}
-
-// Config returns the Config representing the config.yaml file
-// for the charm archive.
-func (a *CharmArchive) Config() *Config {
-	return a.config
-}
-
-// Metrics returns the Metrics representing the metrics.yaml file
-// for the charm archive.
-func (a *CharmArchive) Metrics() *Metrics {
-	return a.metrics
-}
-
-// Actions returns the Actions map for the actions.yaml/functions.yaml  file for the charm
-// archive.
-func (a *CharmArchive) Actions() *Actions {
-	return a.actions
-}
-
-// LXDProfile returns the LXDProfile representing the lxd-profile.yaml file
-// for the charm expanded in dir.
-func (a *CharmArchive) LXDProfile() *LXDProfile {
-	return a.lxdProfile
-}
-
-// Manifest returns the Manifest representing the manifest.yaml file
-// for the charm expanded in dir.
-func (a *CharmArchive) Manifest() *Manifest {
-	return a.manifest
 }
 
 type zipReadCloser struct {

--- a/charmarchive.go
+++ b/charmarchive.go
@@ -258,26 +258,6 @@ func (a *CharmArchive) Manifest() *Manifest {
 	return a.manifest
 }
 
-// ComputedSeries of a charm. This is to support legacy logic on new
-// charms that use Systems.
-func (a *CharmArchive) ComputedSeries() []string {
-	if len(a.manifest.Bases) == 0 {
-		return a.meta.Series
-	}
-	// The slice must be ordered based on system appearance but
-	// have unique elements.
-	seriesSlice := []string(nil)
-	seriesSet := set.NewStrings()
-	for _, base := range a.manifest.Bases {
-		series := base.String()
-		if !seriesSet.Contains(series) {
-			seriesSet.Add(series)
-			seriesSlice = append(seriesSlice, series)
-		}
-	}
-	return seriesSlice
-}
-
 type zipReadCloser struct {
 	io.Closer
 	*zip.Reader

--- a/charmarchive.go
+++ b/charmarchive.go
@@ -252,6 +252,12 @@ func (a *CharmArchive) LXDProfile() *LXDProfile {
 	return a.lxdProfile
 }
 
+// Manifest returns the Manifest representing the manifest.yaml file
+// for the charm expanded in dir.
+func (a *CharmArchive) Manifest() *Manifest {
+	return a.manifest
+}
+
 type zipReadCloser struct {
 	io.Closer
 	*zip.Reader

--- a/charmarchive.go
+++ b/charmarchive.go
@@ -258,6 +258,26 @@ func (a *CharmArchive) Manifest() *Manifest {
 	return a.manifest
 }
 
+// ComputedSeries of a charm. This is to support legacy logic on new
+// charms that use Systems.
+func (a *CharmArchive) ComputedSeries() []string {
+	if len(a.manifest.Bases) == 0 {
+		return a.meta.Series
+	}
+	// The slice must be ordered based on system appearance but
+	// have unique elements.
+	seriesSlice := []string(nil)
+	seriesSet := set.NewStrings()
+	for _, base := range a.manifest.Bases {
+		series := base.String()
+		if !seriesSet.Contains(series) {
+			seriesSet.Add(series)
+			seriesSlice = append(seriesSlice, series)
+		}
+	}
+	return seriesSlice
+}
+
 type zipReadCloser struct {
 	io.Closer
 	*zip.Reader

--- a/charmarchive.go
+++ b/charmarchive.go
@@ -313,8 +313,8 @@ func (zo *zipReaderOpener) openZip() (*zipReadCloser, error) {
 	return &zipReadCloser{Closer: ioutil.NopCloser(nil), Reader: r}, nil
 }
 
-// Manifest returns a set of the charm's contents.
-func (a *CharmArchive) Manifest() (set.Strings, error) {
+// ArchiveMembers returns a set of the charm's contents.
+func (a *CharmArchive) ArchiveMembers() (set.Strings, error) {
 	zipr, err := a.zopen.openZip()
 	if err != nil {
 		return set.NewStrings(), err

--- a/charmarchive_test.go
+++ b/charmarchive_test.go
@@ -43,6 +43,7 @@ var dummyArchiveMembersCommon = []string{
 	"hooks",
 	"hooks/install",
 	"lxd-profile.yaml",
+	"manifest.yaml",
 	"metadata.yaml",
 	"revision",
 	"src",
@@ -112,7 +113,7 @@ func (s *CharmArchiveSuite) TestReadCharmArchiveWithoutActions(c *gc.C) {
 	c.Assert(archive.Actions().ActionSpecs, gc.HasLen, 0)
 }
 
-func (s *CharmDirSuite) TestReadCharmArchiveWithActions(c *gc.C) {
+func (s *CharmArchiveSuite) TestReadCharmArchiveWithActions(c *gc.C) {
 	path := archivePath(c, readCharmDir(c, "dummy-actions"))
 	archive, err := charm.ReadCharmArchive(path)
 	c.Assert(err, gc.IsNil)
@@ -131,7 +132,7 @@ func (s *CharmArchiveSuite) TestReadCharmArchiveBytes(c *gc.C) {
 func (s *CharmArchiveSuite) TestReadCharmArchiveFromReader(c *gc.C) {
 	f, err := os.Open(s.archivePath)
 	c.Assert(err, gc.IsNil)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	info, err := f.Stat()
 	c.Assert(err, gc.IsNil)
 

--- a/charmarchive_test.go
+++ b/charmarchive_test.go
@@ -36,7 +36,7 @@ func (s *CharmArchiveSuite) SetUpSuite(c *gc.C) {
 	s.archivePath = archivePath(c, readCharmDir(c, "dummy"))
 }
 
-var dummyManifestCommon = []string{
+var dummyArchiveMembersCommon = []string{
 	"config.yaml",
 	"empty",
 	"empty/.gitkeep",
@@ -50,8 +50,8 @@ var dummyManifestCommon = []string{
 	".notignored",
 }
 
-var dummyManifest = append(dummyManifestCommon, "actions.yaml")
-var dummyManifestActions = append(dummyManifestCommon, []string{
+var dummyArchiveMembers = append(dummyArchiveMembersCommon, "actions.yaml")
+var dummyArchiveMembersActions = append(dummyArchiveMembersCommon, []string{
 	"actions.yaml",
 	"actions/snapshot",
 	"actions",
@@ -140,24 +140,24 @@ func (s *CharmArchiveSuite) TestReadCharmArchiveFromReader(c *gc.C) {
 	checkDummy(c, archive, "")
 }
 
-func (s *CharmArchiveSuite) TestManifest(c *gc.C) {
+func (s *CharmArchiveSuite) TestArchiveMembers(c *gc.C) {
 	archive, err := charm.ReadCharmArchive(s.archivePath)
 	c.Assert(err, gc.IsNil)
-	manifest, err := archive.Manifest()
+	manifest, err := archive.ArchiveMembers()
 	c.Assert(err, gc.IsNil)
-	c.Assert(manifest, jc.DeepEquals, set.NewStrings(dummyManifest...))
+	c.Assert(manifest, jc.DeepEquals, set.NewStrings(dummyArchiveMembers...))
 }
 
-func (s *CharmArchiveSuite) TestManifestActions(c *gc.C) {
+func (s *CharmArchiveSuite) TestArchiveMembersActions(c *gc.C) {
 	path := archivePath(c, readCharmDir(c, "dummy-actions"))
 	archive, err := charm.ReadCharmArchive(path)
 	c.Assert(err, gc.IsNil)
-	manifest, err := archive.Manifest()
+	manifest, err := archive.ArchiveMembers()
 	c.Assert(err, gc.IsNil)
-	c.Assert(manifest, jc.DeepEquals, set.NewStrings(dummyManifestActions...))
+	c.Assert(manifest, jc.DeepEquals, set.NewStrings(dummyArchiveMembersActions...))
 }
 
-func (s *CharmArchiveSuite) TestManifestNoRevision(c *gc.C) {
+func (s *CharmArchiveSuite) TestArchiveMembersNoRevision(c *gc.C) {
 	archive, err := charm.ReadCharmArchive(s.archivePath)
 	c.Assert(err, gc.IsNil)
 	dirPath := c.MkDir()
@@ -167,20 +167,20 @@ func (s *CharmArchiveSuite) TestManifestNoRevision(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	archive = extCharmArchiveDir(c, dirPath)
-	manifest, err := archive.Manifest()
+	manifest, err := archive.ArchiveMembers()
 	c.Assert(err, gc.IsNil)
-	c.Assert(manifest, gc.DeepEquals, set.NewStrings(dummyManifest...))
+	c.Assert(manifest, gc.DeepEquals, set.NewStrings(dummyArchiveMembers...))
 }
 
-func (s *CharmArchiveSuite) TestManifestSymlink(c *gc.C) {
+func (s *CharmArchiveSuite) TestArchiveMembersSymlink(c *gc.C) {
 	srcPath := cloneDir(c, charmDirPath(c, "dummy"))
 	if err := os.Symlink("../target", filepath.Join(srcPath, "hooks/symlink")); err != nil {
 		c.Skip("cannot symlink")
 	}
-	expected := append([]string{"hooks/symlink"}, dummyManifest...)
+	expected := append([]string{"hooks/symlink"}, dummyArchiveMembers...)
 
 	archive := archiveDir(c, srcPath)
-	manifest, err := archive.Manifest()
+	manifest, err := archive.ArchiveMembers()
 	c.Assert(err, gc.IsNil)
 	c.Assert(manifest, gc.DeepEquals, set.NewStrings(expected...))
 }

--- a/charmarchive_test.go
+++ b/charmarchive_test.go
@@ -16,6 +16,8 @@ import (
 	"syscall"
 
 	"github.com/juju/collections/set"
+	"github.com/juju/systems"
+	"github.com/juju/systems/channel"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -74,6 +76,38 @@ func (s *CharmArchiveSuite) TestReadCharmArchiveWithoutConfig(c *gc.C) {
 	// A lacking config.yaml file still causes a proper
 	// Config value to be returned.
 	c.Assert(archive.Config().Options, gc.HasLen, 0)
+}
+
+func (s *CharmArchiveSuite) TestReadCharmDirManifest(c *gc.C) {
+	path := archivePath(c, readCharmDir(c, "dummy"))
+	dir, err := charm.ReadCharmArchive(path)
+	c.Assert(err, gc.IsNil)
+
+	c.Assert(dir.Manifest().Bases, gc.DeepEquals, []systems.Base{{
+		Name: "ubuntu",
+		Channel: channel.Channel{
+			Name:  "18.04/stable",
+			Track: "18.04",
+			Risk:  "stable",
+		},
+	}, {
+		Name: "ubuntu",
+		Channel: channel.Channel{
+			Name:  "20.04/stable",
+			Track: "20.04",
+			Risk:  "stable",
+		},
+	}})
+}
+
+func (s *CharmArchiveSuite) TestReadCharmDirWithoutManifest(c *gc.C) {
+	path := archivePath(c, readCharmDir(c, "mysql"))
+	dir, err := charm.ReadCharmArchive(path)
+	c.Assert(err, gc.IsNil)
+
+	// A lacking manifest.yaml file still causes a proper
+	// Manifest value to be returned.
+	c.Assert(dir.Manifest().Bases, gc.HasLen, 0)
 }
 
 func (s *CharmArchiveSuite) TestReadCharmArchiveWithoutMetrics(c *gc.C) {

--- a/charmarchive_test.go
+++ b/charmarchive_test.go
@@ -100,7 +100,7 @@ func (s *CharmArchiveSuite) TestReadCharmDirManifest(c *gc.C) {
 	}})
 }
 
-func (s *CharmArchiveSuite) TestReadCharmDirWithoutManifest(c *gc.C) {
+func (s *CharmArchiveSuite) TestReadCharmArchiveWithoutManifest(c *gc.C) {
 	path := archivePath(c, readCharmDir(c, "mysql"))
 	dir, err := charm.ReadCharmArchive(path)
 	c.Assert(err, gc.IsNil)

--- a/charmbase.go
+++ b/charmbase.go
@@ -1,0 +1,72 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charm
+
+// charmBase implements the Charm interface with commonality between
+// a charm archive and directory.
+type charmBase struct {
+	meta       *Meta
+	config     *Config
+	metrics    *Metrics
+	actions    *Actions
+	lxdProfile *LXDProfile
+	manifest   *Manifest
+	revision   int
+	version    string
+}
+
+// Revision returns the revision number for the charm
+// expanded in dir.
+func (c *charmBase) Revision() int {
+	return c.revision
+}
+
+// Version returns the VCS version representing the version file from archive.
+func (c *charmBase) Version() string {
+	return c.version
+}
+
+// Meta returns the Meta representing the metadata.yaml file
+// for the charm expanded in dir.
+func (c *charmBase) Meta() *Meta {
+	return c.meta
+}
+
+// Config returns the Config representing the config.yaml file
+// for the charm expanded in dir.
+func (c *charmBase) Config() *Config {
+	return c.config
+}
+
+// Metrics returns the Metrics representing the metrics.yaml file
+// for the charm expanded in dir.
+func (c *charmBase) Metrics() *Metrics {
+	return c.metrics
+}
+
+// Actions returns the Actions representing the actions.yaml file
+// for the charm expanded in dir.
+func (c *charmBase) Actions() *Actions {
+	return c.actions
+}
+
+// LXDProfile returns the LXDProfile representing the lxd-profile.yaml file
+// for the charm expanded in dir.
+func (c *charmBase) LXDProfile() *LXDProfile {
+	return c.lxdProfile
+}
+
+// Manifest returns the Manifest representing the manifest.yaml file
+// for the charm expanded in dir.
+func (c *charmBase) Manifest() *Manifest {
+	return c.manifest
+}
+
+// SetRevision changes the charm revision number. This affects
+// the revision reported by Revision and the revision of the
+// charm created.
+// The revision file in the charm directory is not modified.
+func (c *charmBase) SetRevision(revision int) {
+	c.revision = revision
+}

--- a/charmdir.go
+++ b/charmdir.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 )
 
@@ -251,6 +252,26 @@ func (dir *CharmDir) LXDProfile() *LXDProfile {
 // for the charm expanded in dir.
 func (dir *CharmDir) Manifest() *Manifest {
 	return dir.manifest
+}
+
+// ComputedSeries of a charm. This is to support legacy logic on new
+// charms that use Systems.
+func (dir *CharmDir) ComputedSeries() []string {
+	if len(dir.manifest.Bases) == 0 {
+		return dir.meta.Series
+	}
+	// The slice must be ordered based on system appearance but
+	// have unique elements.
+	seriesSlice := []string(nil)
+	seriesSet := set.NewStrings()
+	for _, base := range dir.manifest.Bases {
+		series := base.String()
+		if !seriesSet.Contains(series) {
+			seriesSet.Add(series)
+			seriesSlice = append(seriesSlice, series)
+		}
+	}
+	return seriesSlice
 }
 
 // SetRevision changes the charm revision number. This affects

--- a/charmdir.go
+++ b/charmdir.go
@@ -16,7 +16,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 )
 
@@ -252,26 +251,6 @@ func (dir *CharmDir) LXDProfile() *LXDProfile {
 // for the charm expanded in dir.
 func (dir *CharmDir) Manifest() *Manifest {
 	return dir.manifest
-}
-
-// ComputedSeries of a charm. This is to support legacy logic on new
-// charms that use Systems.
-func (dir *CharmDir) ComputedSeries() []string {
-	if len(dir.manifest.Bases) == 0 {
-		return dir.meta.Series
-	}
-	// The slice must be ordered based on system appearance but
-	// have unique elements.
-	seriesSlice := []string(nil)
-	seriesSet := set.NewStrings()
-	for _, base := range dir.manifest.Bases {
-		series := base.String()
-		if !seriesSet.Contains(series) {
-			seriesSet.Add(series)
-			seriesSlice = append(seriesSlice, series)
-		}
-	}
-	return seriesSlice
 }
 
 // SetRevision changes the charm revision number. This affects

--- a/charmdir.go
+++ b/charmdir.go
@@ -45,14 +45,7 @@ var defaultJujuIgnore = `
 // on a charm directory.
 type CharmDir struct {
 	Path       string
-	meta       *Meta
-	config     *Config
-	metrics    *Metrics
-	actions    *Actions
-	lxdProfile *LXDProfile
-	manifest   *Manifest
-	revision   int
-	version    string
+	*charmBase
 }
 
 // Trick to ensure *CharmDir implements the Charm interface.
@@ -70,6 +63,7 @@ func IsCharmDir(path string) bool {
 func ReadCharmDir(path string) (*CharmDir, error) {
 	b := &CharmDir{
 		Path: path,
+		charmBase: &charmBase{},
 	}
 	reader, err := os.Open(b.join("metadata.yaml"))
 	if err != nil {
@@ -204,61 +198,6 @@ func (dir *CharmDir) buildIgnoreRules() (ignoreRuleset, error) {
 func (dir *CharmDir) join(parts ...string) string {
 	parts = append([]string{dir.Path}, parts...)
 	return filepath.Join(parts...)
-}
-
-// Revision returns the revision number for the charm
-// expanded in dir.
-func (dir *CharmDir) Revision() int {
-	return dir.revision
-}
-
-// Version returns the VCS version representing the version file from archive.
-func (dir *CharmDir) Version() string {
-	return dir.version
-}
-
-// Meta returns the Meta representing the metadata.yaml file
-// for the charm expanded in dir.
-func (dir *CharmDir) Meta() *Meta {
-	return dir.meta
-}
-
-// Config returns the Config representing the config.yaml file
-// for the charm expanded in dir.
-func (dir *CharmDir) Config() *Config {
-	return dir.config
-}
-
-// Metrics returns the Metrics representing the metrics.yaml file
-// for the charm expanded in dir.
-func (dir *CharmDir) Metrics() *Metrics {
-	return dir.metrics
-}
-
-// Actions returns the Actions representing the actions.yaml file
-// for the charm expanded in dir.
-func (dir *CharmDir) Actions() *Actions {
-	return dir.actions
-}
-
-// LXDProfile returns the LXDProfile representing the lxd-profile.yaml file
-// for the charm expanded in dir.
-func (dir *CharmDir) LXDProfile() *LXDProfile {
-	return dir.lxdProfile
-}
-
-// Manifest returns the Manifest representing the manifest.yaml file
-// for the charm expanded in dir.
-func (dir *CharmDir) Manifest() *Manifest {
-	return dir.manifest
-}
-
-// SetRevision changes the charm revision number. This affects
-// the revision reported by Revision and the revision of the
-// charm archived by ArchiveTo.
-// The revision file in the charm directory is not modified.
-func (dir *CharmDir) SetRevision(revision int) {
-	dir.revision = revision
 }
 
 // SetDiskRevision does the same as SetRevision but also changes

--- a/charmdir.go
+++ b/charmdir.go
@@ -247,6 +247,12 @@ func (dir *CharmDir) LXDProfile() *LXDProfile {
 	return dir.lxdProfile
 }
 
+// Manifest returns the Manifest representing the manifest.yaml file
+// for the charm expanded in dir.
+func (dir *CharmDir) Manifest() *Manifest {
+	return dir.manifest
+}
+
 // SetRevision changes the charm revision number. This affects
 // the revision reported by Revision and the revision of the
 // charm archived by ArchiveTo.

--- a/charmdir_test.go
+++ b/charmdir_test.go
@@ -143,9 +143,9 @@ func (s *CharmDirSuite) TestArchiveToWithIgnoredFiles(c *gc.C) {
 	archive, err := charm.ReadCharmArchiveBytes(b.Bytes())
 	c.Assert(err, jc.ErrorIsNil)
 
-	manifest, err := archive.Manifest()
+	manifest, err := archive.ArchiveMembers()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(manifest, jc.DeepEquals, set.NewStrings(dummyManifest...))
+	c.Assert(manifest, jc.DeepEquals, set.NewStrings(dummyArchiveMembers...))
 
 	c.Assert(archive.Version(), gc.Not(gc.Equals), "spoofed version")
 	c.Assert(archive.Revision(), gc.Not(gc.Equals), 42)
@@ -196,9 +196,9 @@ tox/**
 	// Based on the .jujuignore rules, we should retain "foo/bar" and
 	// "tox/keep" but nothing else
 	retained := []string{"foo", "tox", "tox/keep"}
-	expContents := set.NewStrings(append(retained, dummyManifest...)...)
+	expContents := set.NewStrings(append(retained, dummyArchiveMembers...)...)
 
-	manifest, err := archive.Manifest()
+	manifest, err := archive.ArchiveMembers()
 	c.Log(manifest.Difference(expContents))
 	c.Log(expContents.Difference(manifest))
 	c.Assert(err, jc.ErrorIsNil)

--- a/charmdir_test.go
+++ b/charmdir_test.go
@@ -45,12 +45,6 @@ func (s *CharmDirSuite) TestIsCharmDirNoMetadataYaml(c *gc.C) {
 	c.Assert(charm.IsCharmDir(path), jc.IsFalse)
 }
 
-func (s *CharmDirSuite) TestReadCharmDirNoManifest(c *gc.C) {
-	path := charmDirPath(c, "bad-bases")
-	_, err := charm.ReadCharmDir(path)
-	c.Assert(err, gc.ErrorMatches, `reading "manifest.yaml" file: open internal/test-charm-repo/quantal/bad-bases/manifest.yaml: no such file or directory`)
-}
-
 func (s *CharmDirSuite) TestReadCharmDir(c *gc.C) {
 	path := charmDirPath(c, "dummy")
 	dir, err := charm.ReadCharmDir(path)
@@ -120,6 +114,7 @@ func (s *CharmDirSuite) TestArchiveTo(c *gc.C) {
 func (s *CharmDirSuite) TestArchiveToWithIgnoredFiles(c *gc.C) {
 	charmDir := cloneDir(c, charmDirPath(c, "dummy"))
 	dir, err := charm.ReadCharmDir(charmDir)
+	c.Assert(err, jc.ErrorIsNil)
 
 	// Add a directory/files that should be ignored
 	nestedGitDir := filepath.Join(dir.Path, ".git/nested")
@@ -675,7 +670,7 @@ func (s *CharmSuite) TestMaybeGenerateVersionStringLogsAbsolutePath(c *gc.C) {
 	logger := ctx.GetLogger("juju.testing")
 	lvl, _ := loggo.ParseLevel("TRACE")
 	logger.SetLogLevel(lvl)
-	defer loggo.RemoveWriter("versionstring-test")
+	defer func() {_, _= loggo.RemoveWriter("versionstring-test") }()
 	defer loggo.ResetLogging()
 
 	testing.PatchExecutableThrowError(c, s, "git", 128)

--- a/computedseries_test.go
+++ b/computedseries_test.go
@@ -16,7 +16,7 @@ type computedSeriesSuite struct {
 
 var _ = gc.Suite(&computedSeriesSuite{})
 
-func (s *computedSeriesSuite) TestDirComputedSeriesLegacy(c *gc.C) {
+func (s *computedSeriesSuite) TestCharmComputedSeriesLegacy(c *gc.C) {
 	meta, err := ReadMeta(strings.NewReader(`
 name: a
 summary: b
@@ -30,10 +30,10 @@ series:
 		manifest: &Manifest{},
 	}
 	c.Assert(err, gc.IsNil)
-	c.Assert(dir.ComputedSeries(), jc.DeepEquals, []string{"bionic"})
+	c.Assert(ComputedSeries(&dir), jc.DeepEquals, []string{"bionic"})
 }
 
-func (s *computedSeriesSuite) TestDirComputedSeries(c *gc.C) {
+func (s *computedSeriesSuite) TestCharmComputedSeries(c *gc.C) {
 	meta, err := ReadMeta(strings.NewReader(`
 name: a
 summary: b
@@ -52,41 +52,5 @@ bases:
 		meta:     meta,
 		manifest: manifest,
 	}
-	c.Assert(dir.ComputedSeries(), jc.DeepEquals, []string{"bionic", "focal"})
-}
-
-func (s *computedSeriesSuite) TestArchiveComputedSeriesLegacy(c *gc.C) {
-	meta, err := ReadMeta(strings.NewReader(`
-name: a
-summary: b
-description: c
-series:
-  - bionic
-`))
-	c.Assert(err, gc.IsNil)
-	arc := CharmArchive{
-		meta:     meta,
-		manifest: &Manifest{},
-	}
-	c.Assert(arc.ComputedSeries(), jc.DeepEquals, []string{"bionic"})
-}
-
-func (s *computedSeriesSuite) TestArchiveComputedSeries(c *gc.C) {
-	meta, err := ReadMeta(strings.NewReader(`
-name: a
-summary: b
-description: c
-`))
-	c.Assert(err, gc.IsNil)
-	manifest, err := ReadManifest(strings.NewReader(`
-bases:
-  - name: ubuntu
-    channel: 14.04/stable
-`))
-	c.Assert(err, gc.IsNil)
-	arc := CharmArchive{
-		meta:     meta,
-		manifest: manifest,
-	}
-	c.Assert(arc.ComputedSeries(), jc.DeepEquals, []string{"trusty"})
+	c.Assert(ComputedSeries(&dir), jc.DeepEquals, []string{"bionic", "focal"})
 }

--- a/computedseries_test.go
+++ b/computedseries_test.go
@@ -25,7 +25,7 @@ series:
   - bionic
 `))
 	c.Assert(err, gc.IsNil)
-	dir := CharmDir{
+	dir := charmBase{
 		meta:     meta,
 		manifest: &Manifest{},
 	}
@@ -48,7 +48,7 @@ bases:
     channel: "20.04"
 `))
 	c.Assert(err, gc.IsNil)
-	dir := CharmDir{
+	dir := charmBase{
 		meta:     meta,
 		manifest: manifest,
 	}

--- a/computedseries_test.go
+++ b/computedseries_test.go
@@ -1,0 +1,92 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charm
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"strings"
+)
+
+type computedSeriesSuite struct {
+	testing.CleanupSuite
+}
+
+var _ = gc.Suite(&computedSeriesSuite{})
+
+func (s *computedSeriesSuite) TestDirComputedSeriesLegacy(c *gc.C) {
+	meta, err := ReadMeta(strings.NewReader(`
+name: a
+summary: b
+description: c
+series:
+  - bionic
+`))
+	c.Assert(err, gc.IsNil)
+	dir := CharmDir{
+		meta:     meta,
+		manifest: &Manifest{},
+	}
+	c.Assert(err, gc.IsNil)
+	c.Assert(dir.ComputedSeries(), jc.DeepEquals, []string{"bionic"})
+}
+
+func (s *computedSeriesSuite) TestDirComputedSeries(c *gc.C) {
+	meta, err := ReadMeta(strings.NewReader(`
+name: a
+summary: b
+description: c
+`))
+	c.Assert(err, gc.IsNil)
+	manifest, err := ReadManifest(strings.NewReader(`
+bases:
+  - name: ubuntu
+    channel: "18.04"
+  - name: ubuntu
+    channel: "20.04"
+`))
+	c.Assert(err, gc.IsNil)
+	dir := CharmDir{
+		meta:     meta,
+		manifest: manifest,
+	}
+	c.Assert(dir.ComputedSeries(), jc.DeepEquals, []string{"bionic", "focal"})
+}
+
+func (s *computedSeriesSuite) TestArchiveComputedSeriesLegacy(c *gc.C) {
+	meta, err := ReadMeta(strings.NewReader(`
+name: a
+summary: b
+description: c
+series:
+  - bionic
+`))
+	c.Assert(err, gc.IsNil)
+	arc := CharmArchive{
+		meta:     meta,
+		manifest: &Manifest{},
+	}
+	c.Assert(arc.ComputedSeries(), jc.DeepEquals, []string{"bionic"})
+}
+
+func (s *computedSeriesSuite) TestArchiveComputedSeries(c *gc.C) {
+	meta, err := ReadMeta(strings.NewReader(`
+name: a
+summary: b
+description: c
+`))
+	c.Assert(err, gc.IsNil)
+	manifest, err := ReadManifest(strings.NewReader(`
+bases:
+  - name: ubuntu
+    channel: 14.04/stable
+`))
+	c.Assert(err, gc.IsNil)
+	arc := CharmArchive{
+		meta:     meta,
+		manifest: manifest,
+	}
+	c.Assert(arc.ComputedSeries(), jc.DeepEquals, []string{"trusty"})
+}

--- a/internal/test-charm-repo/quantal/all-hooks/manifest.yaml
+++ b/internal/test-charm-repo/quantal/all-hooks/manifest.yaml
@@ -1,0 +1,5 @@
+bases:
+  - name: ubuntu
+    channel: 18.04/stable
+  - name: ubuntu
+    channel: "20.04"

--- a/internal/test-charm-repo/quantal/dummy-actions/manifest.yaml
+++ b/internal/test-charm-repo/quantal/dummy-actions/manifest.yaml
@@ -1,0 +1,5 @@
+bases:
+  - name: ubuntu
+    channel: 18.04/stable
+  - name: ubuntu
+    channel: "20.04"

--- a/internal/test-charm-repo/quantal/dummy/manifest.yaml
+++ b/internal/test-charm-repo/quantal/dummy/manifest.yaml
@@ -1,0 +1,5 @@
+bases:
+  - name: ubuntu
+    channel: 18.04/stable
+  - name: ubuntu
+    channel: "20.04"

--- a/internal/test-charm-repo/quantal/metered-empty/manifest.yaml
+++ b/internal/test-charm-repo/quantal/metered-empty/manifest.yaml
@@ -1,0 +1,5 @@
+bases:
+  - name: ubuntu
+    channel: 18.04/stable
+  - name: ubuntu
+    channel: "20.04"

--- a/internal/test-charm-repo/quantal/metered/manifest.yaml
+++ b/internal/test-charm-repo/quantal/metered/manifest.yaml
@@ -1,0 +1,5 @@
+bases:
+  - name: ubuntu
+    channel: 18.04/stable
+  - name: ubuntu
+    channel: "20.04"

--- a/internal/test-charm-repo/quantal/varnish/manifest.yaml
+++ b/internal/test-charm-repo/quantal/varnish/manifest.yaml
@@ -1,0 +1,5 @@
+bases:
+  - name: ubuntu
+    channel: 18.04/stable
+  - name: ubuntu
+    channel: "20.04"

--- a/internal/test-charm-repo/quantal/wordpress/manifest.yaml
+++ b/internal/test-charm-repo/quantal/wordpress/manifest.yaml
@@ -1,0 +1,5 @@
+bases:
+  - name: ubuntu
+    channel: 18.04/stable
+  - name: ubuntu
+    channel: "20.04"

--- a/manifest.go
+++ b/manifest.go
@@ -22,7 +22,7 @@ type Manifest struct {
 	Bases []systems.Base `yaml:"bases"`
 }
 
-func NewManifest() *Manifest{
+func NewManifest() *Manifest {
 	return &Manifest{}
 }
 
@@ -89,10 +89,10 @@ func parseBases(input interface{}) ([]systems.Base, error) {
 	return res, nil
 }
 
-// ReadManifest reads in a Manifest from a charm's manifest.yaml.
-// TODO hml - update this header comment.
-// It is not validated at this point so that the caller can choose to override
-// any validation.
+// ReadManifest reads in a Manifest from a charm's manifest.yaml. Some of
+// validation is done when unmarshalling the manifest, including
+// verification that the base.Name is a supported operating system.  Full
+// validation done by calling Validate().
 func ReadManifest(r io.Reader) (*Manifest, error) {
 	data, err := ioutil.ReadAll(r)
 	if err != nil {

--- a/manifest.go
+++ b/manifest.go
@@ -3,18 +3,123 @@
 
 package charm
 
-import "io"
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/juju/errors"
+	"github.com/juju/schema"
+	"github.com/juju/systems"
+	"github.com/juju/systems/channel"
+	"gopkg.in/yaml.v2"
+)
 
 // Manifest represents the recording of the building of the charm or bundle.
 // The manifest file should represent the metadata.yaml, but a lot more
 // information.
 type Manifest struct {
-	// TODO (stickupkid): Represent architectures in the future.
+	Bases []systems.Base `yaml:"bases"`
+}
+
+func NewManifest() *Manifest{
+	return &Manifest{}
+}
+
+// Validate checks the manifest to ensure there are no empty names, nor channels,
+// and that architectures are supported.
+func (m *Manifest) Validate() error {
+	for _, b := range m.Bases {
+		if err := b.Validate(); err != nil {
+			return fmt.Errorf("invalid base: empty file")
+		}
+	}
+	return nil
+}
+
+func (m *Manifest) UnmarshalYAML(f func(interface{}) error) error {
+	raw := make(map[interface{}]interface{})
+	err := f(&raw)
+	if err != nil {
+		return err
+	}
+
+	v, err := schema.List(baseSchema).Coerce(raw["bases"], nil)
+	if err != nil {
+		return errors.Annotatef(err, "coerce")
+	}
+
+	newV, ok := v.([]interface{})
+	if !ok {
+		return errors.Annotatef(err, "converting")
+	}
+	bases, err := parseBases(newV)
+	if err != nil {
+		return err
+	}
+
+	*m = Manifest{Bases: bases}
+	return nil
+}
+
+func parseBases(input interface{}) ([]systems.Base, error) {
+	var err error
+	if input == nil {
+		return nil, nil
+	}
+	var res []systems.Base
+	for _, v := range input.([]interface{}) {
+		var base systems.Base
+		baseMap := v.(map[string]interface{})
+		if value, ok := baseMap["name"]; ok {
+			base.Name = value.(string)
+		}
+		if value, ok := baseMap["channel"]; ok {
+			base.Channel, err = channel.Parse(value.(string))
+			if err != nil {
+				return nil, errors.Annotatef(err, "parsing channel %q", value.(string))
+			}
+		}
+		err = base.Validate()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		res = append(res, base)
+	}
+	return res, nil
 }
 
 // ReadManifest reads in a Manifest from a charm's manifest.yaml.
+// TODO hml - update this header comment.
 // It is not validated at this point so that the caller can choose to override
 // any validation.
 func ReadManifest(r io.Reader) (*Manifest, error) {
-	return &Manifest{}, nil
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	var manifest *Manifest
+	if err := yaml.Unmarshal(data, &manifest); err != nil {
+		return nil, errors.Annotatef(err, "manifest")
+	}
+	if manifest == nil {
+		return nil, errors.Annotatef(err, "invalid base in manifest")
+	}
+	return manifest, nil
 }
+
+var baseSchema = schema.FieldMap(
+	schema.Fields{
+		"name": schema.OneOf(
+			schema.Const(systems.Ubuntu),
+			schema.Const(systems.Windows),
+			schema.Const(systems.CentOS),
+			schema.Const(systems.OpenSUSE),
+			schema.Const(systems.GenericLinux),
+			schema.Const(systems.OSX),
+		),
+		"channel": schema.String(),
+	}, schema.Defaults{
+		"name":    schema.Omit,
+		"channel": schema.Omit,
+	})

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charm
+
+import (
+	"strings"
+
+	"github.com/juju/systems"
+	"github.com/juju/systems/channel"
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+)
+
+type manifestSuite struct {
+	testing.CleanupSuite
+}
+
+var _ = gc.Suite(&manifestSuite{})
+
+func (s *manifestSuite) TestReadManifest(c *gc.C) {
+	manifest, err := ReadManifest(strings.NewReader(`
+bases:
+  - name: ubuntu
+    channel: "18.04"
+  - name: ubuntu
+    channel: "20.04/stable"
+`))
+	c.Assert(err, gc.IsNil)
+	c.Assert(manifest, gc.DeepEquals, &Manifest{[]systems.Base{{
+		Name: "ubuntu",
+		Channel: channel.Channel{
+			Name:   "18.04/stable",
+			Track:  "18.04",
+			Risk:   "stable",
+			Branch: "",
+		},
+	}, {
+		Name: "ubuntu",
+		Channel: channel.Channel{
+			Name:   "20.04/stable",
+			Track:  "20.04",
+			Risk:   "stable",
+			Branch: "",
+		},
+	},
+	}})
+}

--- a/meta.go
+++ b/meta.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/os/v2"
@@ -371,26 +370,6 @@ func (m Meta) format() Format {
 		return FormatV2
 	}
 	return FormatV1
-}
-
-// ComputedSeries of a charm. This is to support legacy logic on new
-// charms that use Systems.
-func (m Meta) ComputedSeries() []string {
-	if m.format() == FormatV1 {
-		return m.Series
-	}
-	// The slice must be ordered based on system appearance but
-	// have unique elements.
-	seriesSlice := []string(nil)
-	seriesSet := set.NewStrings()
-	for _, base := range m.Bases {
-		series := base.String()
-		if !seriesSet.Contains(series) {
-			seriesSet.Add(series)
-			seriesSlice = append(seriesSlice, series)
-		}
-	}
-	return seriesSlice
 }
 
 // Used for parsing Categories and Tags.

--- a/meta.go
+++ b/meta.go
@@ -495,7 +495,7 @@ func (meta *Meta) UnmarshalYAML(f func(interface{}) error) error {
 		return err
 	}
 
-	if err := ensureUnambigiousFormat(raw); err != nil {
+	if err := ensureUnambiguousFormat(raw); err != nil {
 		return err
 	}
 
@@ -1373,10 +1373,10 @@ var charmSchema = schema.FieldMap(
 	},
 )
 
-// ensureUnambigiousFormat returns an error if the raw data contains
+// ensureUnambiguousFormat returns an error if the raw data contains
 // both metadata v1 and v2 contents. However is it unable to definitively
 // determine which format the charm is as metadata does not contain bases.
-func ensureUnambigiousFormat(raw map[interface{}]interface{}) error {
+func ensureUnambiguousFormat(raw map[interface{}]interface{}) error {
 	format := FormatUnknown
 	matched := []string(nil)
 	mismatched := []string(nil)
@@ -1411,7 +1411,7 @@ func ensureUnambigiousFormat(raw map[interface{}]interface{}) error {
 		}
 	}
 	if mismatched != nil {
-		return errors.Errorf("ambigious metadata: keys %s cannot be used with %s",
+		return errors.Errorf("ambiguous metadata: keys %s cannot be used with %s",
 			`"`+strings.Join(mismatched, `", "`)+`"`,
 			`"`+strings.Join(matched, `", "`)+`"`)
 	}

--- a/meta_test.go
+++ b/meta_test.go
@@ -1657,33 +1657,6 @@ func (s *MetaSuite) TestParseResourceMetaNil(c *gc.C) {
 	})
 }
 
-// TODO hml
-// move and enable with ComputedSeries at Charm level.
-//func (s *MetaSuite) TestComputedSeriesLegacy(c *gc.C) {
-//	meta, err := charm.ReadMeta(strings.NewReader(`
-//name: a
-//summary: b
-//description: c
-//series:
-//  - bionic
-//`))
-//	c.Assert(err, gc.IsNil)
-//	c.Assert(meta.ComputedSeries(), jc.DeepEquals, []string{"bionic"})
-//}
-//
-//func (s *MetaSuite) TestComputedSeries(c *gc.C) {
-//	meta, err := charm.ReadMeta(strings.NewReader(`
-//name: a
-//summary: b
-//description: c
-//bases:
-//  - name: ubuntu
-//    channel: 18.04/stable
-//`))
-//	c.Assert(err, gc.IsNil)
-//	c.Assert(meta.ComputedSeries(), jc.DeepEquals, []string{"bionic"})
-//}
-
 func (s *MetaSuite) TestContainers(c *gc.C) {
 	meta, err := charm.ReadMeta(strings.NewReader(`
 name: a
@@ -1861,6 +1834,10 @@ func (c *dummyCharm) LXDProfile() *charm.LXDProfile {
 }
 
 func (c *dummyCharm) Manifest() *charm.Manifest {
+	panic("unused")
+}
+
+func (c *dummyCharm) ComputedSeries() []string {
 	panic("unused")
 }
 

--- a/meta_test.go
+++ b/meta_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
-	yamlv2 "gopkg.in/yaml.v2"
 
 	"github.com/juju/charm/v8"
 	"github.com/juju/charm/v8/resource"
@@ -84,14 +83,14 @@ func (s *MetaSuite) TestValidTermFormat(c *gc.C) {
 	for i, s := range valid {
 		c.Logf("valid test %d: %s", i, s)
 		meta := charm.Meta{Terms: []string{s}}
-		err := meta.Check()
+		err := meta.Check(charm.FormatV1)
 		c.Check(err, jc.ErrorIsNil)
 	}
 
 	for i, s := range invalid {
 		c.Logf("invalid test %d: %s", i, s)
 		meta := charm.Meta{Terms: []string{s}}
-		err := meta.Check()
+		err := meta.Check(charm.FormatV1)
 		c.Check(err, gc.NotNil)
 	}
 }
@@ -178,7 +177,7 @@ func (s *MetaSuite) TestCheckTerms(c *gc.C) {
 	for i, test := range tests {
 		c.Logf("running test %v: %v", i, test.about)
 		meta := charm.Meta{Terms: test.terms}
-		err := meta.Check()
+		err := meta.Check(charm.FormatV1)
 		if test.expectError == "" {
 			c.Check(err, jc.ErrorIsNil)
 		} else {
@@ -280,7 +279,7 @@ func (s *MetaSuite) TestReadCategory(c *gc.C) {
 func (s *MetaSuite) TestReadTerms(c *gc.C) {
 	meta, err := charm.ReadMeta(repoMeta(c, "terms"))
 	c.Assert(err, jc.ErrorIsNil)
-	err = meta.Check()
+	err = meta.Check(charm.FormatV1)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(meta.Terms, jc.DeepEquals, []string{"term1/1", "term2", "owner/term3/1"})
 }
@@ -293,9 +292,11 @@ description: |
 terms: ["!!!/abc"]
 `
 
-func (s *MetaSuite) TestReadInvalidTerms(c *gc.C) {
+func (s *MetaSuite) TestCheckReadInvalidTerms(c *gc.C) {
 	reader := strings.NewReader(metaDataWithInvalidTermsId)
-	_, err := charm.ReadMeta(reader)
+	meta, err := charm.ReadMeta(reader)
+	c.Assert(err, jc.ErrorIsNil)
+	err = meta.Check(charm.FormatV1)
 	c.Assert(err, gc.ErrorMatches, `wrong owner format "!!!"`)
 }
 
@@ -311,11 +312,13 @@ func (s *MetaSuite) TestSubordinate(c *gc.C) {
 	c.Assert(meta.Subordinate, gc.Equals, true)
 }
 
-func (s *MetaSuite) TestSubordinateWithoutContainerRelation(c *gc.C) {
+func (s *MetaSuite) TestCheckSubordinateWithoutContainerRelation(c *gc.C) {
 	r := repoMeta(c, "dummy")
 	hackYaml := ReadYaml(r)
 	hackYaml["subordinate"] = true
-	_, err := charm.ReadMeta(hackYaml.Reader())
+	meta, err := charm.ReadMeta(hackYaml.Reader())
+	c.Assert(err, jc.ErrorIsNil)
+	err = meta.Check(charm.FormatV1)
 	c.Assert(err, gc.ErrorMatches, "subordinate charm \"dummy\" lacks \"requires\" relation with container scope")
 }
 
@@ -501,15 +504,16 @@ var relationsConstraintsTests = []struct {
 	},
 }
 
-func (s *MetaSuite) TestRelationsConstraints(c *gc.C) {
+func (s *MetaSuite) TestCheckRelationsConstraints(c *gc.C) {
 	check := func(s, e string) {
 		meta, err := charm.ReadMeta(strings.NewReader(s))
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(meta, gc.NotNil)
+		err = meta.Check(charm.FormatV1)
 		if e != "" {
 			c.Assert(err, gc.ErrorMatches, e)
-			c.Assert(meta, gc.IsNil)
 		} else {
 			c.Assert(err, gc.IsNil)
-			c.Assert(meta, gc.NotNil)
 		}
 	}
 	prefix := "name: a\nsummary: b\ndescription: c\n"
@@ -550,36 +554,36 @@ func (s *MetaSuite) TestSeries(c *gc.C) {
 	c.Assert(meta.Series, gc.DeepEquals, []string{"precise", "trusty", "plan9"})
 }
 
-func (s *MetaSuite) TestInvalidSeries(c *gc.C) {
+func (s *MetaSuite) TestCheckInvalidSeries(c *gc.C) {
 	for _, seriesName := range []string{"pre-c1se", "pre^cise", "cp/m", "OpenVMS"} {
-		_, err := charm.ReadMeta(strings.NewReader(
-			fmt.Sprintf("%s\nseries:\n    - %s\n", dummyMetadata, seriesName)))
-		c.Assert(err, gc.NotNil)
+		err := charm.Meta{
+			Name:        "a",
+			Summary:     "b",
+			Description: "c",
+			Series:      []string{seriesName},
+		}.Check(charm.FormatV1)
 		c.Check(err, gc.ErrorMatches, `charm "a" declares invalid series: .*`)
 	}
 }
 
-// TODO hml
-// Fix test once validate moved around and metadata checks after
-// unmarshall, not during.
-//func (s *MetaSuite) TestMinJujuVersion(c *gc.C) {
-//	// series not specified
-//	meta, err := charm.ReadMeta(strings.NewReader(dummyMetadata))
-//	c.Assert(err, gc.IsNil)
-//	c.Check(meta.Series, gc.HasLen, 0)
-//	charmMeta := fmt.Sprintf("%s\nmin-juju-version: ", dummyMetadata)
-//	vals := []version.Number{
-//		{Major: 1, Minor: 25},
-//		{Major: 1, Minor: 25, Tag: "alpha"},
-//		{Major: 1, Minor: 25, Patch: 1},
-//	}
-//	for _, ver := range vals {
-//		val := charmMeta + ver.String()
-//		meta, err = charm.ReadMeta(strings.NewReader(val))
-//		c.Assert(err, gc.IsNil)
-//		c.Assert(meta.MinJujuVersion, gc.Equals, ver)
-//	}
-//}
+func (s *MetaSuite) TestMinJujuVersion(c *gc.C) {
+	// series not specified
+	meta, err := charm.ReadMeta(strings.NewReader(dummyMetadata))
+	c.Assert(err, gc.IsNil)
+	c.Check(meta.Series, gc.HasLen, 0)
+	charmMeta := fmt.Sprintf("%s\nmin-juju-version: ", dummyMetadata)
+	vals := []version.Number{
+		{Major: 1, Minor: 25},
+		{Major: 1, Minor: 25, Tag: "alpha"},
+		{Major: 1, Minor: 25, Patch: 1},
+	}
+	for _, ver := range vals {
+		val := charmMeta + ver.String()
+		meta, err = charm.ReadMeta(strings.NewReader(val))
+		c.Assert(err, gc.IsNil)
+		c.Assert(meta.MinJujuVersion, gc.Equals, ver)
+	}
+}
 
 func (s *MetaSuite) TestInvalidMinJujuVersion(c *gc.C) {
 	_, err := charm.ReadMeta(strings.NewReader(dummyMetadata + "\nmin-juju-version: invalid-version"))
@@ -595,7 +599,7 @@ func (s *MetaSuite) TestNoMinJujuVersion(c *gc.C) {
 
 func (s *MetaSuite) TestCheckMismatchedRelationName(c *gc.C) {
 	// This  Check case cannot be covered by the above
-	// TestRelationsConstraints tests.
+	// TestCheckRelationsConstraints tests.
 	meta := charm.Meta{
 		Name: "foo",
 		Provides: map[string]charm.Relation{
@@ -607,13 +611,13 @@ func (s *MetaSuite) TestCheckMismatchedRelationName(c *gc.C) {
 			},
 		},
 	}
-	err := meta.Check()
+	err := meta.Check(charm.FormatV1)
 	c.Assert(err, gc.ErrorMatches, `charm "foo" has mismatched role "peer"; expected "provider"`)
 }
 
 func (s *MetaSuite) TestCheckMismatchedRole(c *gc.C) {
 	// This  Check case cannot be covered by the above
-	// TestRelationsConstraints tests.
+	// TestCheckRelationsConstraints tests.
 	meta := charm.Meta{
 		Name: "foo",
 		Provides: map[string]charm.Relation{
@@ -624,7 +628,7 @@ func (s *MetaSuite) TestCheckMismatchedRole(c *gc.C) {
 			},
 		},
 	}
-	err := meta.Check()
+	err := meta.Check(charm.FormatV1)
 	c.Assert(err, gc.ErrorMatches, `charm "foo" has mismatched relation name ""; expected "foo"`)
 }
 
@@ -635,7 +639,7 @@ func (s *MetaSuite) TestCheckMismatchedExtraBindingName(c *gc.C) {
 			"foo": {Name: "bar"},
 		},
 	}
-	err := meta.Check()
+	err := meta.Check(charm.FormatV1)
 	c.Assert(err, gc.ErrorMatches, `charm "foo" has invalid extra bindings: mismatched extra binding name: got "bar", expected "foo"`)
 }
 
@@ -644,12 +648,12 @@ func (s *MetaSuite) TestCheckEmptyNameKeyOrEmptyExtraBindingName(c *gc.C) {
 		Name:          "foo",
 		ExtraBindings: map[string]charm.ExtraBinding{"": {Name: "bar"}},
 	}
-	err := meta.Check()
+	err := meta.Check(charm.FormatV1)
 	expectedError := `charm "foo" has invalid extra bindings: missing binding name`
 	c.Assert(err, gc.ErrorMatches, expectedError)
 
 	meta.ExtraBindings = map[string]charm.ExtraBinding{"bar": {Name: ""}}
-	err = meta.Check()
+	err = meta.Check(charm.FormatV1)
 	c.Assert(err, gc.ErrorMatches, expectedError)
 }
 
@@ -1020,19 +1024,6 @@ func (s *MetaSuite) TestYAMLMarshal(c *gc.C) {
 	}
 }
 
-func (s *MetaSuite) TestYAMLMarshalV2(c *gc.C) {
-	for i, test := range metaYAMLMarshalTests {
-		c.Logf("test %d: %s", i, test.about)
-		ch, err := charm.ReadMeta(strings.NewReader(test.yaml))
-		c.Assert(err, gc.IsNil)
-		gotYAML, err := yamlv2.Marshal(ch)
-		c.Assert(err, gc.IsNil)
-		gotCh, err := charm.ReadMeta(bytes.NewReader(gotYAML))
-		c.Assert(err, gc.IsNil)
-		c.Assert(gotCh, jc.DeepEquals, ch)
-	}
-}
-
 func (s *MetaSuite) TestYAMLMarshalSimpleRelationOrExtraBinding(c *gc.C) {
 	// Check that a simple relation / extra-binding gets marshaled as a string.
 	chYAML := `
@@ -1167,7 +1158,7 @@ deployment:
 	}, gc.Commentf("meta: %+v", meta))
 }
 
-func (s *MetaSuite) TestDeploymentErrors(c *gc.C) {
+func (s *MetaSuite) TestCheckDeploymentErrors(c *gc.C) {
 	prefix := `
 name: a
 summary: b
@@ -1215,6 +1206,17 @@ func testErrors(c *gc.C, prefix string, tests []testErrorPayload) {
 	}
 }
 
+func testCheckErrors(c *gc.C, prefix string, tests []testErrorPayload) {
+	for i, test := range tests {
+		c.Logf("test %d: %s", i, test.desc)
+		c.Logf("\n%s\n", prefix+test.yaml)
+		meta, err := charm.ReadMeta(strings.NewReader(prefix + test.yaml))
+		c.Assert(err, jc.ErrorIsNil)
+		err = meta.Check(charm.FormatV1)
+		c.Assert(err, gc.ErrorMatches, test.err)
+	}
+}
+
 func (s *MetaSuite) TestDevicesErrors(c *gc.C) {
 	prefix := `
 name: a
@@ -1236,13 +1238,28 @@ devices:
 		desc: "countmin has to be greater than 0",
 		yaml: "        countmin: -1\n        description: a big gpu device\n        type: gpu",
 		err:  "metadata: invalid device count -1",
-	}, {
+	}}
+
+	testErrors(c, prefix, tests)
+
+}
+
+func (s *MetaSuite) TestCheckDevicesErrors(c *gc.C) {
+	prefix := `
+name: a
+summary: b
+description: c
+devices:
+    bad-nvidia-gpu:
+`[1:]
+
+	tests := []testErrorPayload{{
 		desc: "countmax can not be smaller than countmin",
 		yaml: "        countmin: 2\n        countmax: 1\n        description: a big gpu device\n        type: gpu",
 		err:  "charm \"a\" device \"bad-nvidia-gpu\": maximum count 1 can not be smaller than minimum count 2",
 	}}
 
-	testErrors(c, prefix, tests)
+	testCheckErrors(c, prefix, tests)
 
 }
 
@@ -1307,10 +1324,6 @@ storage:
 		yaml: "  type: filesystem\n  multiple:\n    range: 0",
 		err:  `metadata: storage.store-bad.multiple.range: invalid count 0`,
 	}, {
-		desc: "location cannot be specified for block type storage",
-		yaml: "  type: block\n  location: /dev/sdc",
-		err:  `charm "a" storage "store-bad": location may not be specified for "type: block"`,
-	}, {
 		desc: "minimum size must parse correctly",
 		yaml: "  type: block\n  minimum-size: foo",
 		err:  `metadata: expected a non-negative number, got "foo"`,
@@ -1325,6 +1338,24 @@ storage:
 	}}
 
 	testErrors(c, prefix, tests)
+}
+
+func (s *MetaSuite) TestCheckStorageErrors(c *gc.C) {
+	prefix := `
+name: a
+summary: b
+description: c
+storage:
+ store-bad:
+`[1:]
+
+	tests := []testErrorPayload{{
+		desc: "location cannot be specified for block type storage",
+		yaml: "  type: block\n  location: /dev/sdc",
+		err:  `charm "a" storage "store-bad": location may not be specified for "type: block"`,
+	}}
+
+	testCheckErrors(c, prefix, tests)
 }
 
 func (s *MetaSuite) TestStorageCount(c *gc.C) {

--- a/meta_test.go
+++ b/meta_test.go
@@ -1839,7 +1839,7 @@ storage:
   a:
     type: filesystem
 `))
-	c.Assert(err, gc.ErrorMatches, `ambigious metadata: keys "series" cannot be used with "containers"`)
+	c.Assert(err, gc.ErrorMatches, `ambiguous metadata: keys "series" cannot be used with "containers"`)
 }
 
 type dummyCharm struct{}

--- a/meta_test.go
+++ b/meta_test.go
@@ -1868,10 +1868,6 @@ func (c *dummyCharm) Manifest() *charm.Manifest {
 	panic("unused")
 }
 
-func (c *dummyCharm) ComputedSeries() []string {
-	panic("unused")
-}
-
 func (c *dummyCharm) Revision() int {
 	panic("unused")
 }

--- a/meta_test.go
+++ b/meta_test.go
@@ -1860,6 +1860,10 @@ func (c *dummyCharm) LXDProfile() *charm.LXDProfile {
 	panic("unused")
 }
 
+func (c *dummyCharm) Manifest() *charm.Manifest {
+	panic("unused")
+}
+
 func (c *dummyCharm) Revision() int {
 	panic("unused")
 }


### PR DESCRIPTION
This commit is disruptive.   It introduces a new method, renames one, deletes one and moves one to a different type:

- CharmArchive Manifest is renamed to ArchiveMembers.
- The Charm interface added Manifest.
- Metadata ComputedSeries is moved to the CharmInterface.
- Metadata Format is removed.

ReadManifest has been implemented.  Bases now exist for Manifest, not Metadata.

Where Metadata is validated and check has split into 2 pieces, both in ReadMetadata and ReadCharm.  Full validation of Metadata now requires knowledge of a manifest if any exists.

Some compiler warning have been resolved as drive bys.

ToDo: use local channel and base structures instead of from the systems package.