### PR TITLE
[JUJU-1691] Url parse first part can be series

### DIFF
--- a/url.go
+++ b/url.go
@@ -118,8 +118,8 @@ func ValidateSeries(series string) error {
 
 // IsValidArchitecture reports whether the architecture is a valid architecture
 // in charm or bundle URLs.
-func IsValidArchitecture(arch string) bool {
-	return validArch.MatchString(arch)
+func IsValidArchitecture(architecture string) bool {
+	return validArch.MatchString(architecture) && arch.IsSupportedArch(architecture)
 }
 
 // ValidateArchitecture returns an error if the given architecture is invalid.

--- a/url.go
+++ b/url.go
@@ -196,7 +196,6 @@ func MustParseURL(url string) *URL {
 func ParseURL(url string) (*URL, error) {
 	// Check if we're dealing with a v1 or v2 URL.
 	u, err := gourl.Parse(url)
-
 	if err != nil {
 		return nil, errors.Errorf("cannot parse charm or bundle URL: %q", url)
 	}

--- a/url.go
+++ b/url.go
@@ -554,7 +554,7 @@ func parseIdentifierURL(url *gourl.URL) (*URL, error) {
 	// Optional
 	if r.Architecture != "" {
 		if err := ValidateArchitecture(r.Architecture); err != nil {
-			return nil, errors.Annotatef(err, "cannot parse architecture/series in URL %q", url)
+			return nil, errors.Annotatef(err, "in URL %q", url)
 		}
 	}
 	if r.Series != "" {

--- a/url.go
+++ b/url.go
@@ -529,13 +529,17 @@ func parseIdentifierURL(url *gourl.URL) (*URL, error) {
 	switch len(parts) {
 	case 3:
 		r.Architecture, r.Series, nameRev = parts[0], parts[1], parts[2]
+
+		if err := ValidateArchitecture(r.Architecture); err != nil {
+			return nil, errors.Annotatef(err, "in URL %q", url)
+		}
 	case 2:
 		// Since both the architecture and series are optional,
 		// the first part can be either architecture or series.
-		// To differentiate between them, we use the supported
-		// architecture list defined in juju/utils/arch
+		// To differentiate between them, we go ahead and try to
+		// validate the first part as an architecture to decide.
 
-		if arch.IsSupportedArch(parts[0]) {
+		if err := ValidateArchitecture(parts[0]); err == nil {
 			r.Architecture, nameRev = parts[0], parts[1]
 		} else {
 			r.Series, nameRev = parts[0], parts[1]
@@ -552,11 +556,6 @@ func parseIdentifierURL(url *gourl.URL) (*URL, error) {
 	}
 
 	// Optional
-	if r.Architecture != "" {
-		if err := ValidateArchitecture(r.Architecture); err != nil {
-			return nil, errors.Annotatef(err, "in URL %q", url)
-		}
-	}
 	if r.Series != "" {
 		if err := ValidateSeries(r.Series); err != nil {
 			return nil, errors.Annotatef(err, "in URL %q", url)

--- a/url.go
+++ b/url.go
@@ -554,12 +554,12 @@ func parseIdentifierURL(url *gourl.URL) (*URL, error) {
 	// Optional
 	if r.Architecture != "" {
 		if err := ValidateArchitecture(r.Architecture); err != nil {
-			return nil, errors.Annotatef(err, "cannot parse architecture in URL %q", url)
+			return nil, errors.Annotatef(err, "cannot parse architecture/series in URL %q", url)
 		}
 	}
 	if r.Series != "" {
 		if err := ValidateSeries(r.Series); err != nil {
-			return nil, errors.Annotatef(err, "cannot parse series in URL %q", url)
+			return nil, errors.Annotatef(err, "cannot parse architecture/series in URL %q", url)
 		}
 	}
 

--- a/url.go
+++ b/url.go
@@ -559,7 +559,7 @@ func parseIdentifierURL(url *gourl.URL) (*URL, error) {
 	}
 	if r.Series != "" {
 		if err := ValidateSeries(r.Series); err != nil {
-			return nil, errors.Annotatef(err, "cannot parse architecture/series in URL %q", url)
+			return nil, errors.Annotatef(err, "in URL %q", url)
 		}
 	}
 

--- a/url_test.go
+++ b/url_test.go
@@ -251,10 +251,10 @@ var urlTests = []struct {
 	exact: "ch:arm64/name",
 }, {
 	s:   "ch:~user/name",
-	err: `cannot parse architecture/series in URL "ch:~user/name": series name "~user" not valid`,
+	err: `in URL "ch:~user/name": series name "~user" not valid`,
 }, {
 	s:   "ch:~user/series/name-0",
-	err: `cannot parse architecture/series in URL "ch:~user/series/name-0": architecture name "~user" not valid`,
+	err: `in URL "ch:~user/series/name-0": architecture name "~user" not valid`,
 }, {
 	s:   "ch:nam-!e",
 	err: `cannot parse name and/or revision in URL "ch:nam-!e": name "nam-!e" not valid`,

--- a/url_test.go
+++ b/url_test.go
@@ -246,9 +246,9 @@ var urlTests = []struct {
 	s:   "ch:amd64/istio-gateway-74",
 	url: &charm.URL{"ch", "", "istio-gateway", 74, "", "amd64"},
 }, {
-	s:     "ch:arch/name",
-	url:   &charm.URL{"ch", "", "name", -1, "", "arch"},
-	exact: "ch:arch/name",
+	s:     "ch:arm64/name",
+	url:   &charm.URL{"ch", "", "name", -1, "", "arm64"},
+	exact: "ch:arm64/name",
 }, {
 	s:   "ch:~user/name",
 	err: `cannot parse architecture in URL "ch:~user/name": architecture name "~user" not valid`,

--- a/url_test.go
+++ b/url_test.go
@@ -240,6 +240,12 @@ var urlTests = []struct {
 	s:   "ch:name-1",
 	url: &charm.URL{"ch", "", "name", 1, "", ""},
 }, {
+	s:   "ch:focal/istio-gateway-74",
+	url: &charm.URL{"ch", "", "istio-gateway", 74, "focal", ""},
+}, {
+	s:   "ch:amd64/istio-gateway-74",
+	url: &charm.URL{"ch", "", "istio-gateway", 74, "", "amd64"},
+}, {
 	s:     "ch:arch/name",
 	url:   &charm.URL{"ch", "", "name", -1, "", "arch"},
 	exact: "ch:arch/name",

--- a/url_test.go
+++ b/url_test.go
@@ -251,10 +251,10 @@ var urlTests = []struct {
 	exact: "ch:arm64/name",
 }, {
 	s:   "ch:~user/name",
-	err: `cannot parse architecture in URL "ch:~user/name": architecture name "~user" not valid`,
+	err: `cannot parse architecture/series in URL "ch:~user/name": series name "~user" not valid`,
 }, {
 	s:   "ch:~user/series/name-0",
-	err: `cannot parse architecture in URL "ch:~user/series/name-0": architecture name "~user" not valid`,
+	err: `cannot parse architecture/series in URL "ch:~user/series/name-0": architecture name "~user" not valid`,
 }, {
 	s:   "ch:nam-!e",
 	err: `cannot parse name and/or revision in URL "ch:nam-!e": name "nam-!e" not valid`,

--- a/url_test.go
+++ b/url_test.go
@@ -224,9 +224,9 @@ var urlTests = []struct {
 	exact: "local:foo",
 	url:   &charm.URL{"local", "", "foo", -1, "", ""},
 }, {
-	s:     "arch/series/bar",
-	url:   &charm.URL{"ch", "", "bar", -1, "series", "arch"},
-	exact: "ch:arch/series/bar",
+	s:     "arm64/series/bar",
+	url:   &charm.URL{"ch", "", "bar", -1, "series", "arm64"},
+	exact: "ch:arm64/series/bar",
 }, {
 	s:   "cs:foo/~blah",
 	err: `cannot parse URL $URL: name "~blah" not valid`,

--- a/url_test.go
+++ b/url_test.go
@@ -461,6 +461,10 @@ var validTests = []struct {
 	{charm.IsValidSeries, "precise-1", false},
 	{charm.IsValidSeries, "precise1", true},
 	{charm.IsValidSeries, "pre-c1se", false},
+
+	{charm.IsValidArchitecture, "amd64", true},
+	{charm.IsValidArchitecture, "~amd64", false},
+	{charm.IsValidArchitecture, "not-an-arch", false},
 }
 
 func (s *URLSuite) TestValidCheckers(c *gc.C) {


### PR DESCRIPTION
#### Description

This change fixes the bug in the `charm.ParseURL`, where the first part of an identifier URL is assumed to be the architecture, whereas it can also be the series. As a result:

`ch:focal/istio-gateway-74` is parsed as `{Schema:"ch" User: "" Name:"istio-gateway" Revision:74 Series: "" Architecture:"focal"}`

#### QA Steps

I added the case above in the ParseURL unit tests, along with the `ch:amd64/istio-gateway-74` case. You may just run that:

```
go test -gocheck.v -gocheck.f TestParseURL
```
