### PR TITLE
Add required metadata fields for rootless agents and containers.

### DIFF
--- a/base_test.go
+++ b/base_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/utils/v3/arch"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v11"
+	"github.com/juju/charm/v12"
 )
 
 type baseSuite struct {

--- a/bundle_test.go
+++ b/bundle_test.go
@@ -8,7 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v11"
+	"github.com/juju/charm/v12"
 )
 
 var _ = gc.Suite(&BundleSuite{})

--- a/bundlearchive_test.go
+++ b/bundlearchive_test.go
@@ -12,7 +12,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v11"
+	"github.com/juju/charm/v12"
 )
 
 var _ = gc.Suite(&BundleArchiveSuite{})

--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -15,7 +15,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v11"
+	"github.com/juju/charm/v12"
 )
 
 type bundleDataSuite struct {

--- a/bundledir_test.go
+++ b/bundledir_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v11"
+	"github.com/juju/charm/v12"
 )
 
 type BundleDirSuite struct {

--- a/channel_test.go
+++ b/channel_test.go
@@ -9,7 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v11"
+	"github.com/juju/charm/v12"
 )
 
 type channelSuite struct {

--- a/charm_test.go
+++ b/charm_test.go
@@ -17,7 +17,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 
-	"github.com/juju/charm/v11"
+	"github.com/juju/charm/v12"
 )
 
 type CharmSuite struct {

--- a/charmarchive_test.go
+++ b/charmarchive_test.go
@@ -21,7 +21,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 
-	"github.com/juju/charm/v11"
+	"github.com/juju/charm/v12"
 )
 
 type CharmArchiveSuite struct {

--- a/charmdir_test.go
+++ b/charmdir_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/juju/utils/v3"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v11"
+	"github.com/juju/charm/v12"
 )
 
 type CharmDirSuite struct {

--- a/config_test.go
+++ b/config_test.go
@@ -12,7 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 
-	"github.com/juju/charm/v11"
+	"github.com/juju/charm/v12"
 )
 
 type ConfigSuite struct {

--- a/extra_bindings_test.go
+++ b/extra_bindings_test.go
@@ -7,7 +7,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v11"
+	"github.com/juju/charm/v12"
 )
 
 var _ = gc.Suite(&extraBindingsSuite{})

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/juju/charm/v11
+module github.com/juju/charm/v12
 
 go 1.20
 

--- a/lxdprofile_test.go
+++ b/lxdprofile_test.go
@@ -9,7 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v11"
+	"github.com/juju/charm/v12"
 )
 
 type ProfileSuite struct{}

--- a/meta.go
+++ b/meta.go
@@ -22,9 +22,9 @@ import (
 	"github.com/juju/version/v2"
 	"gopkg.in/yaml.v2"
 
-	"github.com/juju/charm/v11/assumes"
-	"github.com/juju/charm/v11/hooks"
-	"github.com/juju/charm/v11/resource"
+	"github.com/juju/charm/v12/assumes"
+	"github.com/juju/charm/v12/hooks"
+	"github.com/juju/charm/v12/resource"
 )
 
 // RelationScope describes the scope of a relation.

--- a/meta_test.go
+++ b/meta_test.go
@@ -17,9 +17,9 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 
-	"github.com/juju/charm/v11"
-	"github.com/juju/charm/v11/assumes"
-	"github.com/juju/charm/v11/resource"
+	"github.com/juju/charm/v12"
+	"github.com/juju/charm/v12/assumes"
+	"github.com/juju/charm/v12/resource"
 )
 
 func repoMeta(c *gc.C, name string) io.Reader {

--- a/meta_test.go
+++ b/meta_test.go
@@ -1733,6 +1733,8 @@ containers:
     mounts:
       - storage: a
         location: /b/
+    uid: 10
+    gid: 10
 resources:
   test-os:
     type: oci-image
@@ -1748,8 +1750,42 @@ storage:
 				Storage:  "a",
 				Location: "/b/",
 			}},
+			Uid: 10,
+			Gid: 10,
 		},
 	})
