### PR TITLE
Add new hook types for Pebble Notices (JU048)

### DIFF
--- a/hooks/hooks.go
+++ b/hooks/hooks.go
@@ -61,7 +61,7 @@ const (
 	// "mycontainer-pebble-ready".
 
 	PebbleChangeUpdated Kind = "pebble-change-updated"
-	PebbleClientNotice  Kind = "pebble-client-notice"
+	PebbleCustomNotice  Kind = "pebble-custom-notice"
 	PebbleReady         Kind = "pebble-ready"
 )
 
@@ -118,7 +118,7 @@ func StorageHooks() []Kind {
 
 var workloadHooks = []Kind{
 	PebbleChangeUpdated,
-	PebbleClientNotice,
+	PebbleCustomNotice,
 	PebbleReady,
 }
 
@@ -150,7 +150,7 @@ func (kind Kind) IsStorage() bool {
 // IsWorkload returns whether the Kind represents a workload hook.
 func (kind Kind) IsWorkload() bool {
 	switch kind {
-	case PebbleChangeUpdated, PebbleClientNotice, PebbleReady:
+	case PebbleChangeUpdated, PebbleCustomNotice, PebbleReady:
 		return true
 	}
 	return false

--- a/hooks/hooks.go
+++ b/hooks/hooks.go
@@ -60,7 +60,9 @@ const (
 	// kinds represent will be prefixed by the workload/container name; for example,
 	// "mycontainer-pebble-ready".
 
-	PebbleReady Kind = "pebble-ready"
+	PebbleChangeUpdate Kind = "pebble-change-update"
+	PebbleClient       Kind = "pebble-client"
+	PebbleReady        Kind = "pebble-ready"
 )
 
 var unitHooks = []Kind{
@@ -115,6 +117,8 @@ func StorageHooks() []Kind {
 }
 
 var workloadHooks = []Kind{
+	PebbleChangeUpdate,
+	PebbleClient,
 	PebbleReady,
 }
 
@@ -146,7 +150,7 @@ func (kind Kind) IsStorage() bool {
 // IsWorkload returns whether the Kind represents a workload hook.
 func (kind Kind) IsWorkload() bool {
 	switch kind {
-	case PebbleReady:
+	case PebbleChangeUpdate, PebbleClient, PebbleReady:
 		return true
 	}
 	return false

--- a/hooks/hooks.go
+++ b/hooks/hooks.go
@@ -60,9 +60,9 @@ const (
 	// kinds represent will be prefixed by the workload/container name; for example,
 	// "mycontainer-pebble-ready".
 
-	PebbleChangeUpdate Kind = "pebble-change-update"
-	PebbleClient       Kind = "pebble-client"
-	PebbleReady        Kind = "pebble-ready"
+	PebbleChangeUpdated Kind = "pebble-change-updated"
+	PebbleClientNotice  Kind = "pebble-client-notice"
+	PebbleReady         Kind = "pebble-ready"
 )
 
 var unitHooks = []Kind{
@@ -117,8 +117,8 @@ func StorageHooks() []Kind {
 }
 
 var workloadHooks = []Kind{
-	PebbleChangeUpdate,
-	PebbleClient,
+	PebbleChangeUpdated,
+	PebbleClientNotice,
 	PebbleReady,
 }
 
@@ -150,7 +150,7 @@ func (kind Kind) IsStorage() bool {
 // IsWorkload returns whether the Kind represents a workload hook.
 func (kind Kind) IsWorkload() bool {
 	switch kind {
-	case PebbleChangeUpdate, PebbleClient, PebbleReady:
+	case PebbleChangeUpdated, PebbleClientNotice, PebbleReady:
 		return true
 	}
 	return false


### PR DESCRIPTION
Add new hook types for the upcoming Pebble Notices work. See ["Juju and charms" section in JU048](https://docs.google.com/document/d/16PJ85fefalQd7JbWSxkRWn0Ye-Hs8S1yE99eW7pk8fA/edit#heading=h.mpgnfy965ixr), the Pebble Notices spec. New hook names are:

* `<container>-pebble-custom-notice`
* `<container>-pebble-change-updated`