### PR TITLE
Charm+format: Series always dictates a format v1

### DIFF
--- a/charm_test.go
+++ b/charm_test.go
@@ -133,8 +133,15 @@ func (FormatSuite) TestFormatV1NoManifest(c *gc.C) {
 }
 
 func (FormatSuite) TestFormatV1Manifest(c *gc.C) {
-	_, err := charm.ReadCharm(charmDirPath(c, "format-seriesmanifest"))
-	c.Assert(err, gc.ErrorMatches, `metadata v2 manifest.yaml with series slice not valid`)
+	ch, err := charm.ReadCharm(charmDirPath(c, "format-seriesmanifest"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ch, gc.NotNil)
+
+	err = charm.CheckMeta(ch)
+	c.Assert(err, jc.ErrorIsNil)
+
+	f := charm.MetaFormat(ch)
+	c.Assert(f, gc.Equals, charm.FormatV1)
 }
 
 func (FormatSuite) TestFormatV2ContainersNoManifest(c *gc.C) {

--- a/meta.go
+++ b/meta.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/os/v2"
@@ -888,12 +889,7 @@ func (m Meta) checkV2(reasons []FormatSelectionReason) error {
 }
 
 func hasReason(reasons []FormatSelectionReason, reason FormatSelectionReason) bool {
-	for _, v := range reasons {
-		if v == reason {
-			return true
-		}
-	}
-	return false
+	return set.NewStrings(reasons...).Contains(reason)
 }
 
 func reservedName(name string) (reserved bool, reason string) {


### PR DESCRIPTION
If a charm contains a series, even with the presence of manifest.yaml
then that charm is a v1. This is a damn shame, because our modelling
becomes weaker inside of juju, but it seems like charmcraft doesn't
restrict uploads with series and manifests.

The fix is a bit more involved, as we can use a set.String for better
look up times. It also removes duplications with in the selection
reasons.