### PR TITLE
Updated lxd profile for non nil init.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juju/charm/v9
 
-go 1.17
+go 1.18
 
 require (
 	github.com/juju/collections v1.0.0

--- a/lxdprofile.go
+++ b/lxdprofile.go
@@ -27,9 +27,13 @@ type LXDProfile struct {
 	Devices     map[string]map[string]string `json:"devices" yaml:"devices"`
 }
 
-// NewLXDProfile creates a LXDProfile
+// NewLXDProfile creates a LXDProfile with the internal data structures
+// initialised  to non nil values.
 func NewLXDProfile() *LXDProfile {
-	return &LXDProfile{}
+	return &LXDProfile{
+		Config:  map[string]string{},
+		Devices: map[string]map[string]string{},
+	}
 }
 
 // ReadLXDProfile reads in a LXDProfile from a charm's lxd-profile.yaml.
@@ -40,11 +44,11 @@ func ReadLXDProfile(r io.Reader) (*LXDProfile, error) {
 	if err != nil {
 		return nil, err
 	}
-	var profile LXDProfile
-	if err := yaml.Unmarshal(data, &profile); err != nil {
+	profile := NewLXDProfile()
+	if err := yaml.Unmarshal(data, profile); err != nil {
 		return nil, errors.Annotate(err, "failed to unmarshall lxd-profile.yaml")
 	}
-	return &profile, nil
+	return profile, nil
 }
 
 // ValidateConfigDevices validates the Config and Devices properties of the LXDProfile.

--- a/lxdprofile_test.go
+++ b/lxdprofile_test.go
@@ -136,7 +136,7 @@ func (s *ProfileSuite) TestLXDProfileEmptyFile(c *gc.C) {
 	profile, err := charm.ReadLXDProfile(strings.NewReader(`
  
 `))
-	c.Assert(profile, gc.DeepEquals, &charm.LXDProfile{})
+	c.Assert(profile, gc.DeepEquals, charm.NewLXDProfile())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(profile.Empty(), jc.IsTrue)
 	c.Assert(profile.ValidateConfigDevices(), jc.ErrorIsNil)


### PR DESCRIPTION
- Changes the lxdprofile init to have non nil maps for safety and to
  conform with the other encoding that happens within Juju.
- Updated package to go 1.18