### PR TITLE
Allow series in kubernetes bundles.

### DIFF
--- a/bundledata.go
+++ b/bundledata.go
@@ -544,9 +544,6 @@ func (bd *BundleData) verifyBundle(
 		verifier.addErrorf("bundle has an invalid type %q", bd.Type)
 	}
 	if bd.Type == kubernetes {
-		if bd.Series != "" {
-			verifier.addErrorf("bundle series not valid for Kubernetes bundles")
-		}
 		if len(bd.Machines) > 0 {
 			verifier.addErrorf("bundle machines not valid for Kubernetes bundles")
 		}
@@ -679,14 +676,8 @@ func (verifier *bundleDataVerifier) verifyApplications() {
 		if curl != nil && curl.Series != "" && app.Series != "" && curl.Series != app.Series {
 			verifier.addErrorf("the charm URL for application %q has a series which does not match, please remove the series from the URL", name)
 		}
-		if verifier.bd.Type == kubernetes {
-			if app.Series != "" && app.Series != kubernetes {
-				verifier.addErrorf("series for application %q not valid for Kubernetes bundles", name)
-			}
-		} else {
-			if app.Series != "" && !IsValidSeries(app.Series) {
-				verifier.addErrorf("application %q declares an invalid series %q", name, app.Series)
-			}
+		if app.Series != "" && !IsValidSeries(app.Series) {
+			verifier.addErrorf("application %q declares an invalid series %q", name, app.Series)
 		}
 		// Check the Constraints.
 		if err := verifier.verifyConstraints(app.Constraints); err != nil {

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -920,10 +920,8 @@ applications:
         to: ["foo"]
 `
 	errors := []string{
-		"bundle series not valid for Kubernetes bundles",
 		`expected "key=value", got "foo" for application "hadoop"`,
 		`bundle machines not valid for Kubernetes bundles`,
-		`series for application "mariadb" not valid for Kubernetes bundles`,
 		`too many placement directives for application "casandra"`,
 	}
 


### PR DESCRIPTION
Kubernetes bundles that have sidecar charms need to be able to specify series.
The responsibility rests on juju to ensure podspec charms that specify series kubernetes in metadata.yaml use it.