### PR TITLE
Do not set an application series to kubernetes if not specified.

### DIFF
--- a/bundledata.go
+++ b/bundledata.go
@@ -56,9 +56,8 @@ func (lbd *legacyBundleData) setBundleData(bd *BundleData) error {
 			app.Scale_ = 0
 			lbd.Applications[appName] = app
 		}
-		// // Kubernetes bundles default to series "kubernetes".
+		// Kubernetes bundles default to series "kubernetes".
 		if lbd.Type == kubernetes && app.Series == "" {
-			app.Series = kubernetes
 			lbd.Applications[appName] = app
 		}
 		// Non-Kubernetes bundles do not use the placement attribute.

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -806,7 +806,6 @@ applications:
 		Applications: map[string]*charm.ApplicationSpec{
 			"mariadb": {
 				Charm:    "cs:mariadb-k8s-10",
-				Series:   "kubernetes",
 				To:       []string{"foo=bar"},
 				NumUnits: 2,
 			},
@@ -818,7 +817,6 @@ applications:
 			},
 			"redis": {
 				Charm:    "cs:redis-k8s-10",
-				Series:   "kubernetes",
 				To:       []string{"foo=baz"},
 				NumUnits: 3,
 			}},

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -136,11 +136,9 @@ bundle: kubernetes
 applications:
   mysql:
     charm: cs:mysql
-    series: kubernetes
     num_units: 1
   wordpress:
     charm: cs:wordpress
-    series: kubernetes
     num_units: 2
 relations:
 - - wordpress:db
@@ -207,12 +205,10 @@ bundle: kubernetes
 applications:
   mysql:
     charm: cs:mysql
-    series: kubernetes
     num_units: 1
   wordpress:
     charm: cs:wordpress
     channel: edge
-    series: kubernetes
     num_units: 2
     options:
       foo: bar


### PR DESCRIPTION
Let juju determine what the series should be for kubernetes charms in a bundle.  The default is no longer kubernetes with the addition of sidecar charms.  See LP1928796.  Causes issues with local sidecar charms.