### PR TITLE
Remove series from charm URL and bundles

### DIFF
--- a/bundledata_test.go
+++ b/bundledata_test.go
@@ -294,7 +294,6 @@ saas:
 applications:
     wordpress:
       charm: "ch:wordpress"
-      series: "trusty"
       revision: 10
       num_units: 1
 relations:
@@ -310,7 +309,6 @@ relations:
 		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm:    "ch:wordpress",
-				Series:   "trusty",
 				Revision: &ten,
 				NumUnits: 1,
 			},
@@ -326,7 +324,6 @@ applications:
     wordpress:
       charm: "wordpress"
       revision: 10
-      series: trusty
       channel: edge
       num_units: 1
 `,
@@ -337,7 +334,6 @@ applications:
 				Channel:  "edge",
 				Revision: &ten,
 				NumUnits: 1,
-				Series:   "trusty",
 			},
 		},
 	},
@@ -406,13 +402,12 @@ func (*bundleDataSuite) TestCodecRoundTrip(c *gc.C) {
 	}
 }
 
-func (*bundleDataSuite) TestParseLocalWithSeries(c *gc.C) {
+func (*bundleDataSuite) TestParseLocal(c *gc.C) {
 	path := "internal/test-charm-repo/quanta/riak"
 	data := fmt.Sprintf(`
         applications:
             dummy:
                 charm: %s
-                series: xenial
                 num_units: 1
     `, path)
 	bd, err := charm.ReadBundleData(strings.NewReader(data))
@@ -421,7 +416,6 @@ func (*bundleDataSuite) TestParseLocalWithSeries(c *gc.C) {
 		Applications: map[string]*charm.ApplicationSpec{
 			"dummy": {
 				Charm:    path,
-				Series:   "xenial",
 				NumUnits: 1,
 			},
 		}})
@@ -446,7 +440,6 @@ var verifyErrorsTests = []struct {
 }{{
 	about: "as many errors as possible",
 	data: `
-series: "9wrong"
 default-base: "invalidbase"
 
 saas:
@@ -459,7 +452,6 @@ machines:
         constraints: 'bad constraints'
         annotations:
             foo: bar
-        series: 'bad series'
         base: 'bad base'
     bogus:
     3:
@@ -499,7 +491,6 @@ applications:
           charm: wordpress
     postgres:
         charm: "postgres"
-        series: trusty
     terracotta:
         charm: "terracotta"
         base: "ubuntu@22.04"
@@ -524,7 +515,6 @@ relations:
     - ["wordpress:db", "riak:db"]
 `,
 	errors: []string{
-		`bundle declares an invalid series "9wrong"`,
 		`bundle declares an invalid base "invalidbase"`,
 		`invalid offer URL "!some-bogus/url" for SAAS apache2`,
 		`invalid storage name "no_underscores" in application "ceph"`,
@@ -549,7 +539,6 @@ relations:
 		`relation ["mysql:db" "mediawiki:db"] is defined more than once`,
 		`invalid placement syntax "bad placement"`,
 		`invalid relation syntax "mediawiki/db"`,
-		`invalid series "bad series" for machine "0"`,
 		`invalid base "bad base" for machine "0"`,
 		`ambiguous relation "riak" refers to a application and a SAAS in this bundle`,
 		`SAAS "riak" already exists with application "riak" name`,
@@ -765,7 +754,6 @@ applications:
         charm: "gitlab-k8s"
         num_units: 3
         to: [foo=baz]
-        series: kubernetes
     redis:
         charm: "redis-k8s"
         scale: 3
@@ -785,7 +773,6 @@ applications:
 			},
 			"gitlab": {
 				Charm:    "gitlab-k8s",
-				Series:   "kubernetes",
 				To:       []string{"foo=baz"},
 				NumUnits: 3,
 			},
@@ -854,7 +841,6 @@ applications:
 func (s *bundleDataSuite) TestKubernetesBundleErrors(c *gc.C) {
 	data := `
 bundle: "kubernetes"