+}
+
+func (s *MetaSuite) TestInvalidUid(c *gc.C) {
+	_, err := charm.ReadMeta(strings.NewReader(`
+name: a
+summary: b
+description: c
+containers:
+  foo:
+    resource: test-os
+    uid: 1000
+resources:
+  test-os:
+    type: oci-image
+`))
+	c.Assert(err, gc.ErrorMatches, `parsing containers: container "foo" has invalid uid 1000: uid cannot be in reserved range 1000-9999`)
+}
+
+func (s *MetaSuite) TestInvalidGid(c *gc.C) {
+	_, err := charm.ReadMeta(strings.NewReader(`
+name: a
+summary: b
+description: c
+containers:
+  foo:
+    resource: test-os
+    gid: 1000
+resources:
+  test-os:
+    type: oci-image
+`))
+	c.Assert(err, gc.ErrorMatches, `parsing containers: container "foo" has invalid gid 1000: gid cannot be in reserved range 1000-9999`)
 }
 
 func (s *MetaSuite) TestSystemReferencesFileResource(c *gc.C) {

--- a/meta_test.go
+++ b/meta_test.go
@@ -2050,3 +2050,48 @@ func (FormatMetaSuite) TestCheckV2WithDeployment(c *gc.C) {
 	err := meta.Check(charm.FormatV2, charm.SelectionManifest, charm.SelectionBases)
 	c.Assert(err, gc.ErrorMatches, `deployment in metadata v2 not valid`)
 }
+
+func (s *MetaSuite) TestCharmUser(c *gc.C) {
+	meta, err := charm.ReadMeta(strings.NewReader(`
+name: a
+summary: b
+description: c
+charm-user: root
+`))
+	c.Assert(err, gc.IsNil)
+	c.Assert(meta.CharmUser, gc.Equals, charm.RunAsRoot)
+
+	meta, err = charm.ReadMeta(strings.NewReader(`
+name: a
+summary: b
+description: c
+charm-user: sudoer
+`))
+	c.Assert(err, gc.IsNil)
+	c.Assert(meta.CharmUser, gc.Equals, charm.RunAsSudoer)
+
+	meta, err = charm.ReadMeta(strings.NewReader(`
+name: a
+summary: b
+description: c
+charm-user: non-root
+`))
+	c.Assert(err, gc.IsNil)
+	c.Assert(meta.CharmUser, gc.Equals, charm.RunAsNonRoot)
+
+	meta, err = charm.ReadMeta(strings.NewReader(`
+name: a
+summary: b
+description: c
+`))
+	c.Assert(err, gc.IsNil)
+	c.Assert(meta.CharmUser, gc.Equals, charm.RunAsDefault)
+
+	_, err = charm.ReadMeta(strings.NewReader(`
+name: a
+summary: b
+description: c
+charm-user: barry
+`))
+	c.Assert(err, gc.ErrorMatches, `parsing charm-user: invalid charm-user "barry" expected one of root, sudoer or non-root`)
+}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -9,7 +9,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v11"
+	"github.com/juju/charm/v12"
 )
 
 // Keys returns a list of all defined metrics keys.

--- a/offerurl_test.go
+++ b/offerurl_test.go
@@ -10,7 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	charm "github.com/juju/charm/v11"
+	charm "github.com/juju/charm/v12"
 )
 
 type OfferURLSuite struct{}

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -16,7 +16,7 @@ import (
 	gc "gopkg.in/check.v1"
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/juju/charm/v11"
+	"github.com/juju/charm/v12"
 )
 
 type bundleDataOverlaySuite struct {

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -7,7 +7,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v11"
+	"github.com/juju/charm/v12"
 )
 
 var _ = gc.Suite(&payloadClassSuite{})

--- a/resource/fingerprint_test.go
+++ b/resource/fingerprint_test.go
@@ -12,7 +12,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v11/resource"
+	"github.com/juju/charm/v12/resource"
 )
 
 func newFingerprint(c *gc.C, data string) ([]byte, string) {

--- a/resource/meta_test.go
+++ b/resource/meta_test.go
@@ -8,7 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v11/resource"
+	"github.com/juju/charm/v12/resource"
 )
 
 var _ = gc.Suite(&MetaSuite{})

--- a/resource/origin_test.go
+++ b/resource/origin_test.go
@@ -9,7 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v11/resource"
+	"github.com/juju/charm/v12/resource"
 )
 
 type OriginSuite struct {

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -8,7 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v11/resource"
+	"github.com/juju/charm/v12/resource"
 )
 
 var fingerprint = []byte("123456789012345678901234567890123456789012345678")

--- a/resource/type_test.go
+++ b/resource/type_test.go
@@ -8,7 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v11/resource"
+	"github.com/juju/charm/v12/resource"
 )
 
 var _ = gc.Suite(&TypeSuite{})

--- a/resources.go
+++ b/resources.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/schema"
 
-	"github.com/juju/charm/v11/resource"
+	"github.com/juju/charm/v12/resource"
 )
 
 var resourceSchema = schema.FieldMap(

--- a/resources_test.go
+++ b/resources_test.go
@@ -7,7 +7,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v11"
+	"github.com/juju/charm/v12"
 )
 
 var _ = gc.Suite(&resourceSuite{})

--- a/url_test.go
+++ b/url_test.go
@@ -13,7 +13,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 
-	"github.com/juju/charm/v11"
+	"github.com/juju/charm/v12"
 )
 
 type URLSuite struct{}

--- a/version_test.go
+++ b/version_test.go
@@ -8,7 +8,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/charm/v11"
+	"github.com/juju/charm/v12"
 )
 
 type VersionSuite struct{}


### PR DESCRIPTION
Adds new metadata fields required to enable rootless charms on Kubernetes.
- add the `uid` and `gid` fields to each container in the `containers` section which can be omitted.
- limit the uid and gid values to less than 1000 and greater than 9999 as per the spec.
- add the `charm-user` field which can be omitted, with values of `root`, `sudoer` and `non-root`.

### QA

Run unit tests.

### Links

Specs: [JU074](https://docs.google.com/document/d/1Y6OhDVWDadPYSlZVnPpH_upA_RNNRbM0luYLJJRrbUw/edit) [JU075](https://docs.google.com/document/d/1wSTB6R96B031j91ygK0hlfWdwaRPWCZ0ENQnjSDlEH4/edit)
Jira: JUJU-5123 JUJU-5127
