### PR TITLE
docs: deprecation warning

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+<!--
+
+## Deprecation Notice
+
+The charm repository is being moved directly into the [juju/juju](https://github.com/juju/juju/tree/main/internal/charm) source tree.
+Older versions of Juju can still use this repository for bug fixes or minor
+changes, but any new changes should factor the in the requirement to move the
+code to the new location.
+
+-->
+
+## Description of change
+
+<!-- Why this change is needed and what it does. -->
+
+## QA steps
+
+<!-- Describe steps to verify that the change works. -->

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+### Deprecation Notice
+
+The charm repository is being moved directly into the [juju/juju](https://github.com/juju/juju/tree/main/internal/charm) source tree.
+Older versions of Juju can still use this repository for bug fixes or minor
+changes, but any new changes should factor the in the requirement to move the
+code to the new location.
+
+
+------
+
+
 Juju charms
 ===========
 


### PR DESCRIPTION
Add a deprecation warning so people updating the charm repo are aware that addition work is required.