### PR TITLE
Add Revision to ApplicationSpec.

### DIFF
--- a/bundledata.go
+++ b/bundledata.go
@@ -92,6 +92,9 @@ type ApplicationSpec struct {
 	// remote charm.
 	Channel string `bson:"channel,omitempty" yaml:"channel,omitempty" json:"channel,omitempty"`
 
+	// Revision describes the revision of the charm to use when deploying.
+	Revision *int `bson:"revision,omitempty" yaml:"revision,omitempty" json:"revision,omitempty"`
+
 	// Series is the series to use when deploying a local charm,
 	// if the charm does not specify a default or the default
 	// is not the desired value.
@@ -632,6 +635,24 @@ func (verifier *bundleDataVerifier) verifyApplications() {
 			}
 		} else if curl, err = ParseURL(app.Charm); err != nil {
 			verifier.addErrorf("invalid charm URL in application %q: %v", name, err)
+		}
+
+		// Check the revision.
+		if curl != nil {
+			if CharmHub.Matches(curl.Schema) && curl.Revision != -1 {
+				verifier.addErrorf("cannot specify revision in %q, please use revision", curl.String())
+			}
+			if app.Revision != nil {
+				if CharmStore.Matches(curl.Schema) && curl.Revision != -1 && curl.Revision != *app.Revision {
+					verifier.addErrorf("application %q has 2 different revisions specified, please choose 1", name)
+				}
+				if CharmHub.Matches(curl.Schema) && app.Channel == "" {
+					verifier.addErrorf("application %q with a revision requires a channel for future upgrades, please use channel", name)
+				}
+				if *app.Revision < 0 {
+					verifier.addErrorf("the revision for application %q must be zero or greater", name)
+				}
+			}
 		}
 
 		// Check the Series.

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -319,7 +319,29 @@ applications:
 			},
 		},
 	},
+}, {
+	about: "charm revision and channel",
+	data: `
+applications:
+    wordpress:
+      charm: "wordpress"
+      revision: 5
+      channel: edge
+      num_units: 1
+`,
+	expectedBD: &charm.BundleData{
+		Applications: map[string]*charm.ApplicationSpec{
+			"wordpress": {
+				Charm:    "wordpress",
+				Revision: &wordpressRevisionParseTest,
+				Channel:  "edge",
+				NumUnits: 1,
+			},
+		},
+	},
 }}
+
+var wordpressRevisionParseTest = 5
 
 func (*bundleDataSuite) TestParse(c *gc.C) {
 	for i, test := range parseTests {
@@ -1315,6 +1337,53 @@ machines:
 `,
 	errors: []string{
 		`too many units specified in unit placement for application "test"`,
+	},
+}, {
+	about: "charmhub charm revision and no channel",
+	data: `
+applications:
+    wordpress:
+      charm: "wordpress"
+      revision: 5
+      num_units: 1
+`,
+	errors: []string{
+		`application "wordpress" with a revision requires a channel for future upgrades, please use channel`,
+	},
+}, {
+	about: "charmhub charm revision in charm url",
+	data: `
+applications:
+    wordpress:
+      charm: "wordpress-9"
+      num_units: 1
+`,
+	errors: []string{
+		`cannot specify revision in "ch:wordpress-9", please use revision`,
+	},
+}, {
+	about: "charmstore charm url revision does not match revision",
+	data: `
+applications:
+    wordpress:
+      charm: "cs:wordpress-9"
+      revision: 5
+      num_units: 1
+`,
+	errors: []string{
+		`application "wordpress" has 2 different revisions specified, please choose 1`,
+	},
+}, {
+	about: "charmstore charm url revision value less than 0",
+	data: `
+applications:
+    wordpress:
+      charm: "cs:wordpress"
+      revision: -5
+      num_units: 1
+`,
+	errors: []string{
+		`the revision for application "wordpress" must be zero or greater`,
 	},
 }}
 


### PR DESCRIPTION
To be used as a bundle equivalent of deploy by --revision with charmhub charms.
For charmstore charms, the revision can be used in the charm url or revision.