### PR TITLE
[JUJU-1019] Update ParseChannel.

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -85,7 +85,7 @@ func MakePermissiveChannel(track, risk, branch string) Channel {
 // ParseChannel parses a string representing a store channel.
 func ParseChannel(s string) (Channel, error) {
 	if s == "" {
-		return Channel{}, errors.Errorf("channel cannot be empty")
+		return Channel{}, errors.NotValidf("empty channel")
 	}
 
 	p := strings.Split(s, "/")

--- a/channel_test.go
+++ b/channel_test.go
@@ -28,7 +28,7 @@ func (s channelSuite) TestParseChannelNormalize(c *gc.C) {
 	}{{
 		Name:        "empty",
 		Value:       "",
-		ExpectedErr: "channel cannot be empty",
+		ExpectedErr: "empty channel not valid",
 	}, {
 		Name:        "empty components",
 		Value:       "//",


### PR DESCRIPTION
Return a typed NotValid if a channel is empty. Allows deploy to get a typed error when trying to find a charm vs a bundle.

Related to https://bugs.launchpad.net/juju/+bug/1969929