### PR TITLE
Ensure we don't panic on a nil manifest

### DIFF
--- a/charm.go
+++ b/charm.go
@@ -78,14 +78,15 @@ func SeriesForCharm(requestedSeries string, supportedSeries []string) (string, e
 // ComputedSeries of a charm. This is to support legacy logic on new
 // charms that use Bases.
 func ComputedSeries(c Charm) []string {
-	if len(c.Manifest().Bases) == 0 {
+	manifest := c.Manifest()
+	if manifest == nil || len(manifest.Bases) == 0 {
 		return c.Meta().Series
 	}
 	// The slice must be ordered based on system appearance but
 	// have unique elements.
 	seriesSlice := []string(nil)
 	seriesSet := set.NewStrings()
-	for _, base := range c.Manifest().Bases {
+	for _, base := range manifest.Bases {
 		series := base.String()
 		if !seriesSet.Contains(series) {
 			seriesSet.Add(series)

--- a/computedseries_test.go
+++ b/computedseries_test.go
@@ -4,10 +4,11 @@
 package charm
 
 import (
+	"strings"
+
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"strings"
 )
 
 type computedSeriesSuite struct {
@@ -28,6 +29,23 @@ series:
 	dir := charmBase{
 		meta:     meta,
 		manifest: &Manifest{},
+	}
+	c.Assert(err, gc.IsNil)
+	c.Assert(ComputedSeries(&dir), jc.DeepEquals, []string{"bionic"})
+}
+
+func (s *computedSeriesSuite) TestCharmComputedSeriesNilManifest(c *gc.C) {
+	meta, err := ReadMeta(strings.NewReader(`
+name: a
+summary: b
+description: c
+series:
+  - bionic
+`))
+	c.Assert(err, gc.IsNil)
+	dir := charmBase{
+		meta:     meta,
+		manifest: nil,
 	}
 	c.Assert(err, gc.IsNil)
 	c.Assert(ComputedSeries(&dir), jc.DeepEquals, []string{"bionic"})


### PR DESCRIPTION
Given older charms that already live in state, it's possible that you
can end up with no manifest at all. If that's the case we need to ensure
that when you compute a series it doesn't panic.