### PR TITLE
Update to use utils v3

### DIFF
--- a/base.go
+++ b/base.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/os/v2"
-	"github.com/juju/utils/v2/arch"
+	"github.com/juju/utils/v3/arch"
 )
 
 // Base represents an OS/Channel.

--- a/base_test.go
+++ b/base_test.go
@@ -7,12 +7,13 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/juju/charm/v9"
 	"github.com/juju/os/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v2/arch"
+	"github.com/juju/utils/v3/arch"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/charm/v9"
 )
 
 type baseSuite struct {

--- a/bundlearchive.go
+++ b/bundlearchive.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 
-	ziputil "github.com/juju/utils/v2/zip"
+	ziputil "github.com/juju/utils/v3/zip"
 )
 
 type BundleArchive struct {

--- a/bundledata.go
+++ b/bundledata.go
@@ -18,7 +18,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/mgo/v2/bson"
 	"github.com/juju/names/v4"
-	"github.com/juju/utils/v2/keyvalues"
+	"github.com/juju/utils/v3/keyvalues"
 )
 
 const kubernetes = "kubernetes"

--- a/charm_test.go
+++ b/charm_test.go
@@ -11,12 +11,13 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/juju/charm/v9"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v2/fs"
+	"github.com/juju/utils/v3/fs"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
+
+	"github.com/juju/charm/v9"
 )
 
 type CharmSuite struct {

--- a/charmarchive.go
+++ b/charmarchive.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	ziputil "github.com/juju/utils/v2/zip"
+	ziputil "github.com/juju/utils/v3/zip"
 )
 
 // CharmArchive type encapsulates access to data and operations

--- a/charmdir_test.go
+++ b/charmdir_test.go
@@ -15,13 +15,14 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/juju/charm/v9"
 	"github.com/juju/collections/set"
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v2"
+	"github.com/juju/utils/v3"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/charm/v9"
 )
 
 type CharmDirSuite struct {

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,8 @@
 module github.com/juju/charm/v9
 
 require (
-	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271
 	github.com/juju/errors v0.0.0-20200330140219-3fe23663418f
-	github.com/juju/gojsonpointer v0.0.0-20150204194629-afe8b77aa08f // indirect
-	github.com/juju/gojsonreference v0.0.0-20150204194633-f0d24ac5ee33 // indirect
 	github.com/juju/gojsonschema v0.0.0-20150312170016-e1ad140384f2
 	github.com/juju/loggo v0.0.0-20200526014432-9ce3a2e09b5e
 	github.com/juju/mgo/v2 v2.0.0-20210302023703-70d5d206e208
@@ -13,13 +10,29 @@ require (
 	github.com/juju/os/v2 v2.0.0
 	github.com/juju/schema v0.0.0-20160301111646-1e25943f8c6f
 	github.com/juju/testing v0.0.0-20210302031854-2c7ee8570c07
-	github.com/juju/utils/v2 v2.0.0-20200923005554-4646bfea2ef1
+	github.com/juju/utils/v3 v3.0.0-20220130232349-cd7ecef0e94a
 	github.com/juju/version/v2 v2.0.0-20211007103408-2e8da085dc23
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
-	github.com/stretchr/testify v1.6.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	gopkg.in/gobwas/glob.v0 v0.2.3
 	gopkg.in/yaml.v2 v2.4.0
 )
 
-go 1.16
+require (
+	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c // indirect
+	github.com/juju/gojsonpointer v0.0.0-20150204194629-afe8b77aa08f // indirect
+	github.com/juju/gojsonreference v0.0.0-20150204194633-f0d24ac5ee33 // indirect
+	github.com/juju/retry v0.0.0-20180821225755-9058e192b216 // indirect
+	github.com/juju/utils/v2 v2.0.0-20200923005554-4646bfea2ef1 // indirect
+	github.com/juju/version v0.0.0-20191219164919-81c1be00b9a6 // indirect
+	github.com/kr/pretty v0.2.1 // indirect
+	github.com/kr/text v0.2.0 // indirect
+	github.com/stretchr/testify v1.6.1 // indirect
+	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a // indirect
+	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 // indirect
+	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 // indirect
+	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 // indirect
+)
+
+go 1.17

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/juju/utils v0.0.0-20200116185830-d40c2fe10647 h1:wQpkHVbIIpz1PCcLYku9
 github.com/juju/utils v0.0.0-20200116185830-d40c2fe10647/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/utils/v2 v2.0.0-20200923005554-4646bfea2ef1 h1:3y/lDs71xT7YIYtlfODytPNGEF4XVvUUZhFe3s5kkQQ=
 github.com/juju/utils/v2 v2.0.0-20200923005554-4646bfea2ef1/go.mod h1:fdlDtQlzundleLLz/ggoYinEt/LmnrpNKcNTABQATNI=
+github.com/juju/utils/v3 v3.0.0-20220130232349-cd7ecef0e94a h1:5ZWDCeCF0RaITrZGemzmDFIhjR/MVSvBUqgSyaeTMbE=
+github.com/juju/utils/v3 v3.0.0-20220130232349-cd7ecef0e94a/go.mod h1:LzwbbEN7buYjySp4nqnti6c6olSqRXUk6RkbSUUP1n8=
 github.com/juju/version v0.0.0-20161031051906-1f41e27e54f2/go.mod h1:kE8gK5X0CImdr7qpSKl3xB2PmpySSmfj7zVbkZFs81U=
 github.com/juju/version v0.0.0-20180108022336-b64dbd566305/go.mod h1:kE8gK5X0CImdr7qpSKl3xB2PmpySSmfj7zVbkZFs81U=
 github.com/juju/version v0.0.0-20191219164919-81c1be00b9a6 h1:nrqc9b4YKpKV4lPI3GPPFbo5FUuxkWxgZE2Z8O4lgaw=

--- a/manifest.go
+++ b/manifest.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/schema"
-	"github.com/juju/utils/v2/arch"
+	"github.com/juju/utils/v3/arch"
 	"gopkg.in/yaml.v2"
 )
 

--- a/meta.go
+++ b/meta.go
@@ -18,7 +18,7 @@ import (
 	"github.com/juju/os/v2"
 	"github.com/juju/os/v2/series"
 	"github.com/juju/schema"
-	"github.com/juju/utils/v2"
+	"github.com/juju/utils/v3"
 	"github.com/juju/version/v2"
 	"gopkg.in/yaml.v2"
 

--- a/resource/fingerprint.go
+++ b/resource/fingerprint.go
@@ -8,7 +8,7 @@ import (
 	"io"
 
 	"github.com/juju/errors"
-	"github.com/juju/utils/v2/hash"
+	"github.com/juju/utils/v3/hash"
 )
 
 var newHash, validateSum = hash.SHA384()


### PR DESCRIPTION
The `juju/utils` version is bumped to v3.