### PR TITLE
[JUJU-4353] Remove base & series check

### DIFF
--- a/bundledata.go
+++ b/bundledata.go
@@ -549,7 +549,6 @@ func (bd *BundleData) verifyBundle(
 			verifier.addErrorf("bundle declares an invalid base %q", bd.DefaultBase)
 		}
 	}
-	verifier.verifyBaseAndSeriesNotMixed()
 	verifier.verifySaas()
 	verifier.verifyMachines()
 	verifier.verifyApplications()
@@ -577,45 +576,6 @@ var (
 	validOfferName         = regexp.MustCompile("^" + names.ApplicationSnippet + "$")
 	validOfferEndpointName = regexp.MustCompile("^" + names.RelationSnippet + "$")
 )
-
-func (verifier *bundleDataVerifier) verifyBaseAndSeriesNotMixed() {
-	var (
-		basePresent   bool
-		seriesPresent bool
-	)
-	if verifier.bd.DefaultBase != "" {
-		basePresent = true
-	}
-	if verifier.bd.Series != "" {
-		seriesPresent = true
-	}
-	for _, m := range verifier.bd.Machines {
-		if m == nil {
-			continue
-		}
-		if m.Base != "" {
-			basePresent = true
-		}
-		if m.Series != "" {
-			seriesPresent = true
-		}
-	}
-	for _, app := range verifier.bd.Applications {
-		if app == nil {
-			continue
-		}
-		if app.Base != "" {
-			basePresent = true
-		}
-		if app.Series != "" {
-			seriesPresent = true
-		}
-	}
-
-	if basePresent && seriesPresent {
-		verifier.addErrorf("bundle cannot declare both bases and series")
-	}
-}
 
 func (verifier *bundleDataVerifier) verifySaas() {
 	for name, saas := range verifier.bd.Saas {

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -526,7 +526,6 @@ relations:
 	errors: []string{
 		`bundle declares an invalid series "9wrong"`,
 		`bundle declares an invalid base "invalidbase"`,
-		`bundle cannot declare both bases and series`,
 		`invalid offer URL "!some-bogus/url" for SAAS apache2`,
 		`invalid storage name "no_underscores" in application "ceph"`,
 		`invalid storage "invalid-storage" in application "ceph-osd": bad storage constraint`,


### PR DESCRIPTION
We have changed our direction slightly and now bundles can provide both series and bases, provided they match.

It will be left to the client to validate they match, since this library treats bases too abstractly to be able to compare series and bases

This is done to we can smoothly transition bundles over to using bases, so we can remove series without breaking every bundle