### PR TITLE
Add methods to retrieve raw bundle string

### DIFF
--- a/bundle.go
+++ b/bundle.go
@@ -15,6 +15,8 @@ import (
 type Bundle interface {
 	// Data returns the contents of the bundle's bundle.yaml file.
 	Data() *BundleData
+	// BundleBytes returns the raw bytes content of a bundle
+	BundleBytes() []byte
 	// ReadMe returns the contents of the bundle's README.md file.
 	ReadMe() string
 	// ContainsOverlays returns true if the bundle contains any overlays.

--- a/bundle_test.go
+++ b/bundle_test.go
@@ -4,6 +4,9 @@
 package charm_test
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -23,7 +26,7 @@ func (*BundleSuite) TestReadBundleDir(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(b.ContainsOverlays(), jc.IsFalse)
 	c.Assert(b, gc.FitsTypeOf, (*charm.BundleDir)(nil))
-	checkWordpressBundle(c, b, path)
+	checkWordpressBundle(c, b, path, "wordpress-simple")
 }
 
 func (*BundleSuite) TestReadMultiDocBundleDir(c *gc.C) {
@@ -32,7 +35,7 @@ func (*BundleSuite) TestReadMultiDocBundleDir(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(b.ContainsOverlays(), jc.IsTrue)
 	c.Assert(b, gc.FitsTypeOf, (*charm.BundleDir)(nil))
-	checkWordpressBundle(c, b, path)
+	checkWordpressBundle(c, b, path, "wordpress-simple-multidoc")
 }
 
 func (*BundleSuite) TestReadBundleArchive(c *gc.C) {
@@ -41,7 +44,7 @@ func (*BundleSuite) TestReadBundleArchive(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(b.ContainsOverlays(), jc.IsFalse)
 	c.Assert(b, gc.FitsTypeOf, (*charm.BundleDir)(nil))
-	checkWordpressBundle(c, b, path)
+	checkWordpressBundle(c, b, path, "wordpress-simple")
 }
 
 func (*BundleSuite) TestReadMultiDocBundleArchive(c *gc.C) {
@@ -50,10 +53,10 @@ func (*BundleSuite) TestReadMultiDocBundleArchive(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(b.ContainsOverlays(), jc.IsTrue)
 	c.Assert(b, gc.FitsTypeOf, (*charm.BundleDir)(nil))
-	checkWordpressBundle(c, b, path)
+	checkWordpressBundle(c, b, path, "wordpress-simple-multidoc")
 }
 
-func checkWordpressBundle(c *gc.C, b charm.Bundle, path string) {
+func checkWordpressBundle(c *gc.C, b charm.Bundle, path string, bundleName string) {
 	// Load the charms required by the bundle.
 	wordpressCharm := readCharmDir(c, "wordpress")
 	mysqlCharm := readCharmDir(c, "mysql")
@@ -87,6 +90,11 @@ func checkWordpressBundle(c *gc.C, b charm.Bundle, path string) {
 	case *charm.BundleDir:
 		c.Assert(b.Path, gc.Equals, path)
 	}
+
+	bundlePath := filepath.Join("internal/test-charm-repo/bundle", bundleName, "bundle.yaml")
+	raw, err := os.ReadFile(bundlePath)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(b.BundleBytes()), gc.Equals, string(raw))
 }
 
 func verifyOk(string) error {

--- a/bundlearchive_test.go
+++ b/bundlearchive_test.go
@@ -5,7 +5,6 @@ package charm_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -21,35 +20,37 @@ type BundleArchiveSuite struct {
 	archivePath string
 }
 
+const bundleName = "wordpress-simple"
+
 func (s *BundleArchiveSuite) SetUpSuite(c *gc.C) {
-	s.archivePath = archivePath(c, readBundleDir(c, "wordpress-simple"))
+	s.archivePath = archivePath(c, readBundleDir(c, bundleName))
 }
 
 func (s *BundleArchiveSuite) TestReadBundleArchive(c *gc.C) {
 	archive, err := charm.ReadBundleArchive(s.archivePath)
 	c.Assert(err, gc.IsNil)
-	checkWordpressBundle(c, archive, s.archivePath)
+	checkWordpressBundle(c, archive, s.archivePath, bundleName)
 }
 
 func (s *BundleArchiveSuite) TestReadBundleArchiveBytes(c *gc.C) {
-	data, err := ioutil.ReadFile(s.archivePath)
+	data, err := os.ReadFile(s.archivePath)
 	c.Assert(err, gc.IsNil)
 
 	archive, err := charm.ReadBundleArchiveBytes(data)
 	c.Assert(err, gc.IsNil)
 	c.Assert(archive.ContainsOverlays(), jc.IsFalse)
-	checkWordpressBundle(c, archive, "")
+	checkWordpressBundle(c, archive, "", bundleName)
 }
 
 func (s *BundleArchiveSuite) TestReadMultiDocBundleArchiveBytes(c *gc.C) {
 	path := archivePath(c, readBundleDir(c, "wordpress-simple-multidoc"))
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	c.Assert(err, gc.IsNil)
 
 	archive, err := charm.ReadBundleArchiveBytes(data)
 	c.Assert(err, gc.IsNil)
 	c.Assert(archive.ContainsOverlays(), jc.IsTrue)
-	checkWordpressBundle(c, archive, "")
+	checkWordpressBundle(c, archive, "", "wordpress-simple-multidoc")
 }
 
 func (s *BundleArchiveSuite) TestReadBundleArchiveFromReader(c *gc.C) {
@@ -61,7 +62,7 @@ func (s *BundleArchiveSuite) TestReadBundleArchiveFromReader(c *gc.C) {
 
 	archive, err := charm.ReadBundleArchiveFromReader(f, info.Size())
 	c.Assert(err, gc.IsNil)
-	checkWordpressBundle(c, archive, "")
+	checkWordpressBundle(c, archive, "", bundleName)
 }
 
 func (s *BundleArchiveSuite) TestReadBundleArchiveWithoutBundleYAML(c *gc.C) {

--- a/bundledata.go
+++ b/bundledata.go
@@ -49,12 +49,10 @@ type BundleData struct {
 	// Series holds the default series to use when
 	// the bundle deploys applications. A series defined for an application
 	// takes precedence.
-	// Series and Base cannot be mixed.
 	Series string `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
 
 	// Base holds the default base to use when the bundle deploys
 	// applications. A base defined for an application takes precedence.
-	// Series and Base cannot be mixed.
 	DefaultBase string `bson:"default-base,omitempty" json:"default-base,omitempty" yaml:"default-base,omitempty"`
 
 	// Relations holds a slice of 2-element slices,
@@ -104,11 +102,9 @@ type ApplicationSpec struct {
 	Revision *int `bson:"revision,omitempty" yaml:"revision,omitempty" json:"revision,omitempty"`
 
 	// Series is the series to use when deploying the application.
-	// Series and Base cannot be mixed.
 	Series string `bson:",omitempty" yaml:",omitempty" json:",omitempty"`
 
 	// Base is the base to use when deploying the application.
-	// Series and Base cannot be mixed.
 	Base string `bson:",omitempty" yaml:",omitempty" json:",omitempty"`
 
 	// Resources is the set of resource revisions to deploy for the
@@ -355,7 +351,11 @@ type OfferSpec struct {
 // The returned data is not verified - call Verify to ensure
 // that it is OK.
 func ReadBundleData(r io.Reader) (*BundleData, error) {
-	bd, _, err := readBaseFromMultidocBundle(r)
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	bd, _, err := readBaseFromMultidocBundle(b)
 	if err != nil {
 		return nil, err
 	}
@@ -370,8 +370,8 @@ func ReadBundleData(r io.Reader) (*BundleData, error) {
 //
 // Clients that are interested in reading multi-doc bundle data should use the
 // new helpers: LocalBundleDataSource and StreamBundleDataSource.
-func readBaseFromMultidocBundle(r io.Reader) (*BundleData, bool, error) {
-	parts, err := parseBundleParts(r)
+func readBaseFromMultidocBundle(b []byte) (*BundleData, bool, error) {
+	parts, err := parseBundleParts(b)
 	if err != nil {
 		return nil, false, err
 	}

--- a/bundledir_test.go
+++ b/bundledir_test.go
@@ -23,7 +23,7 @@ func (s *BundleDirSuite) TestReadBundleDir(c *gc.C) {
 	path := bundleDirPath(c, "wordpress-simple")
 	dir, err := charm.ReadBundleDir(path)
 	c.Assert(err, gc.IsNil)
-	checkWordpressBundle(c, dir, path)
+	checkWordpressBundle(c, dir, path, "wordpress-simple")
 }
 
 func (s *BundleDirSuite) TestReadBundleDirWithoutREADME(c *gc.C) {

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -4,7 +4,6 @@
 package charm_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -954,6 +953,10 @@ func (s srcWithFakeIncludeResolver) Parts() []*charm.BundleDataPart {
 	return s.src.Parts()
 }
 
+func (s srcWithFakeIncludeResolver) BundleBytes() []byte {
+	return s.src.BundleBytes()
+}
+
 func (s srcWithFakeIncludeResolver) BasePath() string {
 	return s.src.BasePath()
 }
@@ -987,7 +990,7 @@ func testBundleMergeResult(c *gc.C, src, exp string) {
 }
 
 func mustWriteFile(c *gc.C, path, content string) {
-	err := ioutil.WriteFile(path, []byte(content), os.ModePerm)
+	err := os.WriteFile(path, []byte(content), os.ModePerm)
 	c.Assert(err, gc.IsNil)
 }
 


### PR DESCRIPTION
Add this RawBundle method to Bundle interface and BundleDataSource

In Juju, we have come across a need to run some extra parsing + verification which we do not want to do in juju/charm. We want to keep the data model clean in juju/charm.

As such, we need to way to keep the raw bundle data around for later parsing

Add this to BundleDataSource, as this is what we use in Juju

However, we also implement our own BundleDataSource in Juju. built with the Bundle interface here. So we need to add this method to Bundle as well

You can see a draft implementation for this change here:
https://github.com/juju/juju/pull/17350

As a flyby, delete some incorrect comments

## QA Steps

Compile into juju form the following PR and run it's QA steps:
https://github.com/juju/juju/pull/17350