### PR TITLE
fix: include parent directories when listing archive members

### DIFF
--- a/charmarchive.go
+++ b/charmarchive.go
@@ -273,7 +273,16 @@ func (a *CharmArchive) ArchiveMembers() (set.Strings, error) {
 	if err != nil {
 		return set.NewStrings(), err
 	}
-	manifest := set.NewStrings(paths...)
+	manifest := set.NewStrings()
+	// Zip archives can omit file's parent directories,
+	// as these are created automatically during extraction.
+	// Ensure that parent directories exist in the member list.
+	for _, path := range paths {
+		for path != "." && path != "/" {
+			manifest.Add(path)
+			path = filepath.Dir(path)
+		}
+	}
 	// We always write out a revision file, even if there isn't one in the
 	// archive; and we always strip ".", because that's sometimes not present.
 	manifest.Add("revision")


### PR DESCRIPTION
Zip archives may not include parent directories of files, as these are usually automatically created during extraction. This is exactly what charmcraft does when packing the charm (https://github.com/canonical/charmcraft/blob/b48ef739df4732bb3ed35d67893574b260417a04/charmcraft/utils/file.py#L68-L69). And, when Juju creates the charm manifest from this kind of charm zip file, certain directories are omitted from the manifest. This omission can result in directories from previous charm revisions not being removed during an upgrade. And the residual empty directories may cause problems, for example, an empty python package `dist-info` directory may cause the package metadata to malfunction.

In this pull request, updating the `ArchiveMembers` function to add the parent directory to the member list if it does not already exist in the zip archive. This ensures complete cleanup of directories during a charm upgrade.

It is important to note that this change will only ensure the proper cleanup of files for charms that are newly deployed, as charms that are already deployed have their manifests written to the manifest files on disk. While it is possible to modify the `manifestDeployer`'s `loadManifest` function to include the missing directory entries, this adjustment would only remove  residual empty directories from the most recent deployment and would not address problems in older deployments, which seems not worthy it.

Fix: https://bugs.launchpad.net/juju/+bug/2058335

## QA Steps

This issue only affects charms deployed from charmhub, as locally uploaded charms are repacked by Juju, which adds the missing directories during this process.

```
juju deploy github-runner --revision 130 --channel latest/stable
juju refresh github-runner --revision 131
```

Directories such as `openstacksdk-2.1.0.dist-info` and `openstacksdk-3.0.0.dist-info` from two different revisions both exist, causing problem for `openstacksdk`:

```
juju ssh github-runner/3 ls "/var/lib/juju/agents/unit*/charm/venv"
...
openstacksdk-2.1.0.dist-info
openstacksdk-3.0.0.dist-info
...
```