### PR TITLE
feat: Add new hook types for Pebble check events (OP046)

### DIFF
--- a/hooks/hooks.go
+++ b/hooks/hooks.go
@@ -60,9 +60,10 @@ const (
 	// kinds represent will be prefixed by the workload/container name; for example,
 	// "mycontainer-pebble-ready".
 
-	PebbleChangeUpdated Kind = "pebble-change-updated"
-	PebbleCustomNotice  Kind = "pebble-custom-notice"
-	PebbleReady         Kind = "pebble-ready"
+	PebbleCustomNotice   Kind = "pebble-custom-notice"
+	PebbleReady          Kind = "pebble-ready"
+	PebbleCheckFailed    Kind = "pebble-check-failed"
+	PebbleCheckRecovered Kind = "pebble-check-recovered"
 )
 
 var unitHooks = []Kind{
@@ -117,9 +118,10 @@ func StorageHooks() []Kind {
 }
 
 var workloadHooks = []Kind{
-	PebbleChangeUpdated,
 	PebbleCustomNotice,
 	PebbleReady,
+	PebbleCheckFailed,
+	PebbleCheckRecovered,
 }
 
 // WorkloadHooks returns all known container hook kinds.
@@ -150,7 +152,7 @@ func (kind Kind) IsStorage() bool {
 // IsWorkload returns whether the Kind represents a workload hook.
 func (kind Kind) IsWorkload() bool {
 	switch kind {
-	case PebbleChangeUpdated, PebbleCustomNotice, PebbleReady:
+	case PebbleCustomNotice, PebbleReady, PebbleCheckFailed, PebbleCheckRecovered:
 		return true
 	}
 	return false


### PR DESCRIPTION
Add new hook types for the upcoming Pebble check events work. See [OP046](https://docs.google.com/document/d/13ItH8l5ZSmmv9WqZXpqjV8EifZU5e3zxINiNLubnC68/edit). New hook names are:

* `<container>-pebble-check-failed`
* `<container>-pebble-check-recovered`

This also removes the `pebble-change-updated`  hook, since adding support for pebble-change-updated-notice events was reverted (pre-release) from Juju and there are no current plans to add it back (see [OP045](https://docs.google.com/document/d/1EgRwMarsAOB04zWdSpcHbP0VykRApxQlyNFF1oC2Gzw/edit)).

This is required for the main [Juju PR adding check event support](https://github.com/juju/juju/pull/17655).