### PR TITLE
Change EnsureSchema signature to accept the default schema as an arg

### DIFF
--- a/url.go
+++ b/url.go
@@ -50,12 +50,6 @@ func (s Schema) String() string {
 	return string(s)
 }
 
-var (
-	// DefaultSchema for the charm package.
-	// It's used as the fallback for the absence of a schema in a URL.
-	DefaultSchema = CharmHub
-)
-
 // Location represents a charm location, which must declare a path component
 // and a string representation.
 type Location interface {
@@ -560,8 +554,9 @@ func parseIdentifierURL(url *gourl.URL) (*URL, error) {
 }
 
 // EnsureSchema will ensure that the scheme for a given URL is correct and
-// valid.
-func EnsureSchema(url string) (string, error) {
+// valid. If the url does not specify a schema, the provided defaultSchema
+// will be injected to it.
+func EnsureSchema(url string, defaultSchema Schema) (string, error) {
 	u, err := gourl.Parse(url)
 	if err != nil {
 		return "", errors.Errorf("cannot parse charm or bundle URL: %q", url)
@@ -571,7 +566,7 @@ func EnsureSchema(url string) (string, error) {
 		return url, nil
 	case Schema(""):
 		// If the schema is empty, we fall back to the default schema.
-		return DefaultSchema.Prefix(url), nil
+		return defaultSchema.Prefix(url), nil
 	default:
 		return "", errors.NotValidf("schema %q", u.Scheme)
 	}

--- a/url_test.go
+++ b/url_test.go
@@ -414,7 +414,7 @@ var ensureSchemaTests = []struct {
 func (s *URLSuite) TestInferURLNoDefaultSeries(c *gc.C) {
 	for i, t := range ensureSchemaTests {
 		c.Logf("%d: %s", i, t.input)
-		inferred, err := charm.EnsureSchema(t.input)
+		inferred, err := charm.EnsureSchema(t.input, charm.CharmHub)
 		if t.err != "" {
 			c.Assert(err, gc.ErrorMatches, t.err)
 			continue


### PR DESCRIPTION
The default schema that should be used depends on the controller that
juju is talking to. Therefore, it should not be specified as a
package-level public variable and instead should be explicitly provided
by the caller when calling EnsureSchema.