-series: "xenial"
 
 machines:
     0:
@@ -862,7 +848,6 @@ machines:
 applications:
     mariadb:
         charm: "mariadb-k8s"
-        series: "xenial"
         scale: 2
     casandra:
         charm: "casnadra-k8s"

--- a/meta.go
+++ b/meta.go
@@ -822,12 +822,6 @@ func (m Meta) Check(format Format, reasons ...FormatSelectionReason) error {
 		}
 	}
 
-	for _, series := range m.Series {
-		if !IsValidSeries(series) {
-			return errors.Errorf("charm %q declares invalid series: %q", m.Name, series)
-		}
-	}
-
 	names = make(map[string]bool)
 	for name, store := range m.Storage {
 		if store.Location != "" && store.Type != StorageFilesystem {

--- a/meta_test.go
+++ b/meta_test.go
@@ -566,18 +566,6 @@ func (s *MetaSuite) TestSeries(c *gc.C) {
 	c.Assert(meta.Series, gc.DeepEquals, []string{"precise", "trusty", "plan9"})
 }
 
-func (s *MetaSuite) TestCheckInvalidSeries(c *gc.C) {
-	for _, seriesName := range []string{"pre-c1se", "pre^cise", "cp/m", "OpenVMS"} {
-		err := charm.Meta{
-			Name:        "a",
-			Summary:     "b",
-			Description: "c",
-			Series:      []string{seriesName},
-		}.Check(charm.FormatV1)
-		c.Check(err, gc.ErrorMatches, `charm "a" declares invalid series: .*`)
-	}
-}
-
 func (s *MetaSuite) TestMinJujuVersion(c *gc.C) {
 	// series not specified
 	meta, err := charm.ReadMeta(strings.NewReader(dummyMetadata))

--- a/overlay.go
+++ b/overlay.go
@@ -30,18 +30,18 @@ import (
 // To clarify how this method works let's consider a bundle created via the
 // yaml blob below:
 //
-//   applications:
-//     apache2:
-//       charm: cs:apache2-26
-//       offers:
-//         my-offer:
-//           endpoints:
-//           - apache-website
-//           - website-cache
-//         my-other-offer:
-//           endpoints:
-//           - apache-website
-//   series: bionic
+//	applications:
+//	  apache2:
+//	    charm: cs:apache2-26
+//	    offers:
+//	      my-offer:
+//	        endpoints:
+//	        - apache-website
+//	        - website-cache
+//	      my-other-offer:
+//	        endpoints:
+//	        - apache-website
+//	series: bionic
 //
 // The "offers" and "endpoints" attributes are overlay-specific fields. If we
 // were to run this method and then marshal the results back to yaml we would
@@ -49,23 +49,23 @@ import (
 //
 // The base bundle:
 //
-//   applications:
-//     apache2:
-//       charm: cs:apache2-26
-//   series: bionic
+//	applications:
+//	  apache2:
+//	    charm: cs:apache2-26
+//	series: bionic
 //
 // The overlay-specific bundle:
 //
-//   applications:
-//     apache2:
-//       offers:
-//         my-offer:
-//           endpoints:
-//           - apache-website
-//           - website-cache
-//         my-other-offer:
-//           endpoints:
-//           - apache-website
+//	applications:
+//	  apache2:
+//	    offers:
+//	      my-offer:
+//	        endpoints:
+//	        - apache-website
+//	        - website-cache
+//	      my-other-offer:
+//	        endpoints:
+//	        - apache-website
 //
 // The two bundles returned by this method are copies of the original bundle
 // data and can thus be safely manipulated by the caller.
@@ -373,29 +373,34 @@ func isZero(v reflect.Value) bool {
 //
 // When merging an overlay into a base bundle the following rules apply for the
 // BundleData struct fields:
-// - if an overlay specifies a bundle-level series, it overrides the base bundle
-//   series.
-// - overlay-defined relations are appended to the base bundle relations
-// - overlay-defined machines overwrite the base bundle machines.
-// - if an overlay defines an application that is not present in the base bundle,
-//   it will get appended to the application list.
-// - if an overlay defines an empty application or saas value, it will be removed
-//   from the base bundle together with any associated relations. For example, to
-//   remove an application named "mysql" the following overlay snippet can be
-//   provided:
-//     applications:
-//       mysql:
 //
-// - if an overlay defines an application that is also present in the base bundle
-//   the two application specs are merged together (see following rules)
+//   - if an overlay specifies a bundle-level series, it overrides the base bundle
+//     series.
+//
+//   - overlay-defined relations are appended to the base bundle relations
+//
+//   - overlay-defined machines overwrite the base bundle machines.
+//
+//   - if an overlay defines an application that is not present in the base bundle,
+//     it will get appended to the application list.
+//
+//   - if an overlay defines an empty application or saas value, it will be removed
+//     from the base bundle together with any associated relations. For example, to
+//     remove an application named "mysql" the following overlay snippet can be
+//     provided:
+//     applications:
+//     mysql:
+//
+//   - if an overlay defines an application that is also present in the base bundle
+//     the two application specs are merged together (see following rules)
 //
 // ApplicationSpec merge rules:
-// - if the overlay defines a value for a scalar or slice field, it will overwrite
-//   the value from the base spec (e.g. trust, series etc).
-// - if the overlay specifies a nil/empty value for a map field, then the map
-//   field of the base spec will be cleared.
-// - if the overlay specifies a non-empty value for a map field, its key/value
-//   tuples are iterated and:
+//   - if the overlay defines a value for a scalar or slice field, it will overwrite
+//     the value from the base spec (e.g. trust, series etc).
+//   - if the overlay specifies a nil/empty value for a map field, then the map
+//     field of the base spec will be cleared.
+//   - if the overlay specifies a non-empty value for a map field, its key/value
+//     tuples are iterated and:
 //   - if the value is nil/zero and the value is non-scalar, it is deleted from
 //     the base spec.
 //   - otherwise, the key/value is inserted into the base spec overwriting any
@@ -583,9 +588,9 @@ func applyOverlay(base, overlay *BundleDataPart) error {
 		}
 	}
 
-	// If series is set in the config, it overrides the bundle.
-	if series := overlay.Data.Series; series != "" {
-		base.Data.Series = series
+	// If base is set in the config, it overrides the bundle.
+	if b := overlay.Data.DefaultBase; b != "" {
+		base.Data.DefaultBase = b
 	}
 
 	// Append any additional relations.
@@ -621,12 +626,12 @@ func removeRelations(data [][]string, appName string) [][]string {
 // mergeStructs iterates the fields of srcStruct and merges them into the
 // equivalent fields of dstStruct using the following rules:
 //
-// - if src defines a value for a scalar or slice field, it will overwrite
-//   the value from the dst (e.g. trust, series etc).
-// - if the src specifies a nil/empty value for a map field, then the map
-//   field of dst will be cleared.
-// - if the src specifies a non-empty value for a map field, its key/value
-//   tuples are iterated and:
+//   - if src defines a value for a scalar or slice field, it will overwrite
+//     the value from the dst (e.g. trust, series etc).
+//   - if the src specifies a nil/empty value for a map field, then the map
+//     field of dst will be cleared.
+//   - if the src specifies a non-empty value for a map field, its key/value
+//     tuples are iterated and:
 //   - if the value is nil/zero and non-scalar, it is deleted from the dst map.
 //   - otherwise, the key/value is inserted into the dst map overwriting any
 //     existing entries.

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -29,11 +29,9 @@ func (*bundleDataOverlaySuite) TestEmptyBaseApplication(c *gc.C) {
 applications:
   apache2:
 ---
-series: trusty
 applications:
   apache2:
     charm: cs:apache2-42
-    series: bionic
 `[1:]
 
 	_, err := charm.ReadAndMergeBundleData(mustCreateStringDataSource(c, data))
@@ -65,7 +63,6 @@ applications:
 saas:
     apache2:
         url: production:admin/info.apache
-series: bionic
 `[1:]
 
 	expBase := `
@@ -75,7 +72,6 @@ applications:
 saas:
   apache2:
     url: production:admin/info.apache
-series: bionic
 `[1:]
 
 	expOverlay := `
@@ -272,7 +268,6 @@ applications:
 saas:
     apache2:
         url: production:admin/info.apache
-series: bionic
 `
 
 	bd, err := charm.ReadBundleData(strings.NewReader(data))
@@ -311,7 +306,6 @@ applications:
     options:
       foo: bar
       ssl_ca: *ssl_ca
-series: bionic
 `
 
 	bd, err := charm.ReadBundleData(strings.NewReader(data))
@@ -323,25 +317,21 @@ series: bionic
 	c.Assert(charm.VerifyNoOverlayFieldsPresent(static), gc.Equals, nil)
 }
 
-func (*bundleDataOverlaySuite) TestOverrideCharmAndSeries(c *gc.C) {
+func (*bundleDataOverlaySuite) TestOverrideCharm(c *gc.C) {
 	testBundleMergeResult(c, `
 applications:
   apache2:
     charm: apache2
     num_units: 1
 ---
-series: trusty
 applications:
   apache2:
     charm: cs:apache2-42
-    series: bionic
 `, `
 applications:
   apache2:
     charm: cs:apache2-42
-    series: bionic
     num_units: 1
-series: trusty
 `,
 	)
 }
@@ -679,7 +669,6 @@ applications:
     memcached:
         charm: mem
         revision: 47
-        series: trusty
         num_units: 1
         options:
             key: value
@@ -699,7 +688,6 @@ applications:
 defaultwiki: &DEFAULTWIKI
     charm: "mediawiki"
     revision: 5
-    series: trusty
     num_units: 1
     options: &WIKIOPTS
         debug: false
@@ -732,14 +720,12 @@ applications:
   memcached:
     charm: mem
     revision: 47
-    series: trusty
     num_units: 1
     options:
       key: value
   wiki:
     charm: mediawiki
     revision: 5
-    series: trusty
     num_units: 1
     options:
       debug: false

--- a/url_test.go
+++ b/url_test.go
@@ -25,71 +25,71 @@ var urlTests = []struct {
 	exact  string
 	url    *charm.URL
 }{{
-	s:   "local:series/name-1",
-	url: &charm.URL{"local", "name", 1, "series", ""},
-}, {
-	s:   "local:series/name",
-	url: &charm.URL{"local", "name", -1, "series", ""},
-}, {
-	s:   "local:series/n0-0n-n0",
-	url: &charm.URL{"local", "n0-0n-n0", -1, "series", ""},
+	s:   "local:name-1",
+	url: &charm.URL{Schema: "local", Name: "name", Revision: 1, Architecture: ""},
 }, {
 	s:   "local:name",
-	url: &charm.URL{"local", "name", -1, "", ""},
+	url: &charm.URL{Schema: "local", Name: "name", Revision: -1, Architecture: ""},
 }, {
-	s:   "bs:~user/series/name-1",
+	s:   "local:n0-0n-n0",
+	url: &charm.URL{Schema: "local", Name: "n0-0n-n0", Revision: -1, Architecture: ""},
+}, {
+	s:   "local:name",
+	url: &charm.URL{Schema: "local", Name: "name", Revision: -1, Architecture: ""},
+}, {
+	s:   "bs:~user/name-1",
 	err: `cannot parse URL $URL: schema "bs" not valid`,
 }, {
 	s:   ":foo",
 	err: `cannot parse charm or bundle URL: $URL`,
 }, {
-	s:   "local:~user/series/name",
+	s:   "local:~user/name",
 	err: `local charm or bundle URL with user name: $URL`,
 }, {
 	s:   "local:~user/name",
 	err: `local charm or bundle URL with user name: $URL`,
 }, {
 	s:     "amd64/name",
-	url:   &charm.URL{"ch", "name", -1, "", "amd64"},
+	url:   &charm.URL{Schema: "ch", Name: "name", Revision: -1, Architecture: "amd64"},
 	exact: "ch:amd64/name",
 }, {
 	s:     "foo",
-	url:   &charm.URL{"ch", "foo", -1, "", ""},
+	url:   &charm.URL{Schema: "ch", Name: "foo", Revision: -1, Architecture: ""},
 	exact: "ch:foo",
 }, {
 	s:     "foo-1",
 	exact: "ch:foo-1",
-	url:   &charm.URL{"ch", "foo", 1, "", ""},
+	url:   &charm.URL{Schema: "ch", Name: "foo", Revision: 1, Architecture: ""},
 }, {
 	s:     "n0-n0-n0",
 	exact: "ch:n0-n0-n0",
-	url:   &charm.URL{"ch", "n0-n0-n0", -1, "", ""},
+	url:   &charm.URL{Schema: "ch", Name: "n0-n0-n0", Revision: -1, Architecture: ""},
 }, {
 	s:     "local:foo",
 	exact: "local:foo",
-	url:   &charm.URL{"local", "foo", -1, "", ""},
+	url:   &charm.URL{Schema: "local", Name: "foo", Revision: -1, Architecture: ""},
 }, {
-	s:     "arm64/series/bar",
-	url:   &charm.URL{"ch", "bar", -1, "series", "arm64"},
-	exact: "ch:arm64/series/bar",
+	s:     "arm64/bar",
+	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Architecture: "arm64"},
+	exact: "ch:arm64/bar",
 }, {
 	s:   "ch:name",
-	url: &charm.URL{"ch", "name", -1, "", ""},
+	url: &charm.URL{Schema: "ch", Name: "name", Revision: -1, Architecture: ""},
 }, {
 	s:   "ch:name-suffix",
-	url: &charm.URL{"ch", "name-suffix", -1, "", ""},
+	url: &charm.URL{Schema: "ch", Name: "name-suffix", Revision: -1, Architecture: ""},
 }, {
 	s:   "ch:name-1",
-	url: &charm.URL{"ch", "name", 1, "", ""},
+	url: &charm.URL{Schema: "ch", Name: "name", Revision: 1, Architecture: ""},
 }, {
-	s:   "ch:focal/istio-gateway-74",
-	url: &charm.URL{"ch", "istio-gateway", 74, "focal", ""},
+	s:   "ch:istio-gateway-74",
+	url: &charm.URL{Schema: "ch", Name: "istio-gateway", Revision: 74, Architecture: ""},
 }, {
 	s:   "ch:amd64/istio-gateway-74",
-	url: &charm.URL{"ch", "istio-gateway", 74, "", "amd64"},
+	url: &charm.URL{Schema: "ch", Name: "istio-gateway", Revision: 74, Architecture: "amd64"},
 }, {
 	s:     "ch:arm64/name",
-	url:   &charm.URL{"ch", "name", -1, "", "arm64"},
+	url:   &charm.URL{Schema: "ch", Name: "name", Revision: -1, Architecture: "arm64"},
 	exact: "ch:arm64/name",
 }, {
 	s:   "ch:~user/name",
@@ -140,7 +140,7 @@ var ensureSchemaTests = []struct {
 	{input: "foo", expected: "ch:foo"},
 	{input: "foo-1", expected: "ch:foo-1"},
 	{input: "~user/foo", expected: "ch:~user/foo"},
-	{input: "series/foo", expected: "ch:series/foo"},
+	{input: "foo", expected: "ch:foo"},
 	{input: "local:foo", expected: "local:foo"},
 	{
 		input: "unknown:foo",
@@ -148,7 +148,7 @@ var ensureSchemaTests = []struct {
 	},
 }
 
-func (s *URLSuite) TestInferURLNoDefaultSeries(c *gc.C) {
+func (s *URLSuite) TestInferURL(c *gc.C) {
 	for i, t := range ensureSchemaTests {
 		c.Logf("%d: %s", i, t.input)
 		inferred, err := charm.EnsureSchema(t.input, charm.CharmHub)
@@ -180,19 +180,6 @@ var validTests = []struct {
 	{charm.IsValidName, "wordpress-2", false},
 	{charm.IsValidName, "word2-press2", true},
 
-	{charm.IsValidSeries, "", false},
-	{charm.IsValidSeries, "precise", true},
-	{charm.IsValidSeries, "Precise", false},
-	{charm.IsValidSeries, "pre cise", false},
-	{charm.IsValidSeries, "pre-cise", false},
-	{charm.IsValidSeries, "pre^cise", false},
-	{charm.IsValidSeries, "prec1se", true},
-	{charm.IsValidSeries, "-precise", false},
-	{charm.IsValidSeries, "precise-", false},
-	{charm.IsValidSeries, "precise-1", false},
-	{charm.IsValidSeries, "precise1", true},
-	{charm.IsValidSeries, "pre-c1se", false},
-
 	{charm.IsValidArchitecture, "amd64", true},
 	{charm.IsValidArchitecture, "~amd64", false},
 	{charm.IsValidArchitecture, "not-an-arch", false},
@@ -206,17 +193,15 @@ func (s *URLSuite) TestValidCheckers(c *gc.C) {
 }
 
 func (s *URLSuite) TestMustParseURL(c *gc.C) {
-	url := charm.MustParseURL("ch:series/name")
-	c.Assert(url, gc.DeepEquals, &charm.URL{"ch", "name", -1, "series", ""})
-	f := func() { charm.MustParseURL("local:@@/name") }
-	c.Assert(f, gc.PanicMatches, "cannot parse URL \"local:@@/name\": series name \"@@\" not valid")
+	url := charm.MustParseURL("ch:name")
+	c.Assert(url, gc.DeepEquals, &charm.URL{Schema: "ch", Name: "name", Revision: -1, Architecture: ""})
 }
 
 func (s *URLSuite) TestWithRevision(c *gc.C) {
-	url := charm.MustParseURL("ch:series/name")
+	url := charm.MustParseURL("ch:name")
 	other := url.WithRevision(1)
-	c.Assert(url, gc.DeepEquals, &charm.URL{"ch", "name", -1, "series", ""})
-	c.Assert(other, gc.DeepEquals, &charm.URL{"ch", "name", 1, "series", ""})
+	c.Assert(url, gc.DeepEquals, &charm.URL{Schema: "ch", Name: "name", Revision: -1, Architecture: ""})
+	c.Assert(other, gc.DeepEquals, &charm.URL{Schema: "ch", Name: "name", Revision: 1, Architecture: ""})
 
 	// Should always copy. The opposite behavior is error prone.
 	c.Assert(other.WithRevision(1), gc.Not(gc.Equals), other)


### PR DESCRIPTION
Remove references to series from juju/charm in code related to charm url and bundles

For the case of charm urls, to ensure we can still parse existing charm urls, we do not remove the series attribute as such, but instead make it private. It is then only accessible via stringifying a url. This ensures that parsing then stringifying a charm url does not change it's value.

For the time being keep references to series in charm metadata. Wait until we remove support for this in Juju itself

## QA Steps

Compile into juju 4.0

```
juju bootstrap lxd lxd
juju add-model m
juju deploy ubuntu
```