### PR TITLE
Merge v8 into v9

### DIFF
--- a/hooks/hooks.go
+++ b/hooks/hooks.go
@@ -1,7 +1,7 @@
 // Copyright 2013 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENCE file for details.
 
-// hooks provides types and constants that define the hooks known to Juju.
+// Package hooks provides types and constants that define the hooks known to Juju.
 package hooks
 
 // Kind enumerates the different kinds of hooks that exist.
@@ -11,6 +11,7 @@ const (
 	// None of these hooks are ever associated with a relation; each of them
 	// represents a change to the state of the unit as a whole. The values
 	// themselves are all valid hook names.
+
 	Install               Kind = "install"
 	Start                 Kind = "start"
 	ConfigChanged         Kind = "config-changed"
@@ -26,11 +27,13 @@ const (
 	UpdateStatus          Kind = "update-status"
 	PreSeriesUpgrade      Kind = "pre-series-upgrade"
 	PostSeriesUpgrade     Kind = "post-series-upgrade"
+	SecretRotate          Kind = "secret-rotate"
 
 	// These hooks require an associated relation, and the name of the relation
 	// unit whose change triggered the hook. The hook file names that these
 	// kinds represent will be prefixed by the relation name; for example,
 	// "db-relation-joined".
+
 	RelationCreated  Kind = "relation-created"
 	RelationJoined   Kind = "relation-joined"
 	RelationChanged  Kind = "relation-changed"
@@ -39,11 +42,13 @@ const (
 	// This hook requires an associated relation. The represented hook file name
 	// will be prefixed by the relation name, just like the other Relation* Kind
 	// values.
+
 	RelationBroken Kind = "relation-broken"
 
 	// These hooks require an associated storage. The hook file names that these
 	// kinds represent will be prefixed by the storage name; for example,
 	// "shared-fs-storage-attached".
+
 	StorageAttached  Kind = "storage-attached"
 	StorageDetaching Kind = "storage-detaching"
 
@@ -51,6 +56,7 @@ const (
 	// whose change triggered the hook. The hook file names that these
 	// kinds represent will be prefixed by the workload/container name; for example,
 	// "mycontainer-pebble-ready".
+
 	PebbleReady Kind = "pebble-ready"
 )
 
@@ -105,14 +111,14 @@ func StorageHooks() []Kind {
 	return hooks
 }
 
-var workloadkHooks = []Kind{
+var workloadHooks = []Kind{
 	PebbleReady,
 }
 
 // WorkloadHooks returns all known container hook kinds.
 func WorkloadHooks() []Kind {
-	hooks := make([]Kind, len(workloadkHooks))
-	copy(hooks, workloadkHooks)
+	hooks := make([]Kind, len(workloadHooks))
+	copy(hooks, workloadHooks)
 	return hooks
 }
 
@@ -138,6 +144,19 @@ func (kind Kind) IsStorage() bool {
 func (kind Kind) IsWorkload() bool {
 	switch kind {
 	case PebbleReady:
+		return true
+	}
+	return false
+}
+
+var secretHooks = []Kind{
+	SecretRotate,
+}
+
+// IsSecret returns whether the Kind represents a secret hook.
+func (kind Kind) IsSecret() bool {
+	switch kind {
+	case SecretRotate:
 		return true
 	}
 	return false

--- a/hooks/hooks_test.go
+++ b/hooks/hooks_test.go
@@ -1,0 +1,52 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package hooks
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+var _ = gc.Suite(&HooksSuite{})
+
+type HooksSuite struct{}
+
+func (s *HooksSuite) TestIsRelation(c *gc.C) {
+	for _, h := range relationHooks {
+		c.Assert(h.IsRelation(), jc.IsTrue)
+	}
+	for _, h := range unitHooks {
+		c.Assert(h.IsRelation(), jc.IsFalse)
+	}
+}
+
+func (s *HooksSuite) TestIsStorage(c *gc.C) {
+	for _, h := range storageHooks {
+		c.Assert(h.IsStorage(), jc.IsTrue)
+	}
+	for _, h := range unitHooks {
+		c.Assert(h.IsStorage(), jc.IsFalse)
+	}
+}
+
+func (s *HooksSuite) TestIsWorkload(c *gc.C) {
+	for _, h := range workloadHooks {
+		c.Assert(h.IsWorkload(), jc.IsTrue)
+	}
+	for _, h := range unitHooks {
+		c.Assert(h.IsWorkload(), jc.IsFalse)
+	}
+}
+
+func (s *HooksSuite) TestIsSecret(c *gc.C) {
+	for _, h := range secretHooks {
+		c.Assert(h.IsSecret(), jc.IsTrue)
+	}
+	for _, h := range unitHooks {
+		if h == SecretRotate {
+			continue
+		}
+		c.Assert(h.IsSecret(), jc.IsFalse)
+	}
+}

--- a/hooks/package_test.go
+++ b/hooks/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package hooks_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/meta.go
+++ b/meta.go
@@ -904,6 +904,7 @@ func reservedName(charmName, endpointName string) (reserved bool, reason string)
 	}
 	return false, ""
 }
+
 func parseRelations(relations interface{}, role RelationRole) map[string]Relation {
 	if relations == nil {
 		return nil


### PR DESCRIPTION
Merge from v8 branch to bring the following into v9:
- #380 from wallyworld/add-secret-hook
- #377 from SimonRichardson/series-is-always-format-v1
- #376 from SimonRichardson/format-v2-containers
- #375 from SimonRichardson/format-progressive-enhancement
- #374 from SimonRichardson/format-selection-reasons

Trivial conflict resolution in _meta.go_