### PR TITLE
Expose validate error

### DIFF
--- a/base.go
+++ b/base.go
@@ -24,7 +24,7 @@ type Base struct {
 // Validate returns with no error when the Base is valid.
 func (b Base) Validate() error {
 	if b.Name == "" {
-		return errors.NotValidf("name must be specified")
+		return errors.NotValidf("base without name")
 	}
 
 	if !validOSForBase.Contains(b.Name) {

--- a/manifest.go
+++ b/manifest.go
@@ -29,7 +29,7 @@ func NewManifest() *Manifest {
 func (m *Manifest) Validate() error {
 	for _, b := range m.Bases {
 		if err := b.Validate(); err != nil {
-			return errors.Annotate(err, "invalid base")
+			return errors.Annotate(err, "validating manifest")
 		}
 	}
 	return nil

--- a/manifest.go
+++ b/manifest.go
@@ -4,7 +4,6 @@
 package charm
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
 
@@ -30,7 +29,7 @@ func NewManifest() *Manifest {
 func (m *Manifest) Validate() error {
 	for _, b := range m.Bases {
 		if err := b.Validate(); err != nil {
-			return fmt.Errorf("invalid base: empty file")
+			return errors.Annotate(err, "invalid base")
 		}
 	}
 	return nil

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -44,3 +44,21 @@ bases:
 	},
 	}})
 }
+
+func (s *manifestSuite) TestReadValidateManifest(c *gc.C) {
+	_, err := ReadManifest(strings.NewReader(`
+bases:
+  - name: ""
+    channel: "18.04"
+`))
+	c.Assert(err, gc.ErrorMatches, "manifest: name must be specified not valid")
+}
+
+func (s *manifestSuite) TestValidateManifest(c *gc.C) {
+	manifest := &Manifest{
+		Bases: []Base{{
+			Name: "",
+		}},
+	}
+	c.Assert(manifest.Validate(), gc.ErrorMatches, "invalid base: name must be specified not valid")
+}

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -51,7 +51,7 @@ bases:
   - name: ""
     channel: "18.04"
 `))
-	c.Assert(err, gc.ErrorMatches, "manifest: name must be specified not valid")
+	c.Assert(err, gc.ErrorMatches, "manifest: base without name not valid")
 }
 
 func (s *manifestSuite) TestValidateManifest(c *gc.C) {
@@ -60,5 +60,5 @@ func (s *manifestSuite) TestValidateManifest(c *gc.C) {
 			Name: "",
 		}},
 	}
-	c.Assert(manifest.Validate(), gc.ErrorMatches, "invalid base: name must be specified not valid")
+	c.Assert(manifest.Validate(), gc.ErrorMatches, "validating manifest: base without name not valid")
 }


### PR DESCRIPTION
The error during validation was being trapped, we need to ensure that
the error bubbles up so that we can show the issue to the user.