### PR TITLE
bson omitempty for Base elements.

### DIFF
--- a/base.go
+++ b/base.go
@@ -16,9 +16,9 @@ import (
 // Base represents an OS/Channel.
 // Bases can also be converted to and from a series string.
 type Base struct {
-	Name          string   `json:"name,omitempty"`
-	Channel       Channel  `json:"channel,omitempty"`
-	Architectures []string `json:"architectures,omitempty"`
+	Name          string   `bson:"name,omitempty" json:"name,omitempty"`
+	Channel       Channel  `bson:"channel,omitempty" json:"channel,omitempty"`
+	Architectures []string `bson:"architectures,omitempty" json:"architectures,omitempty"`
 }
 
 // Validate returns with no error when the Base is valid.


### PR DESCRIPTION
add bson omitempty to elements of bases, for proper handling in the juju db.