### PR TITLE
Series = version 1

### DIFF
--- a/charm.go
+++ b/charm.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 )
 
@@ -34,7 +35,7 @@ type Charm interface {
 func ReadCharm(path string) (charm Charm, err error) {
 	info, err := os.Stat(path)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	if info.IsDir() {
 		charm, err = ReadCharmDir(path)
@@ -42,10 +43,10 @@ func ReadCharm(path string) (charm Charm, err error) {
 		charm, err = ReadCharmArchive(path)
 	}
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
-	return charm, CheckMeta(charm)
+	return charm, errors.Trace(CheckMeta(charm))
 }
 
 // CheckMeta determines the version of the metadata used by this charm,
@@ -54,7 +55,7 @@ func CheckMeta(ch CharmMeta) error {
 	manifest := ch.Manifest()
 
 	format := FormatV2
-	if manifest == nil || len(manifest.Bases) == 0 {
+	if manifest == nil || len(manifest.Bases) == 0 || len(ch.Meta().Series) > 0 {
 		format = FormatV1
 	}
 

--- a/charm_test.go
+++ b/charm_test.go
@@ -41,10 +41,16 @@ func (s *CharmSuite) TestReadCharm(c *gc.C) {
 	c.Assert(ch.Meta().Name, gc.Equals, "dummy")
 }
 
-func (s *CharmSuite) TestReadCharmDirError(c *gc.C) {
+func (s *CharmSuite) TestReadCharmDirEmptyError(c *gc.C) {
 	ch, err := charm.ReadCharm(c.MkDir())
 	c.Assert(err, gc.NotNil)
 	c.Assert(ch, gc.Equals, nil)
+}
+
+func (s *CharmSuite) TestReadCharmSeriesWithBases(c *gc.C) {
+	ch, err := charm.ReadCharm(charmDirPath(c, "seriesmanifest"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ch, gc.NotNil)
 }
 
 func (s *CharmSuite) TestReadCharmArchiveError(c *gc.C) {
@@ -110,7 +116,7 @@ func checkDummy(c *gc.C, f charm.Charm, path string) {
 	c.Assert(f.Config().Options["title"].Default, gc.Equals, "My Title")
 	c.Assert(f.Actions(), jc.DeepEquals,
 		&charm.Actions{
-			map[string]charm.ActionSpec{
+			ActionSpecs: map[string]charm.ActionSpec{
 				"snapshot": {
 					Description: "Take a snapshot of the database.",
 					Params: map[string]interface{}{

--- a/internal/test-charm-repo/quantal/seriesmanifest/manifest.yaml
+++ b/internal/test-charm-repo/quantal/seriesmanifest/manifest.yaml
@@ -1,0 +1,5 @@
+bases:
+  - name: ubuntu
+    channel: 18.04/stable
+  - name: ubuntu
+    channel: "20.04"

--- a/internal/test-charm-repo/quantal/seriesmanifest/metadata.yaml
+++ b/internal/test-charm-repo/quantal/seriesmanifest/metadata.yaml
@@ -1,0 +1,6 @@
+name: series-and-manifest
+summary: "Both manifest bases and series present"
+series:
+  - kubernetes
+description: |
+  Format V1 should be detected.

--- a/meta.go
+++ b/meta.go
@@ -472,8 +472,8 @@ func ParseTerm(s string) (*TermsId, error) {
 }
 
 // ReadMeta reads the content of a metadata.yaml file and returns
-// its representation.  The data has verfied as unambiguous, but
-// not Check'd.
+// its representation.
+// The data has verified as unambiguous, but not validated.
 func ReadMeta(r io.Reader) (*Meta, error) {
 	data, err := ioutil.ReadAll(r)
 	if err != nil {


### PR DESCRIPTION
Ensures that the presence of non-empty series in metadata.yaml causes the format to be detected as V1.

A new testing charm directory verifies the behaviour in tandem with a new test.
