### PR TITLE
Charm interface for Meta+Manifest

### DIFF
--- a/charm.go
+++ b/charm.go
@@ -14,12 +14,18 @@ import (
 
 var logger = loggo.GetLogger("juju.charm")
 
+// CharmMeta describes methods that inform charm operation.
+type CharmMeta interface {
+	Meta() *Meta
+	Manifest() *Manifest
+}
+
 // The Charm interface is implemented by any type that
 // may be handled as a charm.
 type Charm interface {
-	Meta() *Meta
+	CharmMeta
+
 	Config() *Config
-	Manifest() *Manifest
 	Metrics() *Metrics
 	Actions() *Actions
 	Revision() int
@@ -77,7 +83,7 @@ func SeriesForCharm(requestedSeries string, supportedSeries []string) (string, e
 
 // ComputedSeries of a charm. This is to support legacy logic on new
 // charms that use Bases.
-func ComputedSeries(c Charm) []string {
+func ComputedSeries(c CharmMeta) []string {
 	manifest := c.Manifest()
 	if manifest == nil || len(manifest.Bases) == 0 {
 		return c.Meta().Series

--- a/charm.go
+++ b/charm.go
@@ -78,14 +78,15 @@ func SeriesForCharm(requestedSeries string, supportedSeries []string) (string, e
 // ComputedSeries of a charm. This is to support legacy logic on new
 // charms that use Bases.
 func ComputedSeries(c Charm) []string {
-	if len(c.Manifest().Bases) == 0 {
+	manifest := c.Manifest()
+	if manifest == nil || len(manifest.Bases) == 0 {
 		return c.Meta().Series
 	}
 	// The slice must be ordered based on system appearance but
 	// have unique elements.
 	seriesSlice := []string(nil)
 	seriesSet := set.NewStrings()
-	for _, base := range c.Manifest().Bases {
+	for _, base := range manifest.Bases {
 		series := base.String()
 		if !seriesSet.Contains(series) {
 			seriesSet.Add(series)

--- a/computedseries_test.go
+++ b/computedseries_test.go
@@ -4,10 +4,11 @@
 package charm
 
 import (
+	"strings"
+
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"strings"
 )
 
 type computedSeriesSuite struct {
@@ -28,6 +29,23 @@ series:
 	dir := charmBase{
 		meta:     meta,
 		manifest: &Manifest{},
+	}
+	c.Assert(err, gc.IsNil)
+	c.Assert(ComputedSeries(&dir), jc.DeepEquals, []string{"bionic"})
+}
+
+func (s *computedSeriesSuite) TestCharmComputedSeriesNilManifest(c *gc.C) {
+	meta, err := ReadMeta(strings.NewReader(`
+name: a
+summary: b
+description: c
+series:
+  - bionic
+`))
+	c.Assert(err, gc.IsNil)
+	dir := charmBase{
+		meta:     meta,
+		manifest: nil,
 	}
 	c.Assert(err, gc.IsNil)
 	c.Assert(ComputedSeries(&dir), jc.DeepEquals, []string{"bionic"})


### PR DESCRIPTION
This patch adds an interface for `CharmMeta` that includes `Meta` and `Manifest` and is embedded in `Charm`. It allows for a focussed argument to `ComputedSeries`, which will ease testing when used in Juju.

In addition the fix from #353 in cherry picked from master over to this (v8) branch.