### PR TITLE
Resolve out of sync presence map

### DIFF
--- a/bundledatasrc.go
+++ b/bundledatasrc.go
@@ -31,9 +31,12 @@ func (fpm FieldPresenceMap) forField(fieldName string) FieldPresenceMap {
 		return nil
 	}
 
-	asMap, valid := v.(FieldPresenceMap)
-	if !valid {
-		panic(errors.Errorf("field map entry %q does not point to a nested field presence map", fieldName))
+	// Always returns a FieldPresenceMap even if the underlying type is empty.
+	// As the only way to interact with the map is through the use of the two
+	// methods, then it will allow you to walk over the map in a much saner way.
+	asMap, _ := v.(FieldPresenceMap)
+	if asMap == nil {
+		return FieldPresenceMap{}
 	}
 	return asMap
 }

--- a/overlay.go
+++ b/overlay.go
@@ -512,8 +512,8 @@ func resolveOverlayPresenceFields(base *BundleDataPart) {
 		}
 
 		presence := applications.forField(name)
-		// If the presence map contains scale, but doesn't containt num_units
-		// and if the app.Scale_ has be set to zero. We can then assume that a
+		// If the presence map contains scale, but doesn't contain num_units
+		// and if the app.Scale_ has been set to zero. We can then assume that a
 		// normalistion has occurred.
 		if presence.fieldPresent("scale") && !presence.fieldPresent("num_units") && app.Scale_ == 0 && app.NumUnits > 0 {
 			presence["num_units"] = presence["scale"]
@@ -534,6 +534,7 @@ func applyOverlay(base, overlay *BundleDataPart) error {
 		if base.Data.Applications == nil {
 			base.Data.Applications = make(map[string]*ApplicationSpec, len(overlay.Data.Applications))
 		}
+
 		fpm := overlay.PresenceMap.forField("applications")
 		for srcAppName, srcAppSpec := range overlay.Data.Applications {
 			// If the overlay map points to an empty object, delete

--- a/overlay.go
+++ b/overlay.go
@@ -423,14 +423,18 @@ func ReadAndMergeBundleData(sources ...BundleDataSource) (*BundleData, error) {
 	// Treat the first part as the base bundle
 	base := allParts[0]
 	if err := VerifyNoOverlayFieldsPresent(base.Data); err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	// Merge parts and resolve include directives
 	for index, part := range allParts {
+		// Resolve any re-writing of normalisation that could cause the presence
+		// field to be out of sync with the actual bundle representation.
+		resolveOverlayPresenceFields(part)
+
 		if index != 0 {
 			if err := applyOverlay(base, part); err != nil {
-				return nil, err
+				return nil, errors.Trace(err)
 			}
 		}
 
@@ -490,6 +494,33 @@ func ReadAndMergeBundleData(sources ...BundleDataSource) (*BundleData, error) {
 	return base.Data, nil
 }
 
+// resolveOverlayPresenceFields exists because we expose an internal bundle
+// representation of a type out to the consumers of the library. This means it
+// becomes very difficult to know what was re-written during the normalisation
+// phase, without telling downstream consumers.
+//
+// The following attempts to guess when a normalisation has occurred, but the
+// presence field map is out of sync with the new changes.
+func resolveOverlayPresenceFields(base *BundleDataPart) {
+	applications := base.PresenceMap.forField("applications")
+	if len(applications) == 0 {
+		return
+	}
+	for name, app := range base.Data.Applications {
+		if !applications.fieldPresent(name) {
+			continue
+		}
+
+		presence := applications.forField(name)
+		// If the presence map contains scale, but doesn't containt num_units
+		// and if the app.Scale_ has be set to zero. We can then assume that a
+		// normalistion has occurred.
+		if presence.fieldPresent("scale") && !presence.fieldPresent("num_units") && app.Scale_ == 0 && app.NumUnits > 0 {
+			presence["num_units"] = presence["scale"]
+		}
+	}
+}
+
 func applyOverlay(base, overlay *BundleDataPart) error {
 	if overlay == nil || len(overlay.PresenceMap) == 0 {
 		return nil
@@ -513,7 +544,7 @@ func applyOverlay(base, overlay *BundleDataPart) error {
 				continue
 			}
 
-			// if this is a new application just append it; otherwise
+			// If this is a new application just append it; otherwise
 			// recursively merge the two application specs.
 			dstAppSpec, defined := base.Data.Applications[srcAppName]
 			if !defined {

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -351,6 +351,88 @@ series: trusty
 	)
 }
 
+func (*bundleDataOverlaySuite) TestOverrideScale(c *gc.C) {
+	testBundleMergeResult(c, `
+applications:
+  apache2:
+    charm: cs:apache2-26
+    scale: 1
+---
+applications:
+  apache2:
+    scale: 2
+`, `
+applications:
+  apache2:
+    charm: cs:apache2-26
+    num_units: 2
+`,
+	)
+}
+
+func (*bundleDataOverlaySuite) TestOverrideScaleWithNumUnits(c *gc.C) {
+	// This shouldn't be allowed, but the code does, so we should test it!
+	// Notice that scale doesn't exist.
+	testBundleMergeResult(c, `
+applications:
+  apache2:
+    charm: cs:apache2-26
+    scale: 1
+---
+applications:
+  apache2:
+    num_units: 2
+`, `
+applications:
+  apache2:
+    charm: cs:apache2-26
+    num_units: 2
+`,
+	)
+}
+
+func (*bundleDataOverlaySuite) TestMultipleOverrideScale(c *gc.C) {
+	testBundleMergeResult(c, `
+applications:
+  apache2:
+    charm: cs:apache2-26
+    scale: 1
+---
+applications:
+  apache2:
+    scale: 50
+---
+applications:
+  apache2:
+    scale: 3
+`, `
+applications:
+  apache2:
+    charm: cs:apache2-26
+    num_units: 3
+`,
+	)
+}
+
+func (*bundleDataOverlaySuite) TestOverrideScaleWithZero(c *gc.C) {
+	testBundleMergeResult(c, `
+applications:
+  apache2:
+    charm: cs:apache2-26
+    scale: 1
+---
+applications:
+  apache2:
+    scale: 0
+`, `
+applications:
+  apache2:
+    charm: cs:apache2-26
+    num_units: 1
+`,
+	)
+}
+
 func (*bundleDataOverlaySuite) TestAddAndOverrideResourcesStorageDevicesAndBindings(c *gc.C) {
 	testBundleMergeResult(c, `
 applications:


### PR DESCRIPTION
The following attempts to keep the presence map in sync with the actual
data after normalization. During a normalization "scale" is swapped
out for "num_units". This is fine, except when it comes to overlays you
now don't know if scale or num_units was used for the overlays and
subsequent scale calls are now not used.

This is actually a problem with the library itself. There should be an
internal representation of a bundle that carries all this important
information, which should include schemas etc. At the very end of the
reading/parsing process, we should hand back a clean version of that
charm/bundle. That way we can make the bundle grow organically without
the requirement of so many hacks.

The code is simple, detect and resolve a normalization and just insert
the right value into the presence map before applying an overlay.

-----

Bug: https://bugs.launchpad.net/juju/+bug/1884465