### PR TITLE
Remove duplicate Manifest() from Charm interface.

### DIFF
--- a/charm.go
+++ b/charm.go
@@ -23,7 +23,6 @@ type CharmMeta interface {
 // may be handled as a charm.
 type Charm interface {
 	CharmMeta
-	Manifest() *Manifest
 	Config() *Config
 	Metrics() *Metrics
 	Actions() *Actions


### PR DESCRIPTION
Manifest is part of CharmMeta